### PR TITLE
リソースへのデフォルトコマンド追加

### DIFF
--- a/define/bill.go
+++ b/define/bill.go
@@ -29,6 +29,7 @@ func BillResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:         commands,
+		DefaultCommand:   "list",
 		ResourceCategory: CategoryBilling,
 	}
 }

--- a/define/price.go
+++ b/define/price.go
@@ -19,6 +19,7 @@ func PriceResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:            commands,
+		DefaultCommand:      "list",
 		Aliases:             []string{"public-price"},
 		AltResource:         "PublicPrice",
 		ListResultFieldName: "ServiceClasses",

--- a/define/product_disk.go
+++ b/define/product_disk.go
@@ -26,6 +26,7 @@ func ProductDiskResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:            commands,
+		DefaultCommand:      "list",
 		Aliases:             []string{"disk-plan"},
 		ResourceCategory:    CategoryInformation,
 		ListResultFieldName: "DiskPlans",

--- a/define/product_internet.go
+++ b/define/product_internet.go
@@ -26,6 +26,7 @@ func ProductInternetResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:            commands,
+		DefaultCommand:      "list",
 		Aliases:             []string{"internet-plan"},
 		ResourceCategory:    CategoryInformation,
 		ListResultFieldName: "InternetPlans",

--- a/define/product_license.go
+++ b/define/product_license.go
@@ -26,6 +26,7 @@ func ProductLicenseResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:            commands,
+		DefaultCommand:      "list",
 		Aliases:             []string{"license-info"},
 		ResourceCategory:    CategoryInformation,
 		ListResultFieldName: "LicenseInfo",

--- a/define/product_server.go
+++ b/define/product_server.go
@@ -26,6 +26,7 @@ func ProductServerResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:            commands,
+		DefaultCommand:      "list",
 		Aliases:             []string{"server-plan"},
 		ResourceCategory:    CategoryInformation,
 		ListResultFieldName: "ServerPlans",

--- a/define/region.go
+++ b/define/region.go
@@ -26,6 +26,7 @@ func RegionResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:         commands,
+		DefaultCommand:   "list",
 		ResourceCategory: CategoryInformation,
 	}
 }

--- a/define/zone.go
+++ b/define/zone.go
@@ -26,6 +26,7 @@ func ZoneResource() *schema.Resource {
 
 	return &schema.Resource{
 		Commands:         commands,
+		DefaultCommand:   "list",
 		ResourceCategory: CategoryInformation,
 	}
 }

--- a/schema/command.go
+++ b/schema/command.go
@@ -202,8 +202,6 @@ func (c *Command) Validate() []error {
 		}
 	}
 
-	// TODO IsRequiredIDTypeの場合にidパラメータがあるか(id+nameにするかも)
-
 	return errors
 }
 

--- a/schema/resource.go
+++ b/schema/resource.go
@@ -6,6 +6,7 @@ type Resource struct {
 	Aliases             []string
 	Usage               string
 	Commands            map[string]*Command
+	DefaultCommand      string // 空の場合は`resource -h`
 	AltResource         string // 空の場合はResourceのキーをCamelizeしてsacloud.XXXを対象とする。
 	ListResultFieldName string
 	CommandCategories   []Category

--- a/tools/gen-cli-commands/main.go
+++ b/tools/gen-cli-commands/main.go
@@ -21,7 +21,7 @@ var (
 // Usage is a replacement usage function for the flags package.
 func Usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "\tgen-cli-commands\n")
+	fmt.Fprint(os.Stderr, "\tgen-cli-commands\n")
 	os.Exit(2)
 }
 
@@ -151,6 +151,7 @@ func generateSource(resource *schema.Resource) (string, error) {
 		"Name":                   ctx.DashR(),
 		"Aliases":                tools.FlattenStringList(resource.Aliases),
 		"Usage":                  usage,
+		"DefaultCommand":         resource.DefaultCommand,
 		"Commands":               commands,
 		"Parameters":             parameters,
 		"CategoryResourceMap":    categoryResourceMap,
@@ -387,6 +388,14 @@ func init() {
 			Aliases: []string{ {{.Aliases}} },{{ end }}
 		{{- if .Usage}}
 			Usage: "{{.Usage}}",{{ end }}
+		{{- if .DefaultCommand }}
+			Action: func(c *cli.Context) error {
+				comm := c.App.Command("{{.DefaultCommand}}")
+				if comm != nil {
+					return comm.Run(c)
+				}
+				return cli.ShowSubcommandHelp(c)
+			},{{ end }}
 		Subcommands:[]*cli.Command{
 			{{ range .Commands -}}
 			{


### PR DESCRIPTION
`usacloud <リソース>`まで指定された場合、通常は`usacloud <リソース> -h`が実行される。
この挙動を、指定がある場合はデフォルトコマンドを実行するようにする。

例: デフォルトコマンドに`list`が指定されている場合  

`usacloud <対象リソース>` => `usacloud <対象リソース> list`

