### PR TITLE
Release version 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.0.1 (2017-03-14)
+
+  * Set SkipAuth flag to object-storage commands #41 (yamamoto-febc)
+  * Add confirmation to dangerous operations #44 (yamamoto-febc)
+  * Build the Deploy pipeline #30,#31,#32,#34,#36,#37,#38,#39,#40,#43,#45 (yamamoto-febc)
+
+## 0.0.0 (2017-03-09)
+
+* First release (yamamoto-febc)

--- a/package/deb/debian/changelog
+++ b/package/deb/debian/changelog
@@ -1,3 +1,23 @@
+usacloud (0.0.1-1) stable; urgency=low
+  * Set SkipAuth flag to object-storage commands (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/41>
+  * Add confirmation to dangerous operations (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/44>
+  * Build the Deploy pipeline (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/30>
+    <https://github.com/sacloud/usacloud/pull/31>
+    <https://github.com/sacloud/usacloud/pull/32>
+    <https://github.com/sacloud/usacloud/pull/34>
+    <https://github.com/sacloud/usacloud/pull/36>
+    <https://github.com/sacloud/usacloud/pull/37>
+    <https://github.com/sacloud/usacloud/pull/38>
+    <https://github.com/sacloud/usacloud/pull/39>
+    <https://github.com/sacloud/usacloud/pull/40>
+    <https://github.com/sacloud/usacloud/pull/43>
+    <https://github.com/sacloud/usacloud/pull/45>
+
+ -- usacloud <yamamoto.febc@gmail.com>  Tue, 14 Mar 2017 04:37:27 +0000
+
 usacloud (0.0.0-1) unstable; urgency=low
 
   * Initial release

--- a/package/rpm/usacloud.spec
+++ b/package/rpm/usacloud.spec
@@ -40,5 +40,10 @@ CLI client of the SakuraCloud
 %{_sysconfdir}/bash_completion.d/usacloud
 
 %changelog
+* Tue Mar 14 2017 <yamamoto.febc@gmail.com> - 0.0.1-1
+- Set SkipAuth flag to object-storage commands (by yamamoto-febc)
+- Add confirmation to dangerous operations (by yamamoto-febc)
+- Build the Deploy pipeline (by yamamoto-febc)
+
 * Fri Mar 3 2017 <yamamoto.febc@gmail.com> - 0.0.0
 - Initial commit


### PR DESCRIPTION
- Upload bash_completion to object-storage when deploy #30
- Revert "Upload bash_completion to object-storage when deploy" #31
- Upload bash_completion to object-storage when deploy #32
- Use debuild command #34
- Fix broken build #36
- Revert "Fix broken build" #37
- re-fix broken build #38
- Add travis-ci budge #39
- Use golang:1.8.0 image #40
- Set SkipAuth flag to object-storage commands #41
- Package signing by gpg #43
- Add confirmation to dangerous operations #44
- Add private key to signing to deb packages #45