### PR TITLE
Windows上でのgo generate対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,28 +30,9 @@ deps:
 	go get -u github.com/golang/lint/golint
 
 
-.PHONY: tools
-tools: tools/bin/gen-cli-commands tools/bin/gen-command-funcs tools/bin/gen-input-models tools/bin/gen-command-completion
-
-tools/bin/gen-cli-commands: tools/gen-cli-commands/*.go
-	go build -o $(CURDIR)/tools/bin/gen-cli-commands $(CURDIR)/tools/gen-cli-commands/*.go
-
-tools/bin/gen-command-funcs: tools/gen-command-funcs/*.go
-	go build -o $(CURDIR)/tools/bin/gen-command-funcs $(CURDIR)/tools/gen-command-funcs/*.go
-
-tools/bin/gen-input-models: tools/gen-input-models/*.go
-	go build -o $(CURDIR)/tools/bin/gen-input-models $(CURDIR)/tools/gen-input-models/*.go
-
-tools/bin/gen-command-completion: tools/gen-command-completion/*.go
-	go build -o $(CURDIR)/tools/bin/gen-command-completion $(CURDIR)/tools/gen-command-completion/*.go
-
-
 .PHONY: gen-bash-completion
-gen-bash-completion: gen tools/bin/gen-bash-completion
-	tools/bin/gen-bash-completion
-
-tools/bin/gen-bash-completion: tools/gen-bash-completion/*.go
-	go build -o $(CURDIR)/tools/bin/gen-bash-completion $(CURDIR)/tools/gen-bash-completion/*.go
+gen-bash-completion: gen
+	go run tools/gen-bash-completion/main.go
 
 contrib/completion/bash/usacloud: define/*.go gen-bash-completion
 

--- a/define/resources.go
+++ b/define/resources.go
@@ -1,8 +1,8 @@
 // Package define .
-//go:generate ../tools/bin/gen-input-models
-//go:generate ../tools/bin/gen-cli-commands
-//go:generate ../tools/bin/gen-command-funcs
-//go:generate ../tools/bin/gen-command-completion
+//go:generate go run ../tools/gen-input-models/main.go
+//go:generate go run ../tools/gen-cli-commands/main.go
+//go:generate go run ../tools/gen-command-funcs/main.go
+//go:generate go run ../tools/gen-command-completion/main.go
 package define
 
 import "github.com/sacloud/usacloud/schema"

--- a/tools/gen-command-funcs/internal/functions.go
+++ b/tools/gen-command-funcs/internal/functions.go
@@ -1,13 +1,14 @@
-package main
+package internal
 
 import (
 	"bytes"
 	"fmt"
 	"github.com/sacloud/usacloud/schema"
+	"github.com/sacloud/usacloud/tools"
 	"text/template"
 )
 
-func generateSetParamActions(command *schema.Command) (string, error) {
+func generateSetParamActions(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 
 	b := bytes.NewBufferString("")
 

--- a/tools/gen-command-funcs/internal/generate_create.go
+++ b/tools/gen-command-funcs/internal/generate_create.go
@@ -1,17 +1,18 @@
-package main
+package internal
 
 import (
 	"bytes"
 	"github.com/sacloud/usacloud/schema"
+	"github.com/sacloud/usacloud/tools"
 	"text/template"
 )
 
-func generateDeleteCommand(command *schema.Command) (string, error) {
+func GenerateCreateCommand(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 	b := bytes.NewBufferString("")
 	t := template.New("c")
-	template.Must(t.Parse(deleteCommandTemplate))
+	template.Must(t.Parse(createCommandTemplate))
 
-	setParamActions, err := generateSetParamActions(command)
+	setParamActions, err := generateSetParamActions(ctx, command)
 	if err != nil {
 		return "", err
 	}
@@ -24,15 +25,16 @@ func generateDeleteCommand(command *schema.Command) (string, error) {
 	return b.String(), err
 }
 
-var deleteCommandTemplate = `
+var createCommandTemplate = `
 	client := ctx.GetAPIClient()
 	api := client.Get{{.ResourceName}}API()
+	p := api.New()
 
 	// set params
 	{{.SetParamActions}}
 
-	// call Delete(id)
-	res, err := api.Delete(params.Id)
+	// call Create(id)
+	res, err := api.Create(p)
 	if err != nil {
 		return fmt.Errorf("{{.FuncName}} is failed: %s", err)
 	}

--- a/tools/gen-command-funcs/internal/generate_delete.go
+++ b/tools/gen-command-funcs/internal/generate_delete.go
@@ -1,17 +1,18 @@
-package main
+package internal
 
 import (
 	"bytes"
 	"github.com/sacloud/usacloud/schema"
+	"github.com/sacloud/usacloud/tools"
 	"text/template"
 )
 
-func generateUpdateCommand(command *schema.Command) (string, error) {
+func GenerateDeleteCommand(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 	b := bytes.NewBufferString("")
 	t := template.New("c")
-	template.Must(t.Parse(updateCommandTemplate))
+	template.Must(t.Parse(deleteCommandTemplate))
 
-	setParamActions, err := generateSetParamActions(command)
+	setParamActions, err := generateSetParamActions(ctx, command)
 	if err != nil {
 		return "", err
 	}
@@ -24,19 +25,15 @@ func generateUpdateCommand(command *schema.Command) (string, error) {
 	return b.String(), err
 }
 
-var updateCommandTemplate = `
+var deleteCommandTemplate = `
 	client := ctx.GetAPIClient()
 	api := client.Get{{.ResourceName}}API()
-	p, e := api.Read(params.Id)
-	if e != nil {
-		return fmt.Errorf("{{.FuncName}} is failed: %s", e)
-	}
 
 	// set params
 	{{.SetParamActions}}
 
-	// call Update(id)
-	res, err := api.Update(params.Id, p)
+	// call Delete(id)
+	res, err := api.Delete(params.Id)
 	if err != nil {
 		return fmt.Errorf("{{.FuncName}} is failed: %s", err)
 	}

--- a/tools/gen-command-funcs/internal/generate_find.go
+++ b/tools/gen-command-funcs/internal/generate_find.go
@@ -1,23 +1,24 @@
-package main
+package internal
 
 import (
 	"bytes"
 	"fmt"
 	"github.com/sacloud/usacloud/schema"
+	"github.com/sacloud/usacloud/tools"
 	"text/template"
 )
 
-func generateFindCommand(command *schema.Command) (string, error) {
+func GenerateFindCommand(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 	b := bytes.NewBufferString("")
 	t := template.New("c")
 	template.Must(t.Parse(findCommandTemplate))
 
-	setParamActions, err := generateFindSetParamActions(command)
+	setParamActions, err := generateFindSetParamActions(ctx, command)
 	if err != nil {
 		return "", err
 	}
 
-	filterActions, err := generateFilterActions(command)
+	filterActions, err := generateFilterActions(ctx, command)
 	if err != nil {
 		return "", err
 	}
@@ -54,7 +55,7 @@ var findCommandTemplate = `
 	return ctx.GetOutput().Print(list...)
 `
 
-func generateFindSetParamActions(command *schema.Command) (string, error) {
+func generateFindSetParamActions(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 
 	b := bytes.NewBufferString("")
 
@@ -125,7 +126,7 @@ var findSetParamTemplates = map[schema.HandlerType]string{
 	}`,
 }
 
-func generateFilterActions(command *schema.Command) (string, error) {
+func generateFilterActions(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 
 	b := bytes.NewBufferString("")
 

--- a/tools/gen-command-funcs/internal/generate_manipulate.go
+++ b/tools/gen-command-funcs/internal/generate_manipulate.go
@@ -1,17 +1,18 @@
-package main
+package internal
 
 import (
 	"bytes"
 	"github.com/sacloud/usacloud/schema"
+	"github.com/sacloud/usacloud/tools"
 	"text/template"
 )
 
-func generateManipulateCommand(command *schema.Command) (string, error) {
+func GenerateManipulateCommand(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 	b := bytes.NewBufferString("")
 	t := template.New("c")
 	template.Must(t.Parse(manipulateCommandTemplate))
 
-	setParamActions, err := generateSetParamActions(command)
+	setParamActions, err := generateSetParamActions(ctx, command)
 	if err != nil {
 		return "", err
 	}

--- a/tools/gen-command-funcs/internal/generate_read.go
+++ b/tools/gen-command-funcs/internal/generate_read.go
@@ -1,17 +1,18 @@
-package main
+package internal
 
 import (
 	"bytes"
 	"github.com/sacloud/usacloud/schema"
+	"github.com/sacloud/usacloud/tools"
 	"text/template"
 )
 
-func generateCreateCommand(command *schema.Command) (string, error) {
+func GenerateReadCommand(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 	b := bytes.NewBufferString("")
 	t := template.New("c")
-	template.Must(t.Parse(createCommandTemplate))
+	template.Must(t.Parse(readCommandTemplate))
 
-	setParamActions, err := generateSetParamActions(command)
+	setParamActions, err := generateSetParamActions(ctx, command)
 	if err != nil {
 		return "", err
 	}
@@ -24,16 +25,15 @@ func generateCreateCommand(command *schema.Command) (string, error) {
 	return b.String(), err
 }
 
-var createCommandTemplate = `
+var readCommandTemplate = `
 	client := ctx.GetAPIClient()
 	api := client.Get{{.ResourceName}}API()
-	p := api.New()
 
 	// set params
 	{{.SetParamActions}}
 
-	// call Create(id)
-	res, err := api.Create(p)
+	// call Read(id)
+	res, err := api.Read(params.Id)
 	if err != nil {
 		return fmt.Errorf("{{.FuncName}} is failed: %s", err)
 	}

--- a/tools/gen-command-funcs/internal/generate_update.go
+++ b/tools/gen-command-funcs/internal/generate_update.go
@@ -1,17 +1,18 @@
-package main
+package internal
 
 import (
 	"bytes"
 	"github.com/sacloud/usacloud/schema"
+	"github.com/sacloud/usacloud/tools"
 	"text/template"
 )
 
-func generateReadCommand(command *schema.Command) (string, error) {
+func GenerateUpdateCommand(ctx *tools.GenerateContext, command *schema.Command) (string, error) {
 	b := bytes.NewBufferString("")
 	t := template.New("c")
-	template.Must(t.Parse(readCommandTemplate))
+	template.Must(t.Parse(updateCommandTemplate))
 
-	setParamActions, err := generateSetParamActions(command)
+	setParamActions, err := generateSetParamActions(ctx, command)
 	if err != nil {
 		return "", err
 	}
@@ -24,15 +25,19 @@ func generateReadCommand(command *schema.Command) (string, error) {
 	return b.String(), err
 }
 
-var readCommandTemplate = `
+var updateCommandTemplate = `
 	client := ctx.GetAPIClient()
 	api := client.Get{{.ResourceName}}API()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("{{.FuncName}} is failed: %s", e)
+	}
 
 	// set params
 	{{.SetParamActions}}
 
-	// call Read(id)
-	res, err := api.Read(params.Id)
+	// call Update(id)
+	res, err := api.Update(params.Id, p)
 	if err != nil {
 		return fmt.Errorf("{{.FuncName}} is failed: %s", err)
 	}

--- a/tools/gen-command-funcs/main.go
+++ b/tools/gen-command-funcs/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/sacloud/usacloud/schema"
 	"github.com/sacloud/usacloud/tools"
+	"github.com/sacloud/usacloud/tools/gen-command-funcs/internal"
 	"io/ioutil"
 	"log"
 	"os"
@@ -110,22 +111,22 @@ func generateAction(command *schema.Command) (string, error) {
 	switch command.Type {
 	case schema.CommandList:
 		// list / find / search
-		res, err = generateFindCommand(command)
+		res, err = internal.GenerateFindCommand(ctx, command)
 	case schema.CommandCreate:
 		// create
-		res, err = generateCreateCommand(command)
+		res, err = internal.GenerateCreateCommand(ctx, command)
 	case schema.CommandRead:
 		// read
-		res, err = generateReadCommand(command)
+		res, err = internal.GenerateReadCommand(ctx, command)
 	case schema.CommandUpdate:
 		// update
-		res, err = generateUpdateCommand(command)
+		res, err = internal.GenerateUpdateCommand(ctx, command)
 	case schema.CommandDelete:
 		// delete
-		res, err = generateDeleteCommand(command)
+		res, err = internal.GenerateDeleteCommand(ctx, command)
 	case schema.CommandManipulateMulti, schema.CommandManipulateSingle, schema.CommandManipulateIDOnly:
 		// power-on/off
-		res, err = generateManipulateCommand(command)
+		res, err = internal.GenerateManipulateCommand(ctx, command)
 	case schema.CommandCustom:
 		// custom
 		res = `return fmt.Errorf("Not implements")`


### PR DESCRIPTION
To fix #142 

---

このPRにより`go generate`をWindows上で実行できるようになるが、
その後`go fmt`や`go build`を実行すると`Argument list too long`などのエラーが出る。
このエラーは#141 と#143 にて対応する。