### PR TITLE
--format-fileオプションの追加

### DIFF
--- a/command/functions.go
+++ b/command/functions.go
@@ -66,7 +66,7 @@ func getOutputWriter(formatter output.Formatter) output.Output {
 		if formatter.GetQuiet() {
 			return output.NewIDOutput(o.Out, o.Err)
 		}
-		if formatter.GetFormat() == "" {
+		if formatter.GetFormat() == "" && formatter.GetFormatFile() == "" {
 			return output.NewTableOutput(o.Out, o.Err, formatter)
 		}
 		return output.NewFreeOutput(o.Out, o.Err, formatter)

--- a/command/validators.go
+++ b/command/validators.go
@@ -169,18 +169,35 @@ func validateOutputOption(o output.Option) []error {
 	outputType := o.GetOutputType()
 	columns := o.GetColumn()
 	format := o.GetFormat()
+	formatFile := o.GetFormatFile()
 	quiet := o.GetQuiet()
 
+	// format and format-file
+	if format != "" && formatFile != "" {
+		return []error{fmt.Errorf("%q: can't set with --format-file", "--format")}
+	}
+
+	// format(or format-file) with output-type
 	if outputType != "" && format != "" {
-		return []error{fmt.Errorf("%q: can't set with --output-format", "--format")}
+		return []error{fmt.Errorf("%q: can't set with --output-type", "--format")}
+	}
+	if outputType != "" && formatFile != "" {
+		return []error{fmt.Errorf("%q: can't set with --output-type", "--format-file")}
+	}
+
+	if formatFile != "" {
+		errs := schema.ValidateFileExists()("--format-file", formatFile)
+		if len(errs) > 0 {
+			return errs
+		}
 	}
 
 	if outputType != "" && quiet {
-		return []error{fmt.Errorf("%q: can't set with --output-format", "--quiet")}
+		return []error{fmt.Errorf("%q: can't set with --output-type", "--quiet")}
 	}
 
 	if outputType != "tsv" && outputType != "csv" && len(columns) > 0 {
-		return []error{fmt.Errorf("%q: can't set when --output-format is csv/tsv", "column")}
+		return []error{fmt.Errorf("%q: can't set when --output-type is csv/tsv", "--column")}
 	}
 
 	return []error{}

--- a/output/free_output.go
+++ b/output/free_output.go
@@ -4,24 +4,26 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/astaxie/flatmap"
 	"github.com/bitly/go-simplejson"
 	"io"
+	"io/ioutil"
 	"os"
 	"text/template"
 )
 
 type freeOutput struct {
-	Out    io.Writer
-	Err    io.Writer
-	Format string
+	Out        io.Writer
+	Err        io.Writer
+	Format     string
+	FormatFile string
 }
 
 func NewFreeOutput(out io.Writer, err io.Writer, option Option) Output {
 	return &freeOutput{
-		Out:    out,
-		Err:    err,
-		Format: option.GetFormat(),
+		Out:        out,
+		Err:        err,
+		Format:     option.GetFormat(),
+		FormatFile: option.GetFormatFile(),
 	}
 }
 
@@ -38,6 +40,14 @@ func (o *freeOutput) Print(targets ...interface{}) error {
 		return nil
 	}
 
+	if o.FormatFile != "" {
+		format, err := ioutil.ReadFile(o.FormatFile)
+		if err != nil {
+			return fmt.Errorf("FreeOutput:Print: read format-file is failed: %s", err)
+		}
+		o.Format = string(format)
+	}
+
 	// targets -> byte[] -> []interface{}
 	rawArray, err := json.Marshal(targets)
 	if err != nil {
@@ -48,6 +58,13 @@ func (o *freeOutput) Print(targets ...interface{}) error {
 	if err != nil {
 		return fmt.Errorf("FreeOutput:Print: create simplejson is failed: %s", err)
 	}
+
+	t := template.New("t")
+	_, err = t.Parse(o.Format)
+	if err != nil {
+		return fmt.Errorf("Output format is invalid: %s", err)
+	}
+
 	for i := range targets {
 
 		// interface{} -> map[string]interface{}
@@ -56,32 +73,17 @@ func (o *freeOutput) Print(targets ...interface{}) error {
 		if err != nil {
 			return fmt.Errorf("FreeOutput:Print: json format is invalid: %v", err)
 		}
-
-		// to flatmap( map[string]string )
-		flatMap, err := flatmap.Flatten(mapValue)
-		if err != nil {
-			return fmt.Errorf("FreeOutput:Print: create flatmap is failed: %v", err)
-		}
-
-		flatMap["RowNumber"] = fmt.Sprintf("%d", i+1)
+		mapValue["RowNumber"] = fmt.Sprintf("%d", i+1)
 
 		buf := bytes.NewBufferString("")
-		t := template.New("t")
-		_, err = t.Parse(o.Format)
-		if err != nil {
-			return fmt.Errorf("Output format is invalid: %s", err)
-		}
-
-		err = t.Execute(buf, flatMap)
+		err = t.Execute(buf, mapValue)
 		if err != nil {
 			return err
 		}
 
 		o.Out.Write(buf.Bytes())
 		fmt.Fprintln(o.Out, "")
-
 	}
 
 	return nil
-
 }

--- a/output/free_output_test.go
+++ b/output/free_output_test.go
@@ -1,0 +1,40 @@
+package output
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+type dummyOption struct{}
+
+func (o dummyOption) GetOutputType() string { return "" }
+func (o dummyOption) GetColumn() []string   { return []string{} }
+func (o dummyOption) GetFormat() string     { return "test ID:{{.ID}}" }
+func (o dummyOption) GetFormatFile() string { return "" }
+func (o dummyOption) GetQuiet() bool        { return false }
+
+func TestFreeOutput_Print(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	o := NewFreeOutput(buf, os.Stderr, dummyOption{})
+
+	type dummy struct {
+		ID int64
+	}
+
+	values := []interface{}{
+		&dummy{ID: 1},
+		&dummy{ID: 2},
+	}
+
+	err := o.Print(values...)
+
+	assert.NoError(t, err)
+	assert.Equal(t, testFreeOutputText, buf.String())
+
+}
+
+var testFreeOutputText = `test ID:1
+test ID:2
+`

--- a/output/output.go
+++ b/output/output.go
@@ -15,6 +15,7 @@ type Option interface {
 	GetOutputType() string
 	GetColumn() []string
 	GetFormat() string
+	GetFormatFile() string
 	GetQuiet() bool
 }
 

--- a/schema/command.go
+++ b/schema/command.go
@@ -71,9 +71,15 @@ func (c *Command) ParamCategory(key string) *Category {
 
 func (c *Command) BuildedParams() SortableParams {
 
+	// Notice: ここで追加されるパラメータはdefine.Resourcesからは見えない。
+	//         (コード生成時に追加されるため)
+	//         このため、ランタイムでdefine.Resourcesを参照する必要のある
+	//         ValidatorやConflictsWithは利用できない。
+	//         Validatorを利用したい場合はコード生成時に手動で呼び出すコードを出力する。
+	//         例: command.validateOutputOption(o output.Option)の呼び出し部分など
+
 	// add ID param
 	if c.Type.IsRequiredIDType() {
-		// has "force" param?
 		if _, ok := c.Params["id"]; !ok {
 			c.Params["id"] = &Schema{
 				Type:        TypeInt64,
@@ -86,7 +92,6 @@ func (c *Command) BuildedParams() SortableParams {
 	}
 
 	if c.Type.IsNeedConfirmType() && !c.NeedlessConfirm {
-		// has "assumeyes" param?
 		if _, ok := c.Params["assumeyes"]; !ok {
 			c.Params["assumeyes"] = &Schema{
 				Type:        TypeBool,
@@ -137,6 +142,15 @@ func (c *Command) BuildedParams() SortableParams {
 				Description: "Output format(see text/template package document for detail)",
 				Category:    "output",
 				Order:       40,
+			}
+		}
+		if _, ok := c.Params["format-file"]; !ok {
+			c.Params["format-file"] = &Schema{
+				Type:        TypeString,
+				HandlerType: HandlerNoop,
+				Description: "Output format from file(see text/template package document for detail)",
+				Category:    "output",
+				Order:       50,
 			}
 		}
 	}

--- a/schema/validators.go
+++ b/schema/validators.go
@@ -284,8 +284,12 @@ func ValidateFileExists() ValidateFunc {
 				return res
 			}
 
-			_, err := os.Stat(path)
-			if err != nil {
+			s, err := os.Stat(path)
+			if err == nil {
+				if s.Size() == 0 {
+					res = append(res, fmt.Errorf("%q: File must not be empty", fieldName))
+				}
+			} else {
 				res = append(res, fmt.Errorf("%q: File must be exists", fieldName))
 			}
 		}


### PR DESCRIPTION
## 概要

出力制御用のオプション`--format`に長い文字列を与えたい場合に利用するため、  
フォーマットを記載したファイルを指定できるように`--format-file`オプションを追加する。
(To fix #95)

## 利用方法

あらかじめ以下のようなファイルを用意しておく。
記法は[text/template](https://golang.org/pkg/text/template/)を参照。  
フィールド名は各リソースごとに異なるため、`usacloud [対象リソース] ls --output-type=json`などで調べておく。

```console
$ cat output-format.txt
ID          : {{.ID}}
名称       : {{.Name}}
起動状態: {{if eq .Instance.Status "up"}}起動中{{else}}停止中{{end}}
```

以下のように実行する。
```console
$ usacloud server ls --format-file output-format.txt
ID           : 123456789012
名称        : your-server-name
起動状態 : 停止中
```

なお、これまでは同様の処理を以下のように実行していた。
```bash
$ usacloud server ls --format "`cat output-format.txt`"
```