### PR TITLE
タグによる検索機能

### DIFF
--- a/define/archive.go
+++ b/define/archive.go
@@ -128,7 +128,7 @@ var ArchiveCommandCategories = []schema.Category{
 }
 
 func archiveListParam() map[string]*schema.Schema {
-	return mergeParameterMap(CommonListParam, paramScopeCond)
+	return mergeParameterMap(CommonListParam, paramScopeCond, paramTagsCond)
 }
 
 func archiveListColumns() []output.ColumnDef {

--- a/define/auto_backup.go
+++ b/define/auto_backup.go
@@ -63,7 +63,7 @@ func AutoBackupResource() *schema.Resource {
 }
 
 func autoBackupListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func autoBackupListColumns() []output.ColumnDef {

--- a/define/database.go
+++ b/define/database.go
@@ -161,7 +161,7 @@ var databaseParamsCategories = []schema.Category{
 }
 
 func databaseListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func databaseListColumns() []output.ColumnDef {

--- a/define/disk.go
+++ b/define/disk.go
@@ -178,7 +178,7 @@ var DiskCommandCategories = []schema.Category{
 }
 
 func diskListParam() map[string]*schema.Schema {
-	return mergeParameterMap(CommonListParam, paramScopeCond)
+	return mergeParameterMap(CommonListParam, paramScopeCond, paramTagsCond)
 }
 
 func diskListColumns() []output.ColumnDef {

--- a/define/dns.go
+++ b/define/dns.go
@@ -121,7 +121,7 @@ var dnsCommandParamCategories = []schema.Category{
 }
 
 func dnsListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func dnsListColumns() []output.ColumnDef {

--- a/define/gslb.go
+++ b/define/gslb.go
@@ -102,7 +102,7 @@ func GSLBResource() *schema.Resource {
 }
 
 func gslbListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func gslbListColumns() []output.ColumnDef {

--- a/define/icon.go
+++ b/define/icon.go
@@ -61,7 +61,7 @@ func IconResource() *schema.Resource {
 }
 
 func iconListParam() map[string]*schema.Schema {
-	return mergeParameterMap(CommonListParam, paramScopeCond)
+	return mergeParameterMap(CommonListParam, paramScopeCond, paramTagsCond)
 }
 
 func iconListColumns() []output.ColumnDef {

--- a/define/internet.go
+++ b/define/internet.go
@@ -97,7 +97,7 @@ var internetCommandCategories = []schema.Category{
 }
 
 func internetListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func internetListColumns() []output.ColumnDef {

--- a/define/iso_image.go
+++ b/define/iso_image.go
@@ -119,7 +119,7 @@ var isoImageCommandCategories = []schema.Category{
 }
 
 func isoImageListParam() map[string]*schema.Schema {
-	return mergeParameterMap(CommonListParam, paramScopeCond)
+	return mergeParameterMap(CommonListParam, paramScopeCond, paramTagsCond)
 }
 
 func isoImageListColumns() []output.ColumnDef {

--- a/define/load_balancer.go
+++ b/define/load_balancer.go
@@ -267,7 +267,7 @@ var loadBalancerParamsCategories = []schema.Category{
 }
 
 func loadBalancerListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func loadBalancerListColumns() []output.ColumnDef {

--- a/define/parameters.go
+++ b/define/parameters.go
@@ -132,3 +132,39 @@ var paramScopeCond = map[string]*schema.Schema{
 		Order:        3,
 	},
 }
+
+var paramTagsCond = map[string]*schema.Schema{
+	"tags": {
+		Type:         schema.TypeStringList,
+		HandlerType:  schema.HandlerFilterFunc,
+		FilterFunc:   filterListByTags,
+		Description:  "set filter by tags(AND)",
+		Category:     "filter",
+		ValidateFunc: validateStringSlice(validateStrLen(1, 32)),
+		Order:        4,
+	},
+}
+
+func filterListByTags(_ []interface{}, item interface{}, param interface{}) bool {
+
+	type tagHandler interface {
+		HasTag(target string) bool
+	}
+
+	tagHolder, ok := item.(tagHandler)
+	if !ok {
+		return false
+	}
+
+	paramTags := param.([]string)
+
+	// 完全一致 + AND条件
+	res := true
+	for _, p := range paramTags {
+		if !tagHolder.HasTag(p) {
+			res = false
+			break
+		}
+	}
+	return res
+}

--- a/define/parameters_test.go
+++ b/define/parameters_test.go
@@ -1,0 +1,90 @@
+package define
+
+import (
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFilterByTagFunc(t *testing.T) {
+
+	t.Run("With single word", func(t *testing.T) {
+
+		var sw1 *sacloud.Switch = &sacloud.Switch{Resource: sacloud.NewResource(1)}
+		var sw2 *sacloud.Switch = &sacloud.Switch{Resource: sacloud.NewResource(2)}
+
+		items := []interface{}{sw1, sw2}
+
+		sw1.SetTags([]string{"tag1", "tag2"})
+		sw2.SetTags([]string{"tag11", "tag2"})
+
+		expects := map[string][]bool{
+			"tag1":  {true, false},
+			"tag2":  {true, true},
+			"tag11": {false, true},
+		}
+
+		for k, v := range expects {
+			for i := range items {
+				res := filterListByTags(items, items[i], []string{k})
+				assert.Equal(t, v[i], res,
+					"filterListByTags(%q), expect:%t, but got %t", k, v[i], res)
+			}
+		}
+
+	})
+
+	t.Run("With multiple word", func(t *testing.T) {
+
+		var sw1 *sacloud.Switch = &sacloud.Switch{Resource: sacloud.NewResource(1)}
+		var sw2 *sacloud.Switch = &sacloud.Switch{Resource: sacloud.NewResource(2)}
+		var sw3 *sacloud.Switch = &sacloud.Switch{Resource: sacloud.NewResource(3)}
+
+		items := []interface{}{sw1, sw2, sw3}
+
+		sw1.SetTags([]string{"tag1", "tag2"})
+		sw2.SetTags([]string{"tag1", "tag3"})
+		sw3.SetTags([]string{"tag1", "tag2", "tag3"})
+
+		type expect struct {
+			words   []string
+			results []bool
+		}
+
+		expects := []expect{
+			{
+				words:   []string{"tag1"},
+				results: []bool{true, true, true},
+			},
+			{
+				words:   []string{"tag1", "tag2"},
+				results: []bool{true, false, true},
+			},
+			{
+				words:   []string{"tag1", "tag3"},
+				results: []bool{false, true, true},
+			},
+			{
+				words:   []string{"tag2", "tag3"},
+				results: []bool{false, false, true},
+			},
+			{
+				words:   []string{"tag1", "tag2", "tag3"},
+				results: []bool{false, false, true},
+			},
+			{
+				words:   []string{"tag1", "dummy"},
+				results: []bool{false, false, false},
+			},
+		}
+
+		for _, v := range expects {
+			for i := range items {
+				res := filterListByTags(items, items[i], v.words)
+				assert.Equal(t, v.results[i], res,
+					"filterListByTags(%q), expect:%t, but got %t", v.words, v.results[i], res)
+			}
+		}
+
+	})
+}

--- a/define/server.go
+++ b/define/server.go
@@ -334,7 +334,7 @@ func ServerResource() *schema.Resource {
 }
 
 func serverListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func serverListColumns() []output.ColumnDef {

--- a/define/simple_monitor.go
+++ b/define/simple_monitor.go
@@ -124,7 +124,7 @@ var simpleMonitorUpdateParamCategories = []schema.Category{
 }
 
 func simpleMonitorListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func simpleMonitorListColumns() []output.ColumnDef {

--- a/define/startup_script.go
+++ b/define/startup_script.go
@@ -64,7 +64,8 @@ func StartupScriptResource() *schema.Resource {
 }
 
 func startupScriptListParam() map[string]*schema.Schema {
-	return mergeParameterMap(CommonListParam, paramScopeCond)
+	return mergeParameterMap(CommonListParam, paramScopeCond, paramTagsCond)
+
 }
 
 func startupScriptListColumns() []output.ColumnDef {

--- a/define/switch.go
+++ b/define/switch.go
@@ -94,7 +94,7 @@ var switchCommandCategories = []schema.Category{
 }
 
 func switchListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func switchListColumns() []output.ColumnDef {

--- a/define/vpc_router.go
+++ b/define/vpc_router.go
@@ -634,7 +634,7 @@ var vpcRouterDeleteParamCategories = []schema.Category{
 }
 
 func vpcRouterListParam() map[string]*schema.Schema {
-	return CommonListParam
+	return mergeParameterMap(CommonListParam, paramTagsCond)
 }
 
 func vpcRouterListColumns() []output.ColumnDef {

--- a/schema/handler_type.go
+++ b/schema/handler_type.go
@@ -11,13 +11,14 @@ const (
 	HandlerAndParams
 	HandlerOrParams
 	HandlerCustomFunc
+	HandlerFilterFunc
 	HandlerNoop
 )
 
 // IsWhenListOnly return true when HandlerType is able to use with CommandList
 func (h HandlerType) IsWhenListOnly() bool {
 	switch h {
-	case HandlerSort, HandlerAndParams, HandlerOrParams:
+	case HandlerSort, HandlerAndParams, HandlerOrParams, HandlerFilterFunc:
 		return true
 	default:
 		return false

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -30,6 +30,7 @@ type Schema struct {
 	HandlerType     HandlerType
 	DestinationProp string
 	CustomHandler   ValueHandlerFunc
+	FilterFunc      ListFilterFunc
 
 	CompleteFunc CompletionFunc
 }
@@ -42,6 +43,8 @@ type CompletionContext interface {
 type CompletionFunc func(ctx CompletionContext, currentValue string) []string
 
 type ValueHandlerFunc func(name string, src interface{}, dest interface{})
+
+type ListFilterFunc func(list []interface{}, item interface{}, param interface{}) bool
 
 type ValidateFunc func(string, interface{}) []error
 
@@ -182,8 +185,20 @@ func (s *Schema) Validate(name string) []error {
 		errs = append(errs, fmt.Errorf("schema#%s.%q: needs SliceType(TypeIntList or TypeStringList) in ValueType`", name, "HandlerType"))
 	}
 
+	// customFunc
 	if s.HandlerType == HandlerCustomFunc && s.CustomHandler == nil {
 		errs = append(errs, fmt.Errorf("schema#%s.%q: is required when HandlerType is HandlerCustomFunc`", name, "CustomHandler"))
+	}
+	if s.HandlerType != HandlerCustomFunc && s.CustomHandler != nil {
+		errs = append(errs, fmt.Errorf("schema#%s.%q: is required when HandlerType is HandlerCustomFunc`", name, "CustomHandler"))
+	}
+
+	// filterFunc
+	if s.HandlerType == HandlerFilterFunc && s.FilterFunc == nil {
+		errs = append(errs, fmt.Errorf("schema#%s.%q: is required when HandlerType is HandlerFilterFunc`", name, "FilterFunc"))
+	}
+	if s.HandlerType != HandlerFilterFunc && s.FilterFunc != nil {
+		errs = append(errs, fmt.Errorf("schema#%s.%q: cannot set when HandlerType is HandlerFilterFunc`", name, "FilterFunc"))
 	}
 
 	// DestinationProp


### PR DESCRIPTION
## 概要

各リソースの`ls`/`list`コマンドにて`--tags`パラメータを追加する。  
`--tags`は複数指定可能で、完全一致/AND条件での検索が行われる。

## 対象リソース

- アーカイブ(archive)
- 自動バックアップ(auto_backup)
- データベース(database)
- ディスク(disk)
- DNS(dns)
- GSLB(gslb)
- アイコン(icon)
- スイッチ+ルータ(internet)
- ISOイメージ(iso_image)
- ロードバランサ(load_balancer)
- サーバ(server)
- シンプル監視(simple_monitor)
- スタートアップスクリプト(startup_script)
- スイッチ(switch)
- VPCルータ(vpc_router)
