### PR TITLE
VNCコマンドへサーバ起動待ち用オプション追加

### DIFF
--- a/command/command_server_vnc.go
+++ b/command/command_server_vnc.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/sacloud/usacloud/command/internal"
 	"github.com/sacloud/usacloud/vnc"
 )
 
@@ -9,7 +10,31 @@ func ServerVnc(ctx Context, params *VncServerParam) error {
 
 	client := ctx.GetAPIClient()
 	api := client.GetServerAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("ServerVnc is failed: %s", e)
+	}
 
+	if !p.IsUp() && params.WaitForBoot {
+
+		err := internal.ExecWithProgress(
+			fmt.Sprintf("Still booting[ID:%d]...", params.Id),
+			fmt.Sprintf("Connect to server[ID:%d]", params.Id),
+			GlobalOption.Progress,
+			func(compChan chan bool, errChan chan error) {
+				// call manipurate functions
+				err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				compChan <- true
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("ServerVnc is failed: %s", err)
+		}
+	}
 	vncProxyInfo, e := api.GetVNCProxy(params.Id)
 	if e != nil {
 		return fmt.Errorf("ServerVnc is failed: %s", e)

--- a/command/command_server_vnc_info.go
+++ b/command/command_server_vnc_info.go
@@ -2,12 +2,39 @@ package command
 
 import (
 	"fmt"
+	"github.com/sacloud/usacloud/command/internal"
 )
 
 func ServerVncInfo(ctx Context, params *VncInfoServerParam) error {
 
 	client := ctx.GetAPIClient()
 	api := client.GetServerAPI()
+
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("ServerVncInfo is failed: %s", e)
+	}
+
+	if !p.IsUp() && params.WaitForBoot {
+
+		err := internal.ExecWithProgress(
+			fmt.Sprintf("Still booting[ID:%d]...", params.Id),
+			fmt.Sprintf("Connect to server[ID:%d]", params.Id),
+			GlobalOption.Progress,
+			func(compChan chan bool, errChan chan error) {
+				// call manipurate functions
+				err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				compChan <- true
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("ServerVncInfo is failed: %s", err)
+		}
+	}
 
 	vncProxyInfo, e := api.GetVNCProxy(params.Id)
 	if e != nil {

--- a/command/command_server_vnc_send.go
+++ b/command/command_server_vnc_send.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/sacloud/usacloud/command/internal"
 	"github.com/sacloud/usacloud/vnc"
 	"io/ioutil"
 	"strings"
@@ -11,6 +12,31 @@ func ServerVncSend(ctx Context, params *VncSendServerParam) error {
 
 	client := ctx.GetAPIClient()
 	api := client.GetServerAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("ServerVncSend is failed: %s", e)
+	}
+
+	if !p.IsUp() && params.WaitForBoot {
+
+		err := internal.ExecWithProgress(
+			fmt.Sprintf("Still booting[ID:%d]...", params.Id),
+			fmt.Sprintf("Connect to server[ID:%d]", params.Id),
+			GlobalOption.Progress,
+			func(compChan chan bool, errChan chan error) {
+				// call manipurate functions
+				err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				compChan <- true
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("ServerVncSend is failed: %s", err)
+		}
+	}
 
 	command := ""
 	if params.CommandFile != "" {

--- a/define/server.go
+++ b/define/server.go
@@ -1065,7 +1065,14 @@ func serverSCPParam() map[string]*schema.Schema {
 }
 
 func serverVNCParam() map[string]*schema.Schema {
-	return map[string]*schema.Schema{}
+	return map[string]*schema.Schema{
+		"wait-for-boot": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Description: "wait until the server starts up",
+			Category:    "VNC",
+		},
+	}
 }
 
 func serverVNCSendParam() map[string]*schema.Schema {
@@ -1102,6 +1109,13 @@ func serverVNCSendParam() map[string]*schema.Schema {
 			Description: "write debug info",
 			Category:    "VNC",
 			Order:       40,
+		},
+		"wait-for-boot": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Description: "wait until the server starts up",
+			Category:    "VNC",
+			Order:       50,
 		},
 	}
 }


### PR DESCRIPTION
サーバ作成後すぐにvnc接続する場合などのために`--wait-for-boot`オプションを追加する。  
`server vnc`実行時にこのオプションが指定されると、サーバが起動するまで待機処理をしてからVNC接続処理が行われる。