### PR TITLE
コピー元アーカイブ/ディスクID検索パラメータ追加

### DIFF
--- a/command/cli/cli_archive_gen.go
+++ b/command/cli/cli_archive_gen.go
@@ -52,6 +52,16 @@ func init() {
 						Name:  "tags",
 						Usage: "set filter by tags(AND)",
 					},
+					&cli.Int64Flag{
+						Name:        "source-archive-id",
+						Usage:       "set filter by source-archive-id",
+						Destination: &listParam.SourceArchiveId,
+					},
+					&cli.Int64Flag{
+						Name:        "source-disk-id",
+						Usage:       "set filter by source-disk-id",
+						Destination: &listParam.SourceDiskId,
+					},
 					&cli.IntFlag{
 						Name:        "from",
 						Aliases:     []string{"offset"},
@@ -2256,6 +2266,16 @@ func init() {
 		Key:         "sort",
 		DisplayName: "Sort options",
 		Order:       2147483607,
+	})
+	AppendFlagCategoryMap("archive", "list", "source-archive-id", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("archive", "list", "source-disk-id", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
 	})
 	AppendFlagCategoryMap("archive", "list", "tags", &schema.Category{
 		Key:         "filter",

--- a/command/cli/cli_disk_gen.go
+++ b/command/cli/cli_disk_gen.go
@@ -55,6 +55,16 @@ func init() {
 						Name:  "tags",
 						Usage: "set filter by tags(AND)",
 					},
+					&cli.Int64Flag{
+						Name:        "source-archive-id",
+						Usage:       "set filter by source-archive-id",
+						Destination: &listParam.SourceArchiveId,
+					},
+					&cli.Int64Flag{
+						Name:        "source-disk-id",
+						Usage:       "set filter by source-disk-id",
+						Destination: &listParam.SourceDiskId,
+					},
 					&cli.IntFlag{
 						Name:        "from",
 						Aliases:     []string{"offset"},
@@ -2920,6 +2930,16 @@ func init() {
 		Key:         "sort",
 		DisplayName: "Sort options",
 		Order:       2147483607,
+	})
+	AppendFlagCategoryMap("disk", "list", "source-archive-id", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("disk", "list", "source-disk-id", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
 	})
 	AppendFlagCategoryMap("disk", "list", "tags", &schema.Category{
 		Key:         "filter",

--- a/command/completion/archive_flags_gen.go
+++ b/command/completion/archive_flags_gen.go
@@ -22,6 +22,10 @@ func ArchiveListCompleteFlags(ctx command.Context, params *params.ListArchivePar
 		comp = define.Resources["Archive"].Commands["list"].Params["scope"].CompleteFunc
 	case "tags":
 		comp = define.Resources["Archive"].Commands["list"].Params["tags"].CompleteFunc
+	case "source-archive-id":
+		comp = define.Resources["Archive"].Commands["list"].Params["source-archive-id"].CompleteFunc
+	case "source-disk-id":
+		comp = define.Resources["Archive"].Commands["list"].Params["source-disk-id"].CompleteFunc
 	case "from", "offset":
 		comp = define.Resources["Archive"].Commands["list"].Params["from"].CompleteFunc
 	case "max", "limit":

--- a/command/completion/disk_flags_gen.go
+++ b/command/completion/disk_flags_gen.go
@@ -22,6 +22,10 @@ func DiskListCompleteFlags(ctx command.Context, params *params.ListDiskParam, fl
 		comp = define.Resources["Disk"].Commands["list"].Params["scope"].CompleteFunc
 	case "tags":
 		comp = define.Resources["Disk"].Commands["list"].Params["tags"].CompleteFunc
+	case "source-archive-id":
+		comp = define.Resources["Disk"].Commands["list"].Params["source-archive-id"].CompleteFunc
+	case "source-disk-id":
+		comp = define.Resources["Disk"].Commands["list"].Params["source-disk-id"].CompleteFunc
 	case "from", "offset":
 		comp = define.Resources["Disk"].Commands["list"].Params["from"].CompleteFunc
 	case "max", "limit":

--- a/command/funcs/archive_list_gen.go
+++ b/command/funcs/archive_list_gen.go
@@ -53,6 +53,14 @@ func ArchiveList(ctx command.Context, params *params.ListArchiveParam) error {
 			continue
 		}
 
+		if !params.GetCommandDef().Params["source-archive-id"].FilterFunc(list, &res.Archives[i], params.SourceArchiveId) {
+			continue
+		}
+
+		if !params.GetCommandDef().Params["source-disk-id"].FilterFunc(list, &res.Archives[i], params.SourceDiskId) {
+			continue
+		}
+
 		list = append(list, &res.Archives[i])
 	}
 	return ctx.GetOutput().Print(list...)

--- a/command/funcs/disk_list_gen.go
+++ b/command/funcs/disk_list_gen.go
@@ -53,6 +53,14 @@ func DiskList(ctx command.Context, params *params.ListDiskParam) error {
 			continue
 		}
 
+		if !params.GetCommandDef().Params["source-archive-id"].FilterFunc(list, &res.Disks[i], params.SourceArchiveId) {
+			continue
+		}
+
+		if !params.GetCommandDef().Params["source-disk-id"].FilterFunc(list, &res.Disks[i], params.SourceDiskId) {
+			continue
+		}
+
 		list = append(list, &res.Disks[i])
 	}
 	return ctx.GetOutput().Print(list...)

--- a/command/params/params_archive_gen.go
+++ b/command/params/params_archive_gen.go
@@ -10,18 +10,20 @@ import (
 
 // ListArchiveParam is input parameters for the sacloud API
 type ListArchiveParam struct {
-	Name       []string
-	Id         []int64
-	Scope      string
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name            []string
+	Id              []int64
+	Scope           string
+	Tags            []string
+	SourceArchiveId int64
+	SourceDiskId    int64
+	From            int
+	Max             int
+	Sort            []string
+	OutputType      string
+	Column          []string
+	Quiet           bool
+	Format          string
+	FormatFile      string
 }
 
 // NewListArchiveParam return new ListArchiveParam
@@ -67,6 +69,20 @@ func (p *ListArchiveParam) Validate() []error {
 	{
 		validator := define.Resources["Archive"].Commands["list"].Params["tags"].ValidateFunc
 		errs := validator("--tags", p.Tags)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["Archive"].Commands["list"].Params["source-archive-id"].ValidateFunc
+		errs := validator("--source-archive-id", p.SourceArchiveId)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["Archive"].Commands["list"].Params["source-disk-id"].ValidateFunc
+		errs := validator("--source-disk-id", p.SourceDiskId)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -144,6 +160,20 @@ func (p *ListArchiveParam) SetTags(v []string) {
 
 func (p *ListArchiveParam) GetTags() []string {
 	return p.Tags
+}
+func (p *ListArchiveParam) SetSourceArchiveId(v int64) {
+	p.SourceArchiveId = v
+}
+
+func (p *ListArchiveParam) GetSourceArchiveId() int64 {
+	return p.SourceArchiveId
+}
+func (p *ListArchiveParam) SetSourceDiskId(v int64) {
+	p.SourceDiskId = v
+}
+
+func (p *ListArchiveParam) GetSourceDiskId() int64 {
+	return p.SourceDiskId
 }
 func (p *ListArchiveParam) SetFrom(v int) {
 	p.From = v

--- a/command/params/params_disk_gen.go
+++ b/command/params/params_disk_gen.go
@@ -10,18 +10,20 @@ import (
 
 // ListDiskParam is input parameters for the sacloud API
 type ListDiskParam struct {
-	Name       []string
-	Id         []int64
-	Scope      string
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name            []string
+	Id              []int64
+	Scope           string
+	Tags            []string
+	SourceArchiveId int64
+	SourceDiskId    int64
+	From            int
+	Max             int
+	Sort            []string
+	OutputType      string
+	Column          []string
+	Quiet           bool
+	Format          string
+	FormatFile      string
 }
 
 // NewListDiskParam return new ListDiskParam
@@ -67,6 +69,20 @@ func (p *ListDiskParam) Validate() []error {
 	{
 		validator := define.Resources["Disk"].Commands["list"].Params["tags"].ValidateFunc
 		errs := validator("--tags", p.Tags)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["Disk"].Commands["list"].Params["source-archive-id"].ValidateFunc
+		errs := validator("--source-archive-id", p.SourceArchiveId)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["Disk"].Commands["list"].Params["source-disk-id"].ValidateFunc
+		errs := validator("--source-disk-id", p.SourceDiskId)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -144,6 +160,20 @@ func (p *ListDiskParam) SetTags(v []string) {
 
 func (p *ListDiskParam) GetTags() []string {
 	return p.Tags
+}
+func (p *ListDiskParam) SetSourceArchiveId(v int64) {
+	p.SourceArchiveId = v
+}
+
+func (p *ListDiskParam) GetSourceArchiveId() int64 {
+	return p.SourceArchiveId
+}
+func (p *ListDiskParam) SetSourceDiskId(v int64) {
+	p.SourceDiskId = v
+}
+
+func (p *ListDiskParam) GetSourceDiskId() int64 {
+	return p.SourceDiskId
 }
 func (p *ListDiskParam) SetFrom(v int) {
 	p.From = v

--- a/define/archive.go
+++ b/define/archive.go
@@ -128,7 +128,13 @@ var ArchiveCommandCategories = []schema.Category{
 }
 
 func archiveListParam() map[string]*schema.Schema {
-	return mergeParameterMap(CommonListParam, paramScopeCond, paramTagsCond)
+	return mergeParameterMap(
+		CommonListParam,
+		paramScopeCond,
+		paramTagsCond,
+		paramSourceArchiveIDCond,
+		paramSourceDiskCond,
+	)
 }
 
 func archiveListColumns() []output.ColumnDef {

--- a/define/disk.go
+++ b/define/disk.go
@@ -178,7 +178,13 @@ var DiskCommandCategories = []schema.Category{
 }
 
 func diskListParam() map[string]*schema.Schema {
-	return mergeParameterMap(CommonListParam, paramScopeCond, paramTagsCond)
+	return mergeParameterMap(
+		CommonListParam,
+		paramScopeCond,
+		paramTagsCond,
+		paramSourceArchiveIDCond,
+		paramSourceDiskCond,
+	)
 }
 
 func diskListColumns() []output.ColumnDef {

--- a/define/parameters.go
+++ b/define/parameters.go
@@ -168,3 +168,55 @@ func filterListByTags(_ []interface{}, item interface{}, param interface{}) bool
 	}
 	return res
 }
+
+var paramSourceArchiveIDCond = map[string]*schema.Schema{
+	"source-archive-id": {
+		Type:         schema.TypeInt64,
+		HandlerType:  schema.HandlerFilterFunc,
+		FilterFunc:   filterBySourceArchiveID,
+		Description:  "set filter by source-archive-id",
+		Category:     "filter",
+		ValidateFunc: validateSakuraID(),
+		Order:        5,
+	},
+}
+
+var paramSourceDiskCond = map[string]*schema.Schema{
+	"source-disk-id": {
+		Type:         schema.TypeInt64,
+		HandlerType:  schema.HandlerFilterFunc,
+		FilterFunc:   filterBySourceDiskID,
+		Description:  "set filter by source-disk-id",
+		Category:     "filter",
+		ValidateFunc: validateSakuraID(),
+		Order:        6,
+	},
+}
+
+func filterBySourceArchiveID(_ []interface{}, item interface{}, param interface{}) bool {
+
+	type archiveIDHandler interface {
+		GetSourceArchiveID() int64
+	}
+
+	archiveIDHolder, ok := item.(archiveIDHandler)
+	if !ok {
+		return false
+	}
+
+	return archiveIDHolder.GetSourceArchiveID() == param.(int64)
+}
+
+func filterBySourceDiskID(_ []interface{}, item interface{}, param interface{}) bool {
+
+	type diskIDHandler interface {
+		GetSourceDiskID() int64
+	}
+
+	diskIDHolder, ok := item.(diskIDHandler)
+	if !ok {
+		return false
+	}
+
+	return diskIDHolder.GetSourceDiskID() == param.(int64)
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_copy_source.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_copy_source.go
@@ -28,3 +28,29 @@ func (p *propCopySource) SetSourceDisk(sourceID int64) {
 	}
 	p.SourceArchive = nil
 }
+
+// GetSourceArchive ソースアーカイブ取得
+func (p *propCopySource) GetSourceArchive() *Archive {
+	return p.SourceArchive
+}
+
+// GetSourceDisk ソースディスク取得
+func (p *propCopySource) GetSourceDisk() *Disk {
+	return p.SourceDisk
+}
+
+// GetSourceArchiveID ソースアーカイブID取得
+func (p *propCopySource) GetSourceArchiveID() int64 {
+	if p.SourceArchive != nil {
+		return p.SourceArchive.GetID()
+	}
+	return EmptyID
+}
+
+// GetSourceDiskID ソースディスクID取得
+func (p *propCopySource) GetSourceDiskID() int64 {
+	if p.SourceDisk != nil {
+		return p.SourceDisk.GetID()
+	}
+	return EmptyID
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -101,32 +101,32 @@
 		{
 			"checksumSHA1": "WDN0aBT7ydlh1XoUn2x49bAIJTw=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "0395465063a2dcb415fc8cd4482adeb3ee18e083",
-			"revisionTime": "2017-06-12T08:05:33Z"
+			"revision": "56d12c2b20fc5fc1703998769056078b89c2e7df",
+			"revisionTime": "2017-06-14T06:45:17Z"
 		},
 		{
 			"checksumSHA1": "y08lQO7ZCVfymZ9OKAwS01MhYoE=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "0395465063a2dcb415fc8cd4482adeb3ee18e083",
-			"revisionTime": "2017-06-12T08:05:33Z"
+			"revision": "56d12c2b20fc5fc1703998769056078b89c2e7df",
+			"revisionTime": "2017-06-14T06:45:17Z"
 		},
 		{
 			"checksumSHA1": "SfRWOR6BdWIy9j30hHs1xaWiTbg=",
 			"path": "github.com/sacloud/libsacloud/builder",
-			"revision": "0395465063a2dcb415fc8cd4482adeb3ee18e083",
-			"revisionTime": "2017-06-12T08:05:33Z"
+			"revision": "56d12c2b20fc5fc1703998769056078b89c2e7df",
+			"revisionTime": "2017-06-14T06:45:17Z"
 		},
 		{
-			"checksumSHA1": "gF8HPfb9mS5zFJTjlHKdWRu+VfA=",
+			"checksumSHA1": "IN2J0BMNuTdZ0Fc7Db3HZ8f+Kic=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "0395465063a2dcb415fc8cd4482adeb3ee18e083",
-			"revisionTime": "2017-06-12T08:05:33Z"
+			"revision": "56d12c2b20fc5fc1703998769056078b89c2e7df",
+			"revisionTime": "2017-06-14T06:45:17Z"
 		},
 		{
 			"checksumSHA1": "xEmGlQN95mbzoIKUkoPqGRIFiaA=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "0395465063a2dcb415fc8cd4482adeb3ee18e083",
-			"revisionTime": "2017-06-12T08:05:33Z"
+			"revision": "56d12c2b20fc5fc1703998769056078b89c2e7df",
+			"revisionTime": "2017-06-14T06:45:17Z"
 		},
 		{
 			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",


### PR DESCRIPTION
以下のように利用する。

```console
#コピー元アーカイブIDが"123456789012"のアーカイブを取得
$ usacloud archive ls --source-archive-id 123456789012

#コピー元ディスクIDが"123456789012"のアーカイブを取得
$ usacloud archive ls --source-disk-id 123456789012

#コピー元アーカイブIDが"123456789012"のディスクを取得
$ usacloud disk ls --source-archive-id 123456789012

#コピー元ディスクIDが"123456789012"のディスクを取得
$ usacloud disk ls --source-disk-id 123456789012
```