### PR TITLE
コマンドパラメータのテンプレート対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .env
+
+test.tmpl
+
 bin/*
 tools/bin/*
 

--- a/command/cli/cli_auto_backup_gen.go
+++ b/command/cli/cli_auto_backup_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -43,26 +45,31 @@ func init() {
 						Usage: "set filter by tags(AND)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -70,21 +77,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -108,12 +112,46 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Tags = c.StringSlice("tags")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("tags") {
+						listParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -176,12 +214,61 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Tags = c.StringSlice("tags")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListAutoBackupParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("tags") {
+						listParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -206,9 +293,8 @@ func init() {
 				Usage: "Create AutoBackup",
 				Flags: []cli.Flag{
 					&cli.Int64Flag{
-						Name:        "disk-id",
-						Usage:       "[Required] set target diskID ",
-						Destination: &createParam.DiskId,
+						Name:  "disk-id",
+						Usage: "[Required] set target diskID ",
 					},
 					&cli.StringSliceFlag{
 						Name:  "weekdays",
@@ -216,42 +302,44 @@ func init() {
 						Value: cli.NewStringSlice("all"),
 					},
 					&cli.IntFlag{
-						Name:        "generation",
-						Usage:       "[Required] set backup generation[1-10]",
-						Value:       1,
-						Destination: &createParam.Generation,
+						Name:  "generation",
+						Usage: "[Required] set backup generation[1-10]",
+						Value: 1,
 					},
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "[Required] set resource display name",
-						Destination: &createParam.Name,
+						Name:  "name",
+						Usage: "[Required] set resource display name",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &createParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set resource tags",
 					},
 					&cli.Int64Flag{
-						Name:        "icon-id",
-						Usage:       "set Icon ID",
-						Destination: &createParam.IconId,
+						Name:  "icon-id",
+						Usage: "set Icon ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &createParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &createParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -259,21 +347,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &createParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &createParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &createParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -297,10 +382,52 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, createParam)
 
-					// Set option values for slice
-					createParam.Weekdays = c.StringSlice("weekdays")
-					createParam.Tags = c.StringSlice("tags")
-					createParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("disk-id") {
+						createParam.DiskId = c.Int64("disk-id")
+					}
+					if c.IsSet("weekdays") {
+						createParam.Weekdays = c.StringSlice("weekdays")
+					}
+					if c.IsSet("generation") {
+						createParam.Generation = c.Int("generation")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						createParam.Description = c.String("description")
+					}
+					if c.IsSet("tags") {
+						createParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						createParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -363,10 +490,67 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					createParam.Weekdays = c.StringSlice("weekdays")
-					createParam.Tags = c.StringSlice("tags")
-					createParam.Column = c.StringSlice("column")
+					createParam.ParamTemplate = c.String("param-template")
+					createParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(createParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewCreateAutoBackupParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(createParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("disk-id") {
+						createParam.DiskId = c.Int64("disk-id")
+					}
+					if c.IsSet("weekdays") {
+						createParam.Weekdays = c.StringSlice("weekdays")
+					}
+					if c.IsSet("generation") {
+						createParam.Generation = c.Int("generation")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						createParam.Description = c.String("description")
+					}
+					if c.IsSet("tags") {
+						createParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						createParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -397,10 +581,17 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -408,27 +599,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -452,8 +639,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -516,8 +726,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadAutoBackupParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -600,41 +848,43 @@ func init() {
 						Usage: "set backup target weekdays[all or mon/tue/wed/thu/fri/sat/sun]",
 					},
 					&cli.IntFlag{
-						Name:        "generation",
-						Usage:       "set backup generation[1-10]",
-						Destination: &updateParam.Generation,
+						Name:  "generation",
+						Usage: "set backup generation[1-10]",
 					},
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "set resource display name",
-						Destination: &updateParam.Name,
+						Name:  "name",
+						Usage: "set resource display name",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &updateParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set resource tags",
 					},
 					&cli.Int64Flag{
-						Name:        "icon-id",
-						Usage:       "set Icon ID",
-						Destination: &updateParam.IconId,
+						Name:  "icon-id",
+						Usage: "set Icon ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &updateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &updateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -642,27 +892,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &updateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &updateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &updateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &updateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -686,10 +932,52 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, updateParam)
 
-					// Set option values for slice
-					updateParam.Weekdays = c.StringSlice("weekdays")
-					updateParam.Tags = c.StringSlice("tags")
-					updateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("weekdays") {
+						updateParam.Weekdays = c.StringSlice("weekdays")
+					}
+					if c.IsSet("generation") {
+						updateParam.Generation = c.Int("generation")
+					}
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						updateParam.Description = c.String("description")
+					}
+					if c.IsSet("tags") {
+						updateParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						updateParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -752,10 +1040,67 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					updateParam.Weekdays = c.StringSlice("weekdays")
-					updateParam.Tags = c.StringSlice("tags")
-					updateParam.Column = c.StringSlice("column")
+					updateParam.ParamTemplate = c.String("param-template")
+					updateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(updateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewUpdateAutoBackupParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(updateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("weekdays") {
+						updateParam.Weekdays = c.StringSlice("weekdays")
+					}
+					if c.IsSet("generation") {
+						updateParam.Generation = c.Int("generation")
+					}
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						updateParam.Description = c.String("description")
+					}
+					if c.IsSet("tags") {
+						updateParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						updateParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -836,16 +1181,22 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &deleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &deleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -853,27 +1204,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &deleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &deleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &deleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &deleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -897,8 +1244,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, deleteParam)
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -961,8 +1334,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					deleteParam.ParamTemplate = c.String("param-template")
+					deleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(deleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDeleteAutoBackupParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(deleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1126,6 +1540,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("auto-backup", "create", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("auto-backup", "create", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("auto-backup", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1170,6 +1594,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("auto-backup", "delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("auto-backup", "delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("auto-backup", "delete", "quiet", &schema.Category{
 		Key:         "output",
@@ -1216,6 +1650,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("auto-backup", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("auto-backup", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("auto-backup", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1255,6 +1699,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("auto-backup", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("auto-backup", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("auto-backup", "read", "quiet", &schema.Category{
 		Key:         "output",
@@ -1310,6 +1764,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("auto-backup", "update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("auto-backup", "update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("auto-backup", "update", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_bridge_gen.go
+++ b/command/cli/cli_bridge_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -39,26 +41,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -66,21 +73,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -104,11 +108,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -171,11 +207,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListBridgeParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -200,27 +283,31 @@ func init() {
 				Usage: "Create Bridge",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "[Required] set resource display name",
-						Destination: &createParam.Name,
+						Name:  "name",
+						Usage: "[Required] set resource display name",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &createParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &createParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &createParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -228,21 +315,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &createParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &createParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &createParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -266,8 +350,37 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, createParam)
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						createParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -330,8 +443,52 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					createParam.ParamTemplate = c.String("param-template")
+					createParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(createParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewCreateBridgeParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(createParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						createParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -362,10 +519,17 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -373,27 +537,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -417,8 +577,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -481,8 +664,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadBridgeParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -561,27 +782,31 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "set resource display name",
-						Destination: &updateParam.Name,
+						Name:  "name",
+						Usage: "set resource display name",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &updateParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &updateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &updateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -589,27 +814,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &updateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &updateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &updateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &updateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -633,8 +854,40 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, updateParam)
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						updateParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -697,8 +950,55 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					updateParam.ParamTemplate = c.String("param-template")
+					updateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(updateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewUpdateBridgeParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(updateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						updateParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -779,16 +1079,22 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &deleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &deleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -796,27 +1102,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &deleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &deleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &deleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &deleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -840,8 +1142,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, deleteParam)
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -904,8 +1232,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					deleteParam.ParamTemplate = c.String("param-template")
+					deleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(deleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDeleteBridgeParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(deleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1054,6 +1423,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("bridge", "create", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("bridge", "create", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("bridge", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1088,6 +1467,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("bridge", "delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("bridge", "delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("bridge", "delete", "quiet", &schema.Category{
 		Key:         "output",
@@ -1134,6 +1523,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("bridge", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("bridge", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("bridge", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1168,6 +1567,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("bridge", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("bridge", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("bridge", "read", "quiet", &schema.Category{
 		Key:         "output",
@@ -1213,6 +1622,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("bridge", "update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("bridge", "update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("bridge", "update", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_icon_gen.go
+++ b/command/cli/cli_icon_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -39,35 +41,39 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.StringFlag{
-						Name:        "scope",
-						Usage:       "set filter by scope('user' or 'shared')",
-						Destination: &listParam.Scope,
+						Name:  "scope",
+						Usage: "set filter by scope('user' or 'shared')",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set filter by tags(AND)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -75,21 +81,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -113,12 +116,49 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Tags = c.StringSlice("tags")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("scope") {
+						listParam.Scope = c.String("scope")
+					}
+					if c.IsSet("tags") {
+						listParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -181,12 +221,64 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Tags = c.StringSlice("tags")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListIconParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("scope") {
+						listParam.Scope = c.String("scope")
+					}
+					if c.IsSet("tags") {
+						listParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -211,30 +303,34 @@ func init() {
 				Usage: "Create Icon",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "image",
-						Usage:       "[Required] set file path for upload",
-						Destination: &createParam.Image,
+						Name:  "image",
+						Usage: "[Required] set file path for upload",
 					},
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "[Required] set resource display name",
-						Destination: &createParam.Name,
+						Name:  "name",
+						Usage: "[Required] set resource display name",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set resource tags",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &createParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &createParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -242,21 +338,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &createParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &createParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &createParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -280,9 +373,40 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, createParam)
 
-					// Set option values for slice
-					createParam.Tags = c.StringSlice("tags")
-					createParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("image") {
+						createParam.Image = c.String("image")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						createParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -345,9 +469,55 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					createParam.Tags = c.StringSlice("tags")
-					createParam.Column = c.StringSlice("column")
+					createParam.ParamTemplate = c.String("param-template")
+					createParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(createParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewCreateIconParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(createParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("image") {
+						createParam.Image = c.String("image")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						createParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -378,10 +548,17 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -389,27 +566,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -433,8 +606,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -497,8 +693,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadIconParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -577,25 +811,30 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "set resource display name",
-						Destination: &updateParam.Name,
+						Name:  "name",
+						Usage: "set resource display name",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set resource tags",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &updateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &updateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -603,27 +842,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &updateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &updateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &updateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &updateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -647,9 +882,40 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, updateParam)
 
-					// Set option values for slice
-					updateParam.Tags = c.StringSlice("tags")
-					updateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						updateParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -712,9 +978,55 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					updateParam.Tags = c.StringSlice("tags")
-					updateParam.Column = c.StringSlice("column")
+					updateParam.ParamTemplate = c.String("param-template")
+					updateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(updateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewUpdateIconParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(updateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						updateParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -795,16 +1107,22 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &deleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &deleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -812,27 +1130,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &deleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &deleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &deleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &deleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -856,8 +1170,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, deleteParam)
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -920,8 +1260,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					deleteParam.ParamTemplate = c.String("param-template")
+					deleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(deleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDeleteIconParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(deleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1070,6 +1451,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("icon", "create", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("icon", "create", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("icon", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1109,6 +1500,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("icon", "delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("icon", "delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("icon", "delete", "quiet", &schema.Category{
 		Key:         "output",
@@ -1155,6 +1556,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("icon", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("icon", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("icon", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1200,6 +1611,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("icon", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("icon", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("icon", "read", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1239,6 +1660,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("icon", "update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("icon", "update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("icon", "update", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_interface_gen.go
+++ b/command/cli/cli_interface_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -41,26 +43,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -68,21 +75,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -106,11 +110,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -173,11 +209,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListInterfaceParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -203,21 +286,26 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.Int64Flag{
-						Name:        "packet-filter-id",
-						Usage:       "[Required] set packet filter ID",
-						Destination: &packetFilterConnectParam.PacketFilterId,
+						Name:  "packet-filter-id",
+						Usage: "[Required] set packet filter ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &packetFilterConnectParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &packetFilterConnectParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -240,6 +328,23 @@ func init() {
 
 					// build command context
 					ctx := command.NewContext(c, realArgs, packetFilterConnectParam)
+
+					// Set option values
+					if c.IsSet("packet-filter-id") {
+						packetFilterConnectParam.PacketFilterId = c.Int64("packet-filter-id")
+					}
+					if c.IsSet("assumeyes") {
+						packetFilterConnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						packetFilterConnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						packetFilterConnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						packetFilterConnectParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -301,6 +406,38 @@ func init() {
 					}
 				},
 				Action: func(c *cli.Context) error {
+
+					packetFilterConnectParam.ParamTemplate = c.String("param-template")
+					packetFilterConnectParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(packetFilterConnectParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewPacketFilterConnectInterfaceParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(packetFilterConnectParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("packet-filter-id") {
+						packetFilterConnectParam.PacketFilterId = c.Int64("packet-filter-id")
+					}
+					if c.IsSet("assumeyes") {
+						packetFilterConnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						packetFilterConnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						packetFilterConnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						packetFilterConnectParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -379,21 +516,26 @@ func init() {
 				Usage: "Create Interface",
 				Flags: []cli.Flag{
 					&cli.Int64Flag{
-						Name:        "server-id",
-						Usage:       "[Required] set server ID",
-						Destination: &createParam.ServerId,
+						Name:  "server-id",
+						Usage: "[Required] set server ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &createParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &createParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -401,21 +543,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &createParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &createParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &createParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -439,8 +578,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, createParam)
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("server-id") {
+						createParam.ServerId = c.Int64("server-id")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -503,8 +668,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					createParam.ParamTemplate = c.String("param-template")
+					createParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(createParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewCreateInterfaceParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(createParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("server-id") {
+						createParam.ServerId = c.Int64("server-id")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -535,21 +741,26 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.Int64Flag{
-						Name:        "packet-filter-id",
-						Usage:       "[Required] set packet filter ID",
-						Destination: &packetFilterDisconnectParam.PacketFilterId,
+						Name:  "packet-filter-id",
+						Usage: "[Required] set packet filter ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &packetFilterDisconnectParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &packetFilterDisconnectParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -572,6 +783,23 @@ func init() {
 
 					// build command context
 					ctx := command.NewContext(c, realArgs, packetFilterDisconnectParam)
+
+					// Set option values
+					if c.IsSet("packet-filter-id") {
+						packetFilterDisconnectParam.PacketFilterId = c.Int64("packet-filter-id")
+					}
+					if c.IsSet("assumeyes") {
+						packetFilterDisconnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						packetFilterDisconnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						packetFilterDisconnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						packetFilterDisconnectParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -633,6 +861,38 @@ func init() {
 					}
 				},
 				Action: func(c *cli.Context) error {
+
+					packetFilterDisconnectParam.ParamTemplate = c.String("param-template")
+					packetFilterDisconnectParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(packetFilterDisconnectParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewPacketFilterDisconnectInterfaceParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(packetFilterDisconnectParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("packet-filter-id") {
+						packetFilterDisconnectParam.PacketFilterId = c.Int64("packet-filter-id")
+					}
+					if c.IsSet("assumeyes") {
+						packetFilterDisconnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						packetFilterDisconnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						packetFilterDisconnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						packetFilterDisconnectParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -712,10 +972,17 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -723,27 +990,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -767,8 +1030,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -831,8 +1117,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadInterfaceParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -911,21 +1235,26 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "user-ipaddress",
-						Usage:       "set user-ipaddress",
-						Destination: &updateParam.UserIpaddress,
+						Name:  "user-ipaddress",
+						Usage: "set user-ipaddress",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &updateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &updateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -933,27 +1262,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &updateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &updateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &updateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &updateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -977,8 +1302,37 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, updateParam)
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("user-ipaddress") {
+						updateParam.UserIpaddress = c.String("user-ipaddress")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -1041,8 +1395,52 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					updateParam.ParamTemplate = c.String("param-template")
+					updateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(updateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewUpdateInterfaceParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(updateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("user-ipaddress") {
+						updateParam.UserIpaddress = c.String("user-ipaddress")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1123,16 +1521,22 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &deleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &deleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -1140,27 +1544,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &deleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &deleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &deleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &deleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -1184,8 +1584,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, deleteParam)
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -1248,8 +1674,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					deleteParam.ParamTemplate = c.String("param-template")
+					deleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(deleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDeleteInterfaceParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(deleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1398,6 +1865,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("interface", "create", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("interface", "create", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("interface", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1437,6 +1914,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("interface", "delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("interface", "delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("interface", "delete", "quiet", &schema.Category{
 		Key:         "output",
@@ -1483,6 +1970,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("interface", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("interface", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("interface", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1508,6 +2005,16 @@ func init() {
 		DisplayName: "Packet-Filter options",
 		Order:       1,
 	})
+	AppendFlagCategoryMap("interface", "packet-filter-connect", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("interface", "packet-filter-connect", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("interface", "packet-filter-disconnect", "assumeyes", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -1522,6 +2029,16 @@ func init() {
 		Key:         "packet-filter",
 		DisplayName: "Packet-Filter options",
 		Order:       1,
+	})
+	AppendFlagCategoryMap("interface", "packet-filter-disconnect", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("interface", "packet-filter-disconnect", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("interface", "read", "column", &schema.Category{
 		Key:         "output",
@@ -1547,6 +2064,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("interface", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("interface", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("interface", "read", "quiet", &schema.Category{
 		Key:         "output",
@@ -1582,6 +2109,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("interface", "update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("interface", "update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("interface", "update", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_license_gen.go
+++ b/command/cli/cli_license_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -39,26 +41,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -66,21 +73,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -104,11 +108,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -171,11 +207,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListLicenseParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -200,26 +283,30 @@ func init() {
 				Usage: "Create License",
 				Flags: []cli.Flag{
 					&cli.Int64Flag{
-						Name:        "license-info-id",
-						Usage:       "set LicenseInfo ID",
-						Destination: &createParam.LicenseInfoId,
+						Name:  "license-info-id",
+						Usage: "set LicenseInfo ID",
 					},
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "[Required] set resource display name",
-						Destination: &createParam.Name,
+						Name:  "name",
+						Usage: "[Required] set resource display name",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &createParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &createParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -227,21 +314,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &createParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &createParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &createParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -265,8 +349,37 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, createParam)
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("license-info-id") {
+						createParam.LicenseInfoId = c.Int64("license-info-id")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -329,8 +442,52 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					createParam.ParamTemplate = c.String("param-template")
+					createParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(createParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewCreateLicenseParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(createParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("license-info-id") {
+						createParam.LicenseInfoId = c.Int64("license-info-id")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -361,10 +518,17 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -372,27 +536,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -416,8 +576,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -480,8 +663,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadLicenseParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -560,21 +781,26 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "set resource display name",
-						Destination: &updateParam.Name,
+						Name:  "name",
+						Usage: "set resource display name",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &updateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &updateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -582,27 +808,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &updateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &updateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &updateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &updateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -626,8 +848,37 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, updateParam)
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -690,8 +941,52 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					updateParam.ParamTemplate = c.String("param-template")
+					updateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(updateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewUpdateLicenseParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(updateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -772,16 +1067,22 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &deleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &deleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -789,27 +1090,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &deleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &deleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &deleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &deleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -833,8 +1130,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, deleteParam)
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -897,8 +1220,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					deleteParam.ParamTemplate = c.String("param-template")
+					deleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(deleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDeleteLicenseParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(deleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1047,6 +1411,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("license", "create", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("license", "create", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("license", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1081,6 +1455,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("license", "delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("license", "delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("license", "delete", "quiet", &schema.Category{
 		Key:         "output",
@@ -1127,6 +1511,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("license", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("license", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("license", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1161,6 +1555,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("license", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("license", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("license", "read", "quiet", &schema.Category{
 		Key:         "output",
@@ -1201,6 +1605,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("license", "update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("license", "update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("license", "update", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_packet_filter_gen.go
+++ b/command/cli/cli_packet_filter_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -45,26 +47,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -72,21 +79,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -110,11 +114,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -177,11 +213,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListPacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -206,27 +289,31 @@ func init() {
 				Usage: "Create PacketFilter",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "[Required] set resource display name",
-						Destination: &createParam.Name,
+						Name:  "name",
+						Usage: "[Required] set resource display name",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &createParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &createParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &createParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -234,21 +321,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &createParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &createParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &createParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -272,8 +356,37 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, createParam)
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						createParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -336,8 +449,52 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					createParam.Column = c.StringSlice("column")
+					createParam.ParamTemplate = c.String("param-template")
+					createParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(createParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewCreatePacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(createParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						createParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -368,10 +525,17 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -379,27 +543,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -423,8 +583,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -487,8 +670,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadPacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -567,27 +788,31 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "set resource display name",
-						Destination: &updateParam.Name,
+						Name:  "name",
+						Usage: "set resource display name",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &updateParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &updateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &updateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -595,27 +820,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &updateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &updateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &updateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &updateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -639,8 +860,40 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, updateParam)
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						updateParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -703,8 +956,55 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					updateParam.Column = c.StringSlice("column")
+					updateParam.ParamTemplate = c.String("param-template")
+					updateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(updateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewUpdatePacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(updateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("description") {
+						updateParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -785,16 +1085,22 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &deleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &deleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -802,27 +1108,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &deleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &deleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &deleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &deleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -846,8 +1148,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, deleteParam)
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -910,8 +1238,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					deleteParam.ParamTemplate = c.String("param-template")
+					deleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(deleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDeletePacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(deleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -992,10 +1361,17 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &ruleInfoParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -1003,27 +1379,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &ruleInfoParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &ruleInfoParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &ruleInfoParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &ruleInfoParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -1047,8 +1419,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, ruleInfoParam)
 
-					// Set option values for slice
-					ruleInfoParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						ruleInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleInfoParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleInfoParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -1111,8 +1506,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					ruleInfoParam.Column = c.StringSlice("column")
+					ruleInfoParam.ParamTemplate = c.String("param-template")
+					ruleInfoParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(ruleInfoParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewRuleInfoPacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(ruleInfoParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						ruleInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleInfoParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleInfoParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1187,54 +1620,53 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.IntFlag{
-						Name:        "index",
-						Usage:       "index to insert rule into",
-						Value:       1,
-						Destination: &ruleAddParam.Index,
+						Name:  "index",
+						Usage: "index to insert rule into",
+						Value: 1,
 					},
 					&cli.StringFlag{
-						Name:        "protocol",
-						Usage:       "set target protocol[tcp/udp/icmp/fragment/ip]",
-						Destination: &ruleAddParam.Protocol,
+						Name:  "protocol",
+						Usage: "set target protocol[tcp/udp/icmp/fragment/ip]",
 					},
 					&cli.StringFlag{
-						Name:        "source-network",
-						Usage:       "set source network[A.A.A.A] or [A.A.A.A/N (N=1..31)] or [A.A.A.A/M.M.M.M]",
-						Destination: &ruleAddParam.SourceNetwork,
+						Name:  "source-network",
+						Usage: "set source network[A.A.A.A] or [A.A.A.A/N (N=1..31)] or [A.A.A.A/M.M.M.M]",
 					},
 					&cli.StringFlag{
-						Name:        "source-port",
-						Usage:       "set source port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
-						Destination: &ruleAddParam.SourcePort,
+						Name:  "source-port",
+						Usage: "set source port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
 					},
 					&cli.StringFlag{
-						Name:        "destination-port",
-						Aliases:     []string{"dest-port"},
-						Usage:       "set destination port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
-						Destination: &ruleAddParam.DestinationPort,
+						Name:    "destination-port",
+						Aliases: []string{"dest-port"},
+						Usage:   "set destination port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
 					},
 					&cli.StringFlag{
-						Name:        "action",
-						Usage:       "set action[allow/deny]",
-						Destination: &ruleAddParam.Action,
+						Name:  "action",
+						Usage: "set action[allow/deny]",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &ruleAddParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &ruleAddParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &ruleAddParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -1242,27 +1674,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &ruleAddParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &ruleAddParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &ruleAddParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &ruleAddParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -1286,8 +1714,55 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, ruleAddParam)
 
-					// Set option values for slice
-					ruleAddParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("index") {
+						ruleAddParam.Index = c.Int("index")
+					}
+					if c.IsSet("protocol") {
+						ruleAddParam.Protocol = c.String("protocol")
+					}
+					if c.IsSet("source-network") {
+						ruleAddParam.SourceNetwork = c.String("source-network")
+					}
+					if c.IsSet("source-port") {
+						ruleAddParam.SourcePort = c.String("source-port")
+					}
+					if c.IsSet("destination-port") {
+						ruleAddParam.DestinationPort = c.String("destination-port")
+					}
+					if c.IsSet("action") {
+						ruleAddParam.Action = c.String("action")
+					}
+					if c.IsSet("description") {
+						ruleAddParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						ruleAddParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						ruleAddParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleAddParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleAddParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleAddParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleAddParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleAddParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleAddParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleAddParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -1350,8 +1825,70 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					ruleAddParam.Column = c.StringSlice("column")
+					ruleAddParam.ParamTemplate = c.String("param-template")
+					ruleAddParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(ruleAddParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewRuleAddPacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(ruleAddParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("index") {
+						ruleAddParam.Index = c.Int("index")
+					}
+					if c.IsSet("protocol") {
+						ruleAddParam.Protocol = c.String("protocol")
+					}
+					if c.IsSet("source-network") {
+						ruleAddParam.SourceNetwork = c.String("source-network")
+					}
+					if c.IsSet("source-port") {
+						ruleAddParam.SourcePort = c.String("source-port")
+					}
+					if c.IsSet("destination-port") {
+						ruleAddParam.DestinationPort = c.String("destination-port")
+					}
+					if c.IsSet("action") {
+						ruleAddParam.Action = c.String("action")
+					}
+					if c.IsSet("description") {
+						ruleAddParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						ruleAddParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						ruleAddParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleAddParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleAddParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleAddParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleAddParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleAddParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleAddParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleAddParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1435,53 +1972,52 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.IntFlag{
-						Name:        "index",
-						Usage:       "[Required] index of target rule",
-						Destination: &ruleUpdateParam.Index,
+						Name:  "index",
+						Usage: "[Required] index of target rule",
 					},
 					&cli.StringFlag{
-						Name:        "protocol",
-						Usage:       "set target protocol[tcp/udp/icmp/fragment/ip]",
-						Destination: &ruleUpdateParam.Protocol,
+						Name:  "protocol",
+						Usage: "set target protocol[tcp/udp/icmp/fragment/ip]",
 					},
 					&cli.StringFlag{
-						Name:        "source-network",
-						Usage:       "set source network[A.A.A.A] or [A.A.A.A/N (N=1..31)] or [A.A.A.A/M.M.M.M]",
-						Destination: &ruleUpdateParam.SourceNetwork,
+						Name:  "source-network",
+						Usage: "set source network[A.A.A.A] or [A.A.A.A/N (N=1..31)] or [A.A.A.A/M.M.M.M]",
 					},
 					&cli.StringFlag{
-						Name:        "source-port",
-						Usage:       "set source port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
-						Destination: &ruleUpdateParam.SourcePort,
+						Name:  "source-port",
+						Usage: "set source port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
 					},
 					&cli.StringFlag{
-						Name:        "destination-port",
-						Aliases:     []string{"dest-port"},
-						Usage:       "set destination port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
-						Destination: &ruleUpdateParam.DestinationPort,
+						Name:    "destination-port",
+						Aliases: []string{"dest-port"},
+						Usage:   "set destination port[N (N=0..65535)] or [N-N (N=0..65535)] or [0xPPPP/0xMMMM]",
 					},
 					&cli.StringFlag{
-						Name:        "action",
-						Usage:       "set action[allow/deny]",
-						Destination: &ruleUpdateParam.Action,
+						Name:  "action",
+						Usage: "set action[allow/deny]",
 					},
 					&cli.StringFlag{
-						Name:        "description",
-						Aliases:     []string{"desc"},
-						Usage:       "set resource description",
-						Destination: &ruleUpdateParam.Description,
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set resource description",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &ruleUpdateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &ruleUpdateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -1489,27 +2025,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &ruleUpdateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &ruleUpdateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &ruleUpdateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &ruleUpdateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -1533,8 +2065,55 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, ruleUpdateParam)
 
-					// Set option values for slice
-					ruleUpdateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("index") {
+						ruleUpdateParam.Index = c.Int("index")
+					}
+					if c.IsSet("protocol") {
+						ruleUpdateParam.Protocol = c.String("protocol")
+					}
+					if c.IsSet("source-network") {
+						ruleUpdateParam.SourceNetwork = c.String("source-network")
+					}
+					if c.IsSet("source-port") {
+						ruleUpdateParam.SourcePort = c.String("source-port")
+					}
+					if c.IsSet("destination-port") {
+						ruleUpdateParam.DestinationPort = c.String("destination-port")
+					}
+					if c.IsSet("action") {
+						ruleUpdateParam.Action = c.String("action")
+					}
+					if c.IsSet("description") {
+						ruleUpdateParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						ruleUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						ruleUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleUpdateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleUpdateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleUpdateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleUpdateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleUpdateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleUpdateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -1597,8 +2176,70 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					ruleUpdateParam.Column = c.StringSlice("column")
+					ruleUpdateParam.ParamTemplate = c.String("param-template")
+					ruleUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(ruleUpdateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewRuleUpdatePacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(ruleUpdateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("index") {
+						ruleUpdateParam.Index = c.Int("index")
+					}
+					if c.IsSet("protocol") {
+						ruleUpdateParam.Protocol = c.String("protocol")
+					}
+					if c.IsSet("source-network") {
+						ruleUpdateParam.SourceNetwork = c.String("source-network")
+					}
+					if c.IsSet("source-port") {
+						ruleUpdateParam.SourcePort = c.String("source-port")
+					}
+					if c.IsSet("destination-port") {
+						ruleUpdateParam.DestinationPort = c.String("destination-port")
+					}
+					if c.IsSet("action") {
+						ruleUpdateParam.Action = c.String("action")
+					}
+					if c.IsSet("description") {
+						ruleUpdateParam.Description = c.String("description")
+					}
+					if c.IsSet("assumeyes") {
+						ruleUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						ruleUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleUpdateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleUpdateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleUpdateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleUpdateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleUpdateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleUpdateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1682,21 +2323,26 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.IntFlag{
-						Name:        "index",
-						Usage:       "[Required] index of target rule",
-						Destination: &ruleDeleteParam.Index,
+						Name:  "index",
+						Usage: "[Required] index of target rule",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &ruleDeleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &ruleDeleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -1704,27 +2350,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &ruleDeleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &ruleDeleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &ruleDeleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &ruleDeleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -1748,8 +2390,37 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, ruleDeleteParam)
 
-					// Set option values for slice
-					ruleDeleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("index") {
+						ruleDeleteParam.Index = c.Int("index")
+					}
+					if c.IsSet("assumeyes") {
+						ruleDeleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						ruleDeleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleDeleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleDeleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleDeleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleDeleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleDeleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleDeleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleDeleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -1812,8 +2483,52 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					ruleDeleteParam.Column = c.StringSlice("column")
+					ruleDeleteParam.ParamTemplate = c.String("param-template")
+					ruleDeleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(ruleDeleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewRuleDeletePacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(ruleDeleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("index") {
+						ruleDeleteParam.Index = c.Int("index")
+					}
+					if c.IsSet("assumeyes") {
+						ruleDeleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						ruleDeleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						ruleDeleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						ruleDeleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						ruleDeleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						ruleDeleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						ruleDeleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						ruleDeleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						ruleDeleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1897,21 +2612,26 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.Int64Flag{
-						Name:        "interface-id",
-						Usage:       "[Required] set interface ID",
-						Destination: &interfaceConnectParam.InterfaceId,
+						Name:  "interface-id",
+						Usage: "[Required] set interface ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &interfaceConnectParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &interfaceConnectParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -1934,6 +2654,23 @@ func init() {
 
 					// build command context
 					ctx := command.NewContext(c, realArgs, interfaceConnectParam)
+
+					// Set option values
+					if c.IsSet("interface-id") {
+						interfaceConnectParam.InterfaceId = c.Int64("interface-id")
+					}
+					if c.IsSet("assumeyes") {
+						interfaceConnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						interfaceConnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						interfaceConnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						interfaceConnectParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -1995,6 +2732,38 @@ func init() {
 					}
 				},
 				Action: func(c *cli.Context) error {
+
+					interfaceConnectParam.ParamTemplate = c.String("param-template")
+					interfaceConnectParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(interfaceConnectParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewInterfaceConnectPacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(interfaceConnectParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("interface-id") {
+						interfaceConnectParam.InterfaceId = c.Int64("interface-id")
+					}
+					if c.IsSet("assumeyes") {
+						interfaceConnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						interfaceConnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						interfaceConnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						interfaceConnectParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -2078,21 +2847,26 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.Int64Flag{
-						Name:        "interface-id",
-						Usage:       "[Required] set interface ID",
-						Destination: &interfaceDisconnectParam.InterfaceId,
+						Name:  "interface-id",
+						Usage: "[Required] set interface ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &interfaceDisconnectParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &interfaceDisconnectParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -2115,6 +2889,23 @@ func init() {
 
 					// build command context
 					ctx := command.NewContext(c, realArgs, interfaceDisconnectParam)
+
+					// Set option values
+					if c.IsSet("interface-id") {
+						interfaceDisconnectParam.InterfaceId = c.Int64("interface-id")
+					}
+					if c.IsSet("assumeyes") {
+						interfaceDisconnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						interfaceDisconnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						interfaceDisconnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						interfaceDisconnectParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -2176,6 +2967,38 @@ func init() {
 					}
 				},
 				Action: func(c *cli.Context) error {
+
+					interfaceDisconnectParam.ParamTemplate = c.String("param-template")
+					interfaceDisconnectParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(interfaceDisconnectParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewInterfaceDisconnectPacketFilterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(interfaceDisconnectParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("interface-id") {
+						interfaceDisconnectParam.InterfaceId = c.Int64("interface-id")
+					}
+					if c.IsSet("assumeyes") {
+						interfaceDisconnectParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						interfaceDisconnectParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						interfaceDisconnectParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("id") {
+						interfaceDisconnectParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -2358,6 +3181,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "create", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "create", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("packet-filter", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2393,6 +3226,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("packet-filter", "delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2413,6 +3256,16 @@ func init() {
 		DisplayName: "Interface options",
 		Order:       1,
 	})
+	AppendFlagCategoryMap("packet-filter", "interface-connect", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "interface-connect", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("packet-filter", "interface-disconnect", "assumeyes", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -2427,6 +3280,16 @@ func init() {
 		Key:         "interface",
 		DisplayName: "Interface options",
 		Order:       1,
+	})
+	AppendFlagCategoryMap("packet-filter", "interface-disconnect", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "interface-disconnect", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "list", "column", &schema.Category{
 		Key:         "output",
@@ -2468,6 +3331,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("packet-filter", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2502,6 +3375,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "read", "quiet", &schema.Category{
 		Key:         "output",
@@ -2558,6 +3441,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "rule-add", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "rule-add", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("packet-filter", "rule-add", "protocol", &schema.Category{
 		Key:         "rule",
 		DisplayName: "Rule options",
@@ -2613,6 +3506,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "rule-delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "rule-delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("packet-filter", "rule-delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2642,6 +3545,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "rule-info", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "rule-info", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "rule-info", "quiet", &schema.Category{
 		Key:         "output",
@@ -2697,6 +3610,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "rule-update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "rule-update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "rule-update", "protocol", &schema.Category{
 		Key:         "rule",
@@ -2757,6 +3680,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("packet-filter", "update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "update", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_product_disk_gen.go
+++ b/command/cli/cli_product_disk_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -43,26 +45,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -70,21 +77,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -108,11 +112,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -175,11 +211,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListProductDiskParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -205,16 +288,22 @@ func init() {
 				ArgsUsage: "<ID>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &readParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -222,27 +311,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "[Required] set resource ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "[Required] set resource ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -266,8 +351,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -330,8 +441,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadProductDiskParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -426,6 +578,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-disk", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-disk", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("product-disk", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -465,6 +627,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-disk", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-disk", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-disk", "read", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_product_internet_gen.go
+++ b/command/cli/cli_product_internet_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -43,26 +45,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -70,21 +77,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -108,11 +112,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -175,11 +211,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListProductInternetParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -205,16 +288,22 @@ func init() {
 				ArgsUsage: "<ID>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &readParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -222,27 +311,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "[Required] set resource ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "[Required] set resource ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -266,8 +351,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -330,8 +441,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadProductInternetParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -426,6 +578,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-internet", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-internet", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("product-internet", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -465,6 +627,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-internet", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-internet", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-internet", "read", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_product_license_gen.go
+++ b/command/cli/cli_product_license_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -43,26 +45,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -70,21 +77,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -108,11 +112,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -175,11 +211,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListProductLicenseParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -205,16 +288,22 @@ func init() {
 				ArgsUsage: "<ID>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &readParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -222,27 +311,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "[Required] set resource ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "[Required] set resource ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -266,8 +351,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -330,8 +441,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadProductLicenseParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -426,6 +578,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-license", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-license", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("product-license", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -465,6 +627,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-license", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-license", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-license", "read", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_product_server_gen.go
+++ b/command/cli/cli_product_server_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -43,26 +45,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -70,21 +77,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -108,11 +112,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -175,11 +211,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListProductServerParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -205,16 +288,22 @@ func init() {
 				ArgsUsage: "<ID>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &readParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -222,27 +311,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "[Required] set resource ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "[Required] set resource ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -266,8 +351,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -330,8 +441,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadProductServerParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -426,6 +578,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-server", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-server", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("product-server", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -465,6 +627,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-server", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("product-server", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-server", "read", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_region_gen.go
+++ b/command/cli/cli_region_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -42,26 +44,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -69,21 +76,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -107,11 +111,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -174,11 +210,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListRegionParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -204,16 +287,22 @@ func init() {
 				ArgsUsage: "<ID>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &readParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -221,27 +310,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "[Required] set resource ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "[Required] set resource ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -265,8 +350,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -329,8 +440,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadRegionParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -425,6 +577,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("region", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("region", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("region", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -464,6 +626,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("region", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("region", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("region", "read", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_startup_script_gen.go
+++ b/command/cli/cli_startup_script_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -40,35 +42,39 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.StringFlag{
-						Name:        "scope",
-						Usage:       "set filter by scope('user' or 'shared')",
-						Destination: &listParam.Scope,
+						Name:  "scope",
+						Usage: "set filter by scope('user' or 'shared')",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set filter by tags(AND)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -76,21 +82,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -114,12 +117,49 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Tags = c.StringSlice("tags")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("scope") {
+						listParam.Scope = c.String("scope")
+					}
+					if c.IsSet("tags") {
+						listParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -182,12 +222,64 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Tags = c.StringSlice("tags")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListStartupScriptParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("scope") {
+						listParam.Scope = c.String("scope")
+					}
+					if c.IsSet("tags") {
+						listParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -212,42 +304,44 @@ func init() {
 				Usage: "Create StartupScript",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "script",
-						Aliases:     []string{"note"},
-						Usage:       "set script from file",
-						Destination: &createParam.Script,
+						Name:    "script",
+						Aliases: []string{"note"},
+						Usage:   "set script from file",
 					},
 					&cli.StringFlag{
-						Name:        "script-content",
-						Aliases:     []string{"note-content"},
-						Usage:       "set script content",
-						Destination: &createParam.ScriptContent,
+						Name:    "script-content",
+						Aliases: []string{"note-content"},
+						Usage:   "set script content",
 					},
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "[Required] set resource display name",
-						Destination: &createParam.Name,
+						Name:  "name",
+						Usage: "[Required] set resource display name",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set resource tags",
 					},
 					&cli.Int64Flag{
-						Name:        "icon-id",
-						Usage:       "set Icon ID",
-						Destination: &createParam.IconId,
+						Name:  "icon-id",
+						Usage: "set Icon ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &createParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &createParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -255,21 +349,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &createParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &createParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &createParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -293,9 +384,46 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, createParam)
 
-					// Set option values for slice
-					createParam.Tags = c.StringSlice("tags")
-					createParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("script") {
+						createParam.Script = c.String("script")
+					}
+					if c.IsSet("script-content") {
+						createParam.ScriptContent = c.String("script-content")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						createParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						createParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -358,9 +486,61 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					createParam.Tags = c.StringSlice("tags")
-					createParam.Column = c.StringSlice("column")
+					createParam.ParamTemplate = c.String("param-template")
+					createParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(createParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewCreateStartupScriptParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(createParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("script") {
+						createParam.Script = c.String("script")
+					}
+					if c.IsSet("script-content") {
+						createParam.ScriptContent = c.String("script-content")
+					}
+					if c.IsSet("name") {
+						createParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						createParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						createParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						createParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						createParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						createParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						createParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						createParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						createParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						createParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						createParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -391,10 +571,17 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -402,27 +589,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -446,8 +629,31 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -510,8 +716,46 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadStartupScriptParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -590,42 +834,44 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:        "script",
-						Aliases:     []string{"note"},
-						Usage:       "set script from file",
-						Destination: &updateParam.Script,
+						Name:    "script",
+						Aliases: []string{"note"},
+						Usage:   "set script from file",
 					},
 					&cli.StringFlag{
-						Name:        "script-content",
-						Aliases:     []string{"note-content"},
-						Usage:       "set script content",
-						Destination: &updateParam.ScriptContent,
+						Name:    "script-content",
+						Aliases: []string{"note-content"},
+						Usage:   "set script content",
 					},
 					&cli.StringFlag{
-						Name:        "name",
-						Usage:       "[Required] set resource display name",
-						Destination: &updateParam.Name,
+						Name:  "name",
+						Usage: "[Required] set resource display name",
 					},
 					&cli.StringSliceFlag{
 						Name:  "tags",
 						Usage: "set resource tags",
 					},
 					&cli.Int64Flag{
-						Name:        "icon-id",
-						Usage:       "set Icon ID",
-						Destination: &updateParam.IconId,
+						Name:  "icon-id",
+						Usage: "set Icon ID",
 					},
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &updateParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &updateParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -633,27 +879,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &updateParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &updateParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &updateParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &updateParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -677,9 +919,49 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, updateParam)
 
-					// Set option values for slice
-					updateParam.Tags = c.StringSlice("tags")
-					updateParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("script") {
+						updateParam.Script = c.String("script")
+					}
+					if c.IsSet("script-content") {
+						updateParam.ScriptContent = c.String("script-content")
+					}
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						updateParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						updateParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -742,9 +1024,64 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					updateParam.Tags = c.StringSlice("tags")
-					updateParam.Column = c.StringSlice("column")
+					updateParam.ParamTemplate = c.String("param-template")
+					updateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(updateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewUpdateStartupScriptParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(updateParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("script") {
+						updateParam.Script = c.String("script")
+					}
+					if c.IsSet("script-content") {
+						updateParam.ScriptContent = c.String("script-content")
+					}
+					if c.IsSet("name") {
+						updateParam.Name = c.String("name")
+					}
+					if c.IsSet("tags") {
+						updateParam.Tags = c.StringSlice("tags")
+					}
+					if c.IsSet("icon-id") {
+						updateParam.IconId = c.Int64("icon-id")
+					}
+					if c.IsSet("assumeyes") {
+						updateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						updateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						updateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						updateParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						updateParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						updateParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						updateParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						updateParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						updateParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -825,16 +1162,22 @@ func init() {
 				ArgsUsage: "<ID or Name(allow multiple target)>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &deleteParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &deleteParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -842,27 +1185,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &deleteParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &deleteParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &deleteParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "set target ID",
-						Destination: &deleteParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -886,8 +1225,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, deleteParam)
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -950,8 +1315,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					deleteParam.Column = c.StringSlice("column")
+					deleteParam.ParamTemplate = c.String("param-template")
+					deleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(deleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDeleteStartupScriptParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(deleteParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						deleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						deleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						deleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						deleteParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						deleteParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						deleteParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						deleteParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						deleteParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						deleteParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1100,6 +1506,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("startup-script", "create", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("startup-script", "create", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("startup-script", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1150,6 +1566,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("startup-script", "delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("startup-script", "delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("startup-script", "delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1194,6 +1620,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("startup-script", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("startup-script", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("startup-script", "list", "quiet", &schema.Category{
 		Key:         "output",
@@ -1240,6 +1676,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("startup-script", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("startup-script", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("startup-script", "read", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1284,6 +1730,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("startup-script", "update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("startup-script", "update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("startup-script", "update", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/cli/cli_zone_gen.go
+++ b/command/cli/cli_zone_gen.go
@@ -3,7 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/imdario/mergo"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/completion"
 	"github.com/sacloud/usacloud/command/funcs"
@@ -42,26 +44,31 @@ func init() {
 						Usage: "set filter by id(s)",
 					},
 					&cli.IntFlag{
-						Name:        "from",
-						Aliases:     []string{"offset"},
-						Usage:       "set offset",
-						Destination: &listParam.From,
+						Name:    "from",
+						Aliases: []string{"offset"},
+						Usage:   "set offset",
 					},
 					&cli.IntFlag{
-						Name:        "max",
-						Aliases:     []string{"limit"},
-						Usage:       "set limit",
-						Destination: &listParam.Max,
+						Name:    "max",
+						Aliases: []string{"limit"},
+						Usage:   "set limit",
 					},
 					&cli.StringSliceFlag{
 						Name:  "sort",
 						Usage: "set field(s) for sort",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &listParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -69,21 +76,18 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &listParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &listParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &listParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -107,11 +111,43 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, listParam)
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -174,11 +210,58 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					listParam.Name = c.StringSlice("name")
-					listParam.Id = c.Int64Slice("id")
-					listParam.Sort = c.StringSlice("sort")
-					listParam.Column = c.StringSlice("column")
+					listParam.ParamTemplate = c.String("param-template")
+					listParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(listParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewListZoneParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(listParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("name") {
+						listParam.Name = c.StringSlice("name")
+					}
+					if c.IsSet("id") {
+						listParam.Id = c.Int64Slice("id")
+					}
+					if c.IsSet("from") {
+						listParam.From = c.Int("from")
+					}
+					if c.IsSet("max") {
+						listParam.Max = c.Int("max")
+					}
+					if c.IsSet("sort") {
+						listParam.Sort = c.StringSlice("sort")
+					}
+					if c.IsSet("param-template") {
+						listParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						listParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						listParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						listParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						listParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						listParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						listParam.FormatFile = c.String("format-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -204,16 +287,22 @@ func init() {
 				ArgsUsage: "<ID>",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:        "assumeyes",
-						Aliases:     []string{"y"},
-						Usage:       "assume that the answer to any question which would be asked is yes",
-						Destination: &readParam.Assumeyes,
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
 					},
 					&cli.StringFlag{
-						Name:        "output-type",
-						Aliases:     []string{"out"},
-						Usage:       "Output type [json/csv/tsv]",
-						Destination: &readParam.OutputType,
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
 					},
 					&cli.StringSliceFlag{
 						Name:    "column",
@@ -221,27 +310,23 @@ func init() {
 						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
 					},
 					&cli.BoolFlag{
-						Name:        "quiet",
-						Aliases:     []string{"q"},
-						Usage:       "Only display IDs",
-						Destination: &readParam.Quiet,
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
 					},
 					&cli.StringFlag{
-						Name:        "format",
-						Aliases:     []string{"fmt"},
-						Usage:       "Output format(see text/template package document for detail)",
-						Destination: &readParam.Format,
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
 					},
 					&cli.StringFlag{
-						Name:        "format-file",
-						Usage:       "Output format from file(see text/template package document for detail)",
-						Destination: &readParam.FormatFile,
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
 					},
 					&cli.Int64Flag{
-						Name:        "id",
-						Usage:       "[Required] set resource ID",
-						Destination: &readParam.Id,
-						Hidden:      true,
+						Name:   "id",
+						Usage:  "[Required] set resource ID",
+						Hidden: true,
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -265,8 +350,34 @@ func init() {
 					// build command context
 					ctx := command.NewContext(c, realArgs, readParam)
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					if strings.HasPrefix(prev, "-") {
 						// prev if flag , is values setted?
@@ -329,8 +440,49 @@ func init() {
 				},
 				Action: func(c *cli.Context) error {
 
-					// Set option values for slice
-					readParam.Column = c.StringSlice("column")
+					readParam.ParamTemplate = c.String("param-template")
+					readParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(readParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewReadZoneParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(readParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("assumeyes") {
+						readParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						readParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						readParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("output-type") {
+						readParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						readParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						readParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						readParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						readParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("id") {
+						readParam.Id = c.Int64("id")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -425,6 +577,16 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("zone", "list", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("zone", "list", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
 	AppendFlagCategoryMap("zone", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -464,6 +626,16 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("zone", "read", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("zone", "read", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("zone", "read", "quiet", &schema.Category{
 		Key:         "output",

--- a/command/completion/archive_flags_gen.go
+++ b/command/completion/archive_flags_gen.go
@@ -64,8 +64,6 @@ func ArchiveCreateCompleteFlags(ctx command.Context, params *params.CreateArchiv
 		comp = define.Resources["Archive"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Archive"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Archive"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -108,8 +106,6 @@ func ArchiveUpdateCompleteFlags(ctx command.Context, params *params.UpdateArchiv
 		comp = define.Resources["Archive"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Archive"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Archive"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Archive"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -128,8 +124,6 @@ func ArchiveDeleteCompleteFlags(ctx command.Context, params *params.DeleteArchiv
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Archive"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Archive"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -150,8 +144,6 @@ func ArchiveUploadCompleteFlags(ctx command.Context, params *params.UploadArchiv
 	switch flagName {
 	case "archive-file":
 		comp = define.Resources["Archive"].Commands["upload"].Params["archive-file"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Archive"].Commands["upload"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Archive"].Commands["upload"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -172,8 +164,6 @@ func ArchiveDownloadCompleteFlags(ctx command.Context, params *params.DownloadAr
 	switch flagName {
 	case "file-destination":
 		comp = define.Resources["Archive"].Commands["download"].Params["file-destination"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Archive"].Commands["download"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Archive"].Commands["download"].Params["id"].CompleteFunc
 	}
@@ -190,8 +180,6 @@ func ArchiveFtpOpenCompleteFlags(ctx command.Context, params *params.FtpOpenArch
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Archive"].Commands["ftp-open"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Archive"].Commands["ftp-open"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -210,8 +198,6 @@ func ArchiveFtpCloseCompleteFlags(ctx command.Context, params *params.FtpCloseAr
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Archive"].Commands["ftp-close"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Archive"].Commands["ftp-close"].Params["id"].CompleteFunc
 	}

--- a/command/completion/auto_backup_flags_gen.go
+++ b/command/completion/auto_backup_flags_gen.go
@@ -56,8 +56,6 @@ func AutoBackupCreateCompleteFlags(ctx command.Context, params *params.CreateAut
 		comp = define.Resources["AutoBackup"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["AutoBackup"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["AutoBackup"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -104,8 +102,6 @@ func AutoBackupUpdateCompleteFlags(ctx command.Context, params *params.UpdateAut
 		comp = define.Resources["AutoBackup"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["AutoBackup"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["AutoBackup"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["AutoBackup"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -124,8 +120,6 @@ func AutoBackupDeleteCompleteFlags(ctx command.Context, params *params.DeleteAut
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["AutoBackup"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["AutoBackup"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/bridge_flags_gen.go
+++ b/command/completion/bridge_flags_gen.go
@@ -44,8 +44,6 @@ func BridgeCreateCompleteFlags(ctx command.Context, params *params.CreateBridgeP
 		comp = define.Resources["Bridge"].Commands["create"].Params["name"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["Bridge"].Commands["create"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Bridge"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -84,8 +82,6 @@ func BridgeUpdateCompleteFlags(ctx command.Context, params *params.UpdateBridgeP
 		comp = define.Resources["Bridge"].Commands["update"].Params["name"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["Bridge"].Commands["update"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Bridge"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Bridge"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -104,8 +100,6 @@ func BridgeDeleteCompleteFlags(ctx command.Context, params *params.DeleteBridgeP
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Bridge"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Bridge"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/database_flags_gen.go
+++ b/command/completion/database_flags_gen.go
@@ -74,8 +74,6 @@ func DatabaseCreateCompleteFlags(ctx command.Context, params *params.CreateDatab
 		comp = define.Resources["Database"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Database"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Database"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -128,8 +126,6 @@ func DatabaseUpdateCompleteFlags(ctx command.Context, params *params.UpdateDatab
 		comp = define.Resources["Database"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Database"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Database"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Database"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -148,8 +144,6 @@ func DatabaseDeleteCompleteFlags(ctx command.Context, params *params.DeleteDatab
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Database"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "force", "f":
 		comp = define.Resources["Database"].Commands["delete"].Params["force"].CompleteFunc
 	case "id":
@@ -170,8 +164,6 @@ func DatabaseBootCompleteFlags(ctx command.Context, params *params.BootDatabaseP
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Database"].Commands["boot"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Database"].Commands["boot"].Params["id"].CompleteFunc
 	}
@@ -188,8 +180,6 @@ func DatabaseShutdownCompleteFlags(ctx command.Context, params *params.ShutdownD
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Database"].Commands["shutdown"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Database"].Commands["shutdown"].Params["id"].CompleteFunc
 	}
@@ -206,8 +196,6 @@ func DatabaseShutdownForceCompleteFlags(ctx command.Context, params *params.Shut
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Database"].Commands["shutdown-force"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Database"].Commands["shutdown-force"].Params["id"].CompleteFunc
 	}
@@ -224,8 +212,6 @@ func DatabaseResetCompleteFlags(ctx command.Context, params *params.ResetDatabas
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Database"].Commands["reset"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Database"].Commands["reset"].Params["id"].CompleteFunc
 	}

--- a/command/completion/disk_flags_gen.go
+++ b/command/completion/disk_flags_gen.go
@@ -68,8 +68,6 @@ func DiskCreateCompleteFlags(ctx command.Context, params *params.CreateDiskParam
 		comp = define.Resources["Disk"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Disk"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -114,8 +112,6 @@ func DiskUpdateCompleteFlags(ctx command.Context, params *params.UpdateDiskParam
 		comp = define.Resources["Disk"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Disk"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -134,8 +130,6 @@ func DiskDeleteCompleteFlags(ctx command.Context, params *params.DeleteDiskParam
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -170,8 +164,6 @@ func DiskEditCompleteFlags(ctx command.Context, params *params.EditDiskParam, fl
 		comp = define.Resources["Disk"].Commands["edit"].Params["nw-masklen"].CompleteFunc
 	case "startup-script-ids", "note-ids":
 		comp = define.Resources["Disk"].Commands["edit"].Params["startup-script-ids"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["edit"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["edit"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -194,8 +186,6 @@ func DiskReinstallFromArchiveCompleteFlags(ctx command.Context, params *params.R
 		comp = define.Resources["Disk"].Commands["reinstall-from-archive"].Params["source-archive-id"].CompleteFunc
 	case "distant-from":
 		comp = define.Resources["Disk"].Commands["reinstall-from-archive"].Params["distant-from"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["reinstall-from-archive"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["reinstall-from-archive"].Params["id"].CompleteFunc
 	}
@@ -216,8 +206,6 @@ func DiskReinstallFromDiskCompleteFlags(ctx command.Context, params *params.Rein
 		comp = define.Resources["Disk"].Commands["reinstall-from-disk"].Params["source-disk-id"].CompleteFunc
 	case "distant-from":
 		comp = define.Resources["Disk"].Commands["reinstall-from-disk"].Params["distant-from"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["reinstall-from-disk"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["reinstall-from-disk"].Params["id"].CompleteFunc
 	}
@@ -236,8 +224,6 @@ func DiskReinstallToBlankCompleteFlags(ctx command.Context, params *params.Reins
 	switch flagName {
 	case "distant-from":
 		comp = define.Resources["Disk"].Commands["reinstall-to-blank"].Params["distant-from"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["reinstall-to-blank"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["reinstall-to-blank"].Params["id"].CompleteFunc
 	}
@@ -256,8 +242,6 @@ func DiskServerConnectCompleteFlags(ctx command.Context, params *params.ServerCo
 	switch flagName {
 	case "server-id":
 		comp = define.Resources["Disk"].Commands["server-connect"].Params["server-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["server-connect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["server-connect"].Params["id"].CompleteFunc
 	}
@@ -274,8 +258,6 @@ func DiskServerDisconnectCompleteFlags(ctx command.Context, params *params.Serve
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Disk"].Commands["server-disconnect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Disk"].Commands["server-disconnect"].Params["id"].CompleteFunc
 	}

--- a/command/completion/dns_flags_gen.go
+++ b/command/completion/dns_flags_gen.go
@@ -68,8 +68,6 @@ func DNSCreateCompleteFlags(ctx command.Context, params *params.CreateDNSParam, 
 		comp = define.Resources["DNS"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["DNS"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["DNS"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -104,8 +102,6 @@ func DNSRecordAddCompleteFlags(ctx command.Context, params *params.RecordAddDNSP
 		comp = define.Resources["DNS"].Commands["record-add"].Params["srv-port"].CompleteFunc
 	case "srv-target":
 		comp = define.Resources["DNS"].Commands["record-add"].Params["srv-target"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["DNS"].Commands["record-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["DNS"].Commands["record-add"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -162,8 +158,6 @@ func DNSRecordUpdateCompleteFlags(ctx command.Context, params *params.RecordUpda
 		comp = define.Resources["DNS"].Commands["record-update"].Params["srv-port"].CompleteFunc
 	case "srv-target":
 		comp = define.Resources["DNS"].Commands["record-update"].Params["srv-target"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["DNS"].Commands["record-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["DNS"].Commands["record-update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -184,8 +178,6 @@ func DNSRecordDeleteCompleteFlags(ctx command.Context, params *params.RecordDele
 	switch flagName {
 	case "index":
 		comp = define.Resources["DNS"].Commands["record-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["DNS"].Commands["record-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["DNS"].Commands["record-delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -210,8 +202,6 @@ func DNSUpdateCompleteFlags(ctx command.Context, params *params.UpdateDNSParam, 
 		comp = define.Resources["DNS"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["DNS"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["DNS"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["DNS"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -230,8 +220,6 @@ func DNSDeleteCompleteFlags(ctx command.Context, params *params.DeleteDNSParam, 
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["DNS"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["DNS"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/gslb_flags_gen.go
+++ b/command/completion/gslb_flags_gen.go
@@ -84,8 +84,6 @@ func GSLBCreateCompleteFlags(ctx command.Context, params *params.CreateGSLBParam
 		comp = define.Resources["GSLB"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["GSLB"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["GSLB"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -108,8 +106,6 @@ func GSLBServerAddCompleteFlags(ctx command.Context, params *params.ServerAddGSL
 		comp = define.Resources["GSLB"].Commands["server-add"].Params["enabled"].CompleteFunc
 	case "weight":
 		comp = define.Resources["GSLB"].Commands["server-add"].Params["weight"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["GSLB"].Commands["server-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["GSLB"].Commands["server-add"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -154,8 +150,6 @@ func GSLBServerUpdateCompleteFlags(ctx command.Context, params *params.ServerUpd
 		comp = define.Resources["GSLB"].Commands["server-update"].Params["enabled"].CompleteFunc
 	case "weight":
 		comp = define.Resources["GSLB"].Commands["server-update"].Params["weight"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["GSLB"].Commands["server-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["GSLB"].Commands["server-update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -176,8 +170,6 @@ func GSLBServerDeleteCompleteFlags(ctx command.Context, params *params.ServerDel
 	switch flagName {
 	case "index":
 		comp = define.Resources["GSLB"].Commands["server-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["GSLB"].Commands["server-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["GSLB"].Commands["server-delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -220,8 +212,6 @@ func GSLBUpdateCompleteFlags(ctx command.Context, params *params.UpdateGSLBParam
 		comp = define.Resources["GSLB"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["GSLB"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["GSLB"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["GSLB"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -240,8 +230,6 @@ func GSLBDeleteCompleteFlags(ctx command.Context, params *params.DeleteGSLBParam
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["GSLB"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["GSLB"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/icon_flags_gen.go
+++ b/command/completion/icon_flags_gen.go
@@ -50,8 +50,6 @@ func IconCreateCompleteFlags(ctx command.Context, params *params.CreateIconParam
 		comp = define.Resources["Icon"].Commands["create"].Params["name"].CompleteFunc
 	case "tags":
 		comp = define.Resources["Icon"].Commands["create"].Params["tags"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Icon"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -90,8 +88,6 @@ func IconUpdateCompleteFlags(ctx command.Context, params *params.UpdateIconParam
 		comp = define.Resources["Icon"].Commands["update"].Params["name"].CompleteFunc
 	case "tags":
 		comp = define.Resources["Icon"].Commands["update"].Params["tags"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Icon"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Icon"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -110,8 +106,6 @@ func IconDeleteCompleteFlags(ctx command.Context, params *params.DeleteIconParam
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Icon"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Icon"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/interface_flags_gen.go
+++ b/command/completion/interface_flags_gen.go
@@ -42,8 +42,6 @@ func InterfacePacketFilterConnectCompleteFlags(ctx command.Context, params *para
 	switch flagName {
 	case "packet-filter-id":
 		comp = define.Resources["Interface"].Commands["packet-filter-connect"].Params["packet-filter-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Interface"].Commands["packet-filter-connect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Interface"].Commands["packet-filter-connect"].Params["id"].CompleteFunc
 	}
@@ -62,8 +60,6 @@ func InterfaceCreateCompleteFlags(ctx command.Context, params *params.CreateInte
 	switch flagName {
 	case "server-id":
 		comp = define.Resources["Interface"].Commands["create"].Params["server-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Interface"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -82,8 +78,6 @@ func InterfacePacketFilterDisconnectCompleteFlags(ctx command.Context, params *p
 	switch flagName {
 	case "packet-filter-id":
 		comp = define.Resources["Interface"].Commands["packet-filter-disconnect"].Params["packet-filter-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Interface"].Commands["packet-filter-disconnect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Interface"].Commands["packet-filter-disconnect"].Params["id"].CompleteFunc
 	}
@@ -120,8 +114,6 @@ func InterfaceUpdateCompleteFlags(ctx command.Context, params *params.UpdateInte
 	switch flagName {
 	case "user-ipaddress":
 		comp = define.Resources["Interface"].Commands["update"].Params["user-ipaddress"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Interface"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Interface"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -140,8 +132,6 @@ func InterfaceDeleteCompleteFlags(ctx command.Context, params *params.DeleteInte
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Interface"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Interface"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/internet_flags_gen.go
+++ b/command/completion/internet_flags_gen.go
@@ -68,8 +68,6 @@ func InternetUpdateBandwidthCompleteFlags(ctx command.Context, params *params.Up
 	switch flagName {
 	case "band-width":
 		comp = define.Resources["Internet"].Commands["update-bandwidth"].Params["band-width"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Internet"].Commands["update-bandwidth"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Internet"].Commands["update-bandwidth"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -100,8 +98,6 @@ func InternetCreateCompleteFlags(ctx command.Context, params *params.CreateInter
 		comp = define.Resources["Internet"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Internet"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Internet"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -146,8 +142,6 @@ func InternetUpdateCompleteFlags(ctx command.Context, params *params.UpdateInter
 		comp = define.Resources["Internet"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Internet"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Internet"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Internet"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -166,8 +160,6 @@ func InternetDeleteCompleteFlags(ctx command.Context, params *params.DeleteInter
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Internet"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Internet"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/iso_image_flags_gen.go
+++ b/command/completion/iso_image_flags_gen.go
@@ -56,8 +56,6 @@ func ISOImageCreateCompleteFlags(ctx command.Context, params *params.CreateISOIm
 		comp = define.Resources["ISOImage"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["ISOImage"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["ISOImage"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -100,8 +98,6 @@ func ISOImageUpdateCompleteFlags(ctx command.Context, params *params.UpdateISOIm
 		comp = define.Resources["ISOImage"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["ISOImage"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["ISOImage"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ISOImage"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -120,8 +116,6 @@ func ISOImageDeleteCompleteFlags(ctx command.Context, params *params.DeleteISOIm
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["ISOImage"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ISOImage"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -142,8 +136,6 @@ func ISOImageUploadCompleteFlags(ctx command.Context, params *params.UploadISOIm
 	switch flagName {
 	case "iso-file":
 		comp = define.Resources["ISOImage"].Commands["upload"].Params["iso-file"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["ISOImage"].Commands["upload"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ISOImage"].Commands["upload"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -164,8 +156,6 @@ func ISOImageDownloadCompleteFlags(ctx command.Context, params *params.DownloadI
 	switch flagName {
 	case "file-destination":
 		comp = define.Resources["ISOImage"].Commands["download"].Params["file-destination"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["ISOImage"].Commands["download"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ISOImage"].Commands["download"].Params["id"].CompleteFunc
 	}
@@ -182,8 +172,6 @@ func ISOImageFtpOpenCompleteFlags(ctx command.Context, params *params.FtpOpenISO
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["ISOImage"].Commands["ftp-open"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ISOImage"].Commands["ftp-open"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -202,8 +190,6 @@ func ISOImageFtpCloseCompleteFlags(ctx command.Context, params *params.FtpCloseI
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["ISOImage"].Commands["ftp-close"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ISOImage"].Commands["ftp-close"].Params["id"].CompleteFunc
 	}

--- a/command/completion/license_flags_gen.go
+++ b/command/completion/license_flags_gen.go
@@ -44,8 +44,6 @@ func LicenseCreateCompleteFlags(ctx command.Context, params *params.CreateLicens
 		comp = define.Resources["License"].Commands["create"].Params["license-info-id"].CompleteFunc
 	case "name":
 		comp = define.Resources["License"].Commands["create"].Params["name"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["License"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -82,8 +80,6 @@ func LicenseUpdateCompleteFlags(ctx command.Context, params *params.UpdateLicens
 	switch flagName {
 	case "name":
 		comp = define.Resources["License"].Commands["update"].Params["name"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["License"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["License"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -102,8 +98,6 @@ func LicenseDeleteCompleteFlags(ctx command.Context, params *params.DeleteLicens
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["License"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["License"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/load_balancer_flags_gen.go
+++ b/command/completion/load_balancer_flags_gen.go
@@ -66,8 +66,6 @@ func LoadBalancerCreateCompleteFlags(ctx command.Context, params *params.CreateL
 		comp = define.Resources["LoadBalancer"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["LoadBalancer"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -110,8 +108,6 @@ func LoadBalancerUpdateCompleteFlags(ctx command.Context, params *params.UpdateL
 		comp = define.Resources["LoadBalancer"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["LoadBalancer"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -132,8 +128,6 @@ func LoadBalancerDeleteCompleteFlags(ctx command.Context, params *params.DeleteL
 	switch flagName {
 	case "force", "f":
 		comp = define.Resources["LoadBalancer"].Commands["delete"].Params["force"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -152,8 +146,6 @@ func LoadBalancerBootCompleteFlags(ctx command.Context, params *params.BootLoadB
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["boot"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["boot"].Params["id"].CompleteFunc
 	}
@@ -170,8 +162,6 @@ func LoadBalancerShutdownCompleteFlags(ctx command.Context, params *params.Shutd
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["shutdown"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["shutdown"].Params["id"].CompleteFunc
 	}
@@ -188,8 +178,6 @@ func LoadBalancerShutdownForceCompleteFlags(ctx command.Context, params *params.
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["shutdown-force"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["shutdown-force"].Params["id"].CompleteFunc
 	}
@@ -206,8 +194,6 @@ func LoadBalancerResetCompleteFlags(ctx command.Context, params *params.ResetLoa
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["reset"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["reset"].Params["id"].CompleteFunc
 	}
@@ -282,8 +268,6 @@ func LoadBalancerVipAddCompleteFlags(ctx command.Context, params *params.VipAddL
 		comp = define.Resources["LoadBalancer"].Commands["vip-add"].Params["delay-loop"].CompleteFunc
 	case "sorry-server":
 		comp = define.Resources["LoadBalancer"].Commands["vip-add"].Params["sorry-server"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["vip-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["vip-add"].Params["id"].CompleteFunc
 	}
@@ -310,8 +294,6 @@ func LoadBalancerVipUpdateCompleteFlags(ctx command.Context, params *params.VipU
 		comp = define.Resources["LoadBalancer"].Commands["vip-update"].Params["delay-loop"].CompleteFunc
 	case "sorry-server":
 		comp = define.Resources["LoadBalancer"].Commands["vip-update"].Params["sorry-server"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["vip-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["vip-update"].Params["id"].CompleteFunc
 	}
@@ -330,8 +312,6 @@ func LoadBalancerVipDeleteCompleteFlags(ctx command.Context, params *params.VipD
 	switch flagName {
 	case "index":
 		comp = define.Resources["LoadBalancer"].Commands["vip-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["vip-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["vip-delete"].Params["id"].CompleteFunc
 	}
@@ -388,8 +368,6 @@ func LoadBalancerServerAddCompleteFlags(ctx command.Context, params *params.Serv
 		comp = define.Resources["LoadBalancer"].Commands["server-add"].Params["response-code"].CompleteFunc
 	case "enabled":
 		comp = define.Resources["LoadBalancer"].Commands["server-add"].Params["enabled"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["server-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["server-add"].Params["id"].CompleteFunc
 	}
@@ -422,8 +400,6 @@ func LoadBalancerServerUpdateCompleteFlags(ctx command.Context, params *params.S
 		comp = define.Resources["LoadBalancer"].Commands["server-update"].Params["response-code"].CompleteFunc
 	case "enabled":
 		comp = define.Resources["LoadBalancer"].Commands["server-update"].Params["enabled"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["server-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["server-update"].Params["id"].CompleteFunc
 	}
@@ -448,8 +424,6 @@ func LoadBalancerServerDeleteCompleteFlags(ctx command.Context, params *params.S
 		comp = define.Resources["LoadBalancer"].Commands["server-delete"].Params["port"].CompleteFunc
 	case "ipaddress", "ip":
 		comp = define.Resources["LoadBalancer"].Commands["server-delete"].Params["ipaddress"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["LoadBalancer"].Commands["server-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["LoadBalancer"].Commands["server-delete"].Params["id"].CompleteFunc
 	}

--- a/command/completion/object_storage_flags_gen.go
+++ b/command/completion/object_storage_flags_gen.go
@@ -46,8 +46,6 @@ func ObjectStoragePutCompleteFlags(ctx command.Context, params *params.PutObject
 		comp = define.Resources["ObjectStorage"].Commands["put"].Params["secret-key"].CompleteFunc
 	case "bucket":
 		comp = define.Resources["ObjectStorage"].Commands["put"].Params["bucket"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["ObjectStorage"].Commands["put"].Params["assumeyes"].CompleteFunc
 	}
 
 	if comp != nil {
@@ -92,8 +90,6 @@ func ObjectStorageDeleteCompleteFlags(ctx command.Context, params *params.Delete
 		comp = define.Resources["ObjectStorage"].Commands["delete"].Params["secret-key"].CompleteFunc
 	case "bucket":
 		comp = define.Resources["ObjectStorage"].Commands["delete"].Params["bucket"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["ObjectStorage"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	}
 
 	if comp != nil {

--- a/command/completion/packet_filter_flags_gen.go
+++ b/command/completion/packet_filter_flags_gen.go
@@ -44,8 +44,6 @@ func PacketFilterCreateCompleteFlags(ctx command.Context, params *params.CreateP
 		comp = define.Resources["PacketFilter"].Commands["create"].Params["name"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["PacketFilter"].Commands["create"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -84,8 +82,6 @@ func PacketFilterUpdateCompleteFlags(ctx command.Context, params *params.UpdateP
 		comp = define.Resources["PacketFilter"].Commands["update"].Params["name"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["PacketFilter"].Commands["update"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["PacketFilter"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -104,8 +100,6 @@ func PacketFilterDeleteCompleteFlags(ctx command.Context, params *params.DeleteP
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["PacketFilter"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -156,8 +150,6 @@ func PacketFilterRuleAddCompleteFlags(ctx command.Context, params *params.RuleAd
 		comp = define.Resources["PacketFilter"].Commands["rule-add"].Params["action"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["PacketFilter"].Commands["rule-add"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["rule-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["PacketFilter"].Commands["rule-add"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -190,8 +182,6 @@ func PacketFilterRuleUpdateCompleteFlags(ctx command.Context, params *params.Rul
 		comp = define.Resources["PacketFilter"].Commands["rule-update"].Params["action"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["PacketFilter"].Commands["rule-update"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["rule-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["PacketFilter"].Commands["rule-update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -212,8 +202,6 @@ func PacketFilterRuleDeleteCompleteFlags(ctx command.Context, params *params.Rul
 	switch flagName {
 	case "index":
 		comp = define.Resources["PacketFilter"].Commands["rule-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["rule-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["PacketFilter"].Commands["rule-delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -234,8 +222,6 @@ func PacketFilterInterfaceConnectCompleteFlags(ctx command.Context, params *para
 	switch flagName {
 	case "interface-id":
 		comp = define.Resources["PacketFilter"].Commands["interface-connect"].Params["interface-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["interface-connect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["PacketFilter"].Commands["interface-connect"].Params["id"].CompleteFunc
 	}
@@ -254,8 +240,6 @@ func PacketFilterInterfaceDisconnectCompleteFlags(ctx command.Context, params *p
 	switch flagName {
 	case "interface-id":
 		comp = define.Resources["PacketFilter"].Commands["interface-disconnect"].Params["interface-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["PacketFilter"].Commands["interface-disconnect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["PacketFilter"].Commands["interface-disconnect"].Params["id"].CompleteFunc
 	}

--- a/command/completion/product_disk_flags_gen.go
+++ b/command/completion/product_disk_flags_gen.go
@@ -40,8 +40,6 @@ func ProductDiskReadCompleteFlags(ctx command.Context, params *params.ReadProduc
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["ProductDisk"].Commands["read"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ProductDisk"].Commands["read"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/product_internet_flags_gen.go
+++ b/command/completion/product_internet_flags_gen.go
@@ -40,8 +40,6 @@ func ProductInternetReadCompleteFlags(ctx command.Context, params *params.ReadPr
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["ProductInternet"].Commands["read"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ProductInternet"].Commands["read"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/product_license_flags_gen.go
+++ b/command/completion/product_license_flags_gen.go
@@ -40,8 +40,6 @@ func ProductLicenseReadCompleteFlags(ctx command.Context, params *params.ReadPro
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["ProductLicense"].Commands["read"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ProductLicense"].Commands["read"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/product_server_flags_gen.go
+++ b/command/completion/product_server_flags_gen.go
@@ -40,8 +40,6 @@ func ProductServerReadCompleteFlags(ctx command.Context, params *params.ReadProd
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["ProductServer"].Commands["read"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["ProductServer"].Commands["read"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/region_flags_gen.go
+++ b/command/completion/region_flags_gen.go
@@ -40,8 +40,6 @@ func RegionReadCompleteFlags(ctx command.Context, params *params.ReadRegionParam
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Region"].Commands["read"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Region"].Commands["read"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/server_flags_gen.go
+++ b/command/completion/server_flags_gen.go
@@ -118,8 +118,6 @@ func ServerBuildCompleteFlags(ctx command.Context, params *params.BuildServerPar
 		comp = define.Resources["Server"].Commands["build"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Server"].Commands["build"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["build"].Params["assumeyes"].CompleteFunc
 	case "us-keyboard":
 		comp = define.Resources["Server"].Commands["build"].Params["us-keyboard"].CompleteFunc
 	case "disable-boot-after-create":
@@ -166,8 +164,6 @@ func ServerUpdateCompleteFlags(ctx command.Context, params *params.UpdateServerP
 		comp = define.Resources["Server"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Server"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -190,8 +186,6 @@ func ServerDeleteCompleteFlags(ctx command.Context, params *params.DeleteServerP
 		comp = define.Resources["Server"].Commands["delete"].Params["force"].CompleteFunc
 	case "without-disk":
 		comp = define.Resources["Server"].Commands["delete"].Params["without-disk"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -214,8 +208,6 @@ func ServerPlanChangeCompleteFlags(ctx command.Context, params *params.PlanChang
 		comp = define.Resources["Server"].Commands["plan-change"].Params["core"].CompleteFunc
 	case "memory":
 		comp = define.Resources["Server"].Commands["plan-change"].Params["memory"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["plan-change"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["plan-change"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -234,8 +226,6 @@ func ServerBootCompleteFlags(ctx command.Context, params *params.BootServerParam
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["boot"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["boot"].Params["id"].CompleteFunc
 	}
@@ -252,8 +242,6 @@ func ServerShutdownCompleteFlags(ctx command.Context, params *params.ShutdownSer
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["shutdown"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["shutdown"].Params["id"].CompleteFunc
 	}
@@ -270,8 +258,6 @@ func ServerShutdownForceCompleteFlags(ctx command.Context, params *params.Shutdo
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["shutdown-force"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["shutdown-force"].Params["id"].CompleteFunc
 	}
@@ -288,8 +274,6 @@ func ServerResetCompleteFlags(ctx command.Context, params *params.ResetServerPar
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["reset"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["reset"].Params["id"].CompleteFunc
 	}
@@ -400,8 +384,6 @@ func ServerScpCompleteFlags(ctx command.Context, params *params.ScpServerParam, 
 		comp = define.Resources["Server"].Commands["scp"].Params["port"].CompleteFunc
 	case "password":
 		comp = define.Resources["Server"].Commands["scp"].Params["password"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["scp"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -420,8 +402,6 @@ func ServerVncCompleteFlags(ctx command.Context, params *params.VncServerParam, 
 	switch flagName {
 	case "wait-for-boot":
 		comp = define.Resources["Server"].Commands["vnc"].Params["wait-for-boot"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["vnc"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["vnc"].Params["id"].CompleteFunc
 	}
@@ -468,8 +448,6 @@ func ServerVncSendCompleteFlags(ctx command.Context, params *params.VncSendServe
 		comp = define.Resources["Server"].Commands["vnc-send"].Params["debug"].CompleteFunc
 	case "wait-for-boot":
 		comp = define.Resources["Server"].Commands["vnc-send"].Params["wait-for-boot"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["vnc-send"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["vnc-send"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -508,8 +486,6 @@ func ServerDiskConnectCompleteFlags(ctx command.Context, params *params.DiskConn
 	switch flagName {
 	case "disk-id":
 		comp = define.Resources["Server"].Commands["disk-connect"].Params["disk-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["disk-connect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["disk-connect"].Params["id"].CompleteFunc
 	}
@@ -528,8 +504,6 @@ func ServerDiskDisconnectCompleteFlags(ctx command.Context, params *params.DiskD
 	switch flagName {
 	case "disk-id":
 		comp = define.Resources["Server"].Commands["disk-disconnect"].Params["disk-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["disk-disconnect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["disk-disconnect"].Params["id"].CompleteFunc
 	}
@@ -566,8 +540,6 @@ func ServerInterfaceAddForInternetCompleteFlags(ctx command.Context, params *par
 	switch flagName {
 	case "without-disk-edit":
 		comp = define.Resources["Server"].Commands["interface-add-for-internet"].Params["without-disk-edit"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["interface-add-for-internet"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["interface-add-for-internet"].Params["id"].CompleteFunc
 	}
@@ -594,8 +566,6 @@ func ServerInterfaceAddForRouterCompleteFlags(ctx command.Context, params *param
 		comp = define.Resources["Server"].Commands["interface-add-for-router"].Params["default-route"].CompleteFunc
 	case "nw-masklen", "network-masklen":
 		comp = define.Resources["Server"].Commands["interface-add-for-router"].Params["nw-masklen"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["interface-add-for-router"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["interface-add-for-router"].Params["id"].CompleteFunc
 	}
@@ -622,8 +592,6 @@ func ServerInterfaceAddForSwitchCompleteFlags(ctx command.Context, params *param
 		comp = define.Resources["Server"].Commands["interface-add-for-switch"].Params["default-route"].CompleteFunc
 	case "nw-masklen", "network-masklen":
 		comp = define.Resources["Server"].Commands["interface-add-for-switch"].Params["nw-masklen"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["interface-add-for-switch"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["interface-add-for-switch"].Params["id"].CompleteFunc
 	}
@@ -640,8 +608,6 @@ func ServerInterfaceAddDisconnectedCompleteFlags(ctx command.Context, params *pa
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["interface-add-disconnected"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["interface-add-disconnected"].Params["id"].CompleteFunc
 	}
@@ -690,8 +656,6 @@ func ServerIsoInsertCompleteFlags(ctx command.Context, params *params.IsoInsertS
 		comp = define.Resources["Server"].Commands["iso-insert"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Server"].Commands["iso-insert"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["iso-insert"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["iso-insert"].Params["id"].CompleteFunc
 	}
@@ -708,8 +672,6 @@ func ServerIsoEjectCompleteFlags(ctx command.Context, params *params.IsoEjectSer
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Server"].Commands["iso-eject"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Server"].Commands["iso-eject"].Params["id"].CompleteFunc
 	}

--- a/command/completion/simple_monitor_flags_gen.go
+++ b/command/completion/simple_monitor_flags_gen.go
@@ -74,8 +74,6 @@ func SimpleMonitorCreateCompleteFlags(ctx command.Context, params *params.Create
 		comp = define.Resources["SimpleMonitor"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["SimpleMonitor"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["SimpleMonitor"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -140,8 +138,6 @@ func SimpleMonitorUpdateCompleteFlags(ctx command.Context, params *params.Update
 		comp = define.Resources["SimpleMonitor"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["SimpleMonitor"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["SimpleMonitor"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["SimpleMonitor"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -160,8 +156,6 @@ func SimpleMonitorDeleteCompleteFlags(ctx command.Context, params *params.Delete
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["SimpleMonitor"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["SimpleMonitor"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/ssh_key_flags_gen.go
+++ b/command/completion/ssh_key_flags_gen.go
@@ -46,10 +46,6 @@ func SSHKeyCreateCompleteFlags(ctx command.Context, params *params.CreateSSHKeyP
 		comp = define.Resources["SSHKey"].Commands["create"].Params["name"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["SSHKey"].Commands["create"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["SSHKey"].Commands["create"].Params["assumeyes"].CompleteFunc
-	case "public-key-content":
-		comp = define.Resources["SSHKey"].Commands["create"].Params["public-key-content"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -88,8 +84,6 @@ func SSHKeyUpdateCompleteFlags(ctx command.Context, params *params.UpdateSSHKeyP
 		comp = define.Resources["SSHKey"].Commands["update"].Params["name"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["SSHKey"].Commands["update"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["SSHKey"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["SSHKey"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -108,8 +102,6 @@ func SSHKeyDeleteCompleteFlags(ctx command.Context, params *params.DeleteSSHKeyP
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["SSHKey"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["SSHKey"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -134,8 +126,6 @@ func SSHKeyGenerateCompleteFlags(ctx command.Context, params *params.GenerateSSH
 		comp = define.Resources["SSHKey"].Commands["generate"].Params["name"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["SSHKey"].Commands["generate"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["SSHKey"].Commands["generate"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}

--- a/command/completion/startup_script_flags_gen.go
+++ b/command/completion/startup_script_flags_gen.go
@@ -54,8 +54,6 @@ func StartupScriptCreateCompleteFlags(ctx command.Context, params *params.Create
 		comp = define.Resources["StartupScript"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["StartupScript"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["StartupScript"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -100,8 +98,6 @@ func StartupScriptUpdateCompleteFlags(ctx command.Context, params *params.Update
 		comp = define.Resources["StartupScript"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["StartupScript"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["StartupScript"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["StartupScript"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -120,8 +116,6 @@ func StartupScriptDeleteCompleteFlags(ctx command.Context, params *params.Delete
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["StartupScript"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["StartupScript"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/completion/switch_flags_gen.go
+++ b/command/completion/switch_flags_gen.go
@@ -50,8 +50,6 @@ func SwitchCreateCompleteFlags(ctx command.Context, params *params.CreateSwitchP
 		comp = define.Resources["Switch"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Switch"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Switch"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -94,8 +92,6 @@ func SwitchUpdateCompleteFlags(ctx command.Context, params *params.UpdateSwitchP
 		comp = define.Resources["Switch"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["Switch"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Switch"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Switch"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -114,8 +110,6 @@ func SwitchDeleteCompleteFlags(ctx command.Context, params *params.DeleteSwitchP
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Switch"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Switch"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -136,8 +130,6 @@ func SwitchBridgeConnectCompleteFlags(ctx command.Context, params *params.Bridge
 	switch flagName {
 	case "bridge-id":
 		comp = define.Resources["Switch"].Commands["bridge-connect"].Params["bridge-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["Switch"].Commands["bridge-connect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Switch"].Commands["bridge-connect"].Params["id"].CompleteFunc
 	}
@@ -154,8 +146,6 @@ func SwitchBridgeDisconnectCompleteFlags(ctx command.Context, params *params.Bri
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Switch"].Commands["bridge-disconnect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Switch"].Commands["bridge-disconnect"].Params["id"].CompleteFunc
 	}

--- a/command/completion/vpc_router_flags_gen.go
+++ b/command/completion/vpc_router_flags_gen.go
@@ -64,8 +64,6 @@ func VPCRouterCreateCompleteFlags(ctx command.Context, params *params.CreateVPCR
 		comp = define.Resources["VPCRouter"].Commands["create"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["VPCRouter"].Commands["create"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["create"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}
@@ -110,8 +108,6 @@ func VPCRouterUpdateCompleteFlags(ctx command.Context, params *params.UpdateVPCR
 		comp = define.Resources["VPCRouter"].Commands["update"].Params["tags"].CompleteFunc
 	case "icon-id":
 		comp = define.Resources["VPCRouter"].Commands["update"].Params["icon-id"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["update"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -132,8 +128,6 @@ func VPCRouterDeleteCompleteFlags(ctx command.Context, params *params.DeleteVPCR
 	switch flagName {
 	case "force", "f":
 		comp = define.Resources["VPCRouter"].Commands["delete"].Params["force"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["delete"].Params["id"].CompleteFunc
 	case "output-type", "out":
@@ -152,8 +146,6 @@ func VPCRouterBootCompleteFlags(ctx command.Context, params *params.BootVPCRoute
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["boot"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["boot"].Params["id"].CompleteFunc
 	}
@@ -170,8 +162,6 @@ func VPCRouterShutdownCompleteFlags(ctx command.Context, params *params.Shutdown
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["shutdown"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["shutdown"].Params["id"].CompleteFunc
 	}
@@ -188,8 +178,6 @@ func VPCRouterShutdownForceCompleteFlags(ctx command.Context, params *params.Shu
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["shutdown-force"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["shutdown-force"].Params["id"].CompleteFunc
 	}
@@ -206,8 +194,6 @@ func VPCRouterResetCompleteFlags(ctx command.Context, params *params.ResetVPCRou
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["reset"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["reset"].Params["id"].CompleteFunc
 	}
@@ -288,8 +274,6 @@ func VPCRouterInterfaceConnectCompleteFlags(ctx command.Context, params *params.
 		comp = define.Resources["VPCRouter"].Commands["interface-connect"].Params["ipaddress2"].CompleteFunc
 	case "nw-masklen", "network-masklen":
 		comp = define.Resources["VPCRouter"].Commands["interface-connect"].Params["nw-masklen"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["interface-connect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["interface-connect"].Params["id"].CompleteFunc
 	}
@@ -322,8 +306,6 @@ func VPCRouterInterfaceUpdateCompleteFlags(ctx command.Context, params *params.I
 		comp = define.Resources["VPCRouter"].Commands["interface-update"].Params["alias"].CompleteFunc
 	case "nw-masklen", "network-masklen":
 		comp = define.Resources["VPCRouter"].Commands["interface-update"].Params["nw-masklen"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["interface-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["interface-update"].Params["id"].CompleteFunc
 	}
@@ -344,8 +326,6 @@ func VPCRouterInterfaceDisconnectCompleteFlags(ctx command.Context, params *para
 		comp = define.Resources["VPCRouter"].Commands["interface-disconnect"].Params["index"].CompleteFunc
 	case "with-reboot":
 		comp = define.Resources["VPCRouter"].Commands["interface-disconnect"].Params["with-reboot"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["interface-disconnect"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["interface-disconnect"].Params["id"].CompleteFunc
 	}
@@ -386,8 +366,6 @@ func VPCRouterStaticNatAddCompleteFlags(ctx command.Context, params *params.Stat
 		comp = define.Resources["VPCRouter"].Commands["static-nat-add"].Params["private"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["VPCRouter"].Commands["static-nat-add"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["static-nat-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["static-nat-add"].Params["id"].CompleteFunc
 	}
@@ -412,8 +390,6 @@ func VPCRouterStaticNatUpdateCompleteFlags(ctx command.Context, params *params.S
 		comp = define.Resources["VPCRouter"].Commands["static-nat-update"].Params["private"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["VPCRouter"].Commands["static-nat-update"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["static-nat-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["static-nat-update"].Params["id"].CompleteFunc
 	}
@@ -432,8 +408,6 @@ func VPCRouterStaticNatDeleteCompleteFlags(ctx command.Context, params *params.S
 	switch flagName {
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["static-nat-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["static-nat-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["static-nat-delete"].Params["id"].CompleteFunc
 	}
@@ -478,8 +452,6 @@ func VPCRouterPortForwardingAddCompleteFlags(ctx command.Context, params *params
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-add"].Params["private-port"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-add"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["port-forwarding-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-add"].Params["id"].CompleteFunc
 	}
@@ -508,8 +480,6 @@ func VPCRouterPortForwardingUpdateCompleteFlags(ctx command.Context, params *par
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-update"].Params["private-port"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-update"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["port-forwarding-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-update"].Params["id"].CompleteFunc
 	}
@@ -528,8 +498,6 @@ func VPCRouterPortForwardingDeleteCompleteFlags(ctx command.Context, params *par
 	switch flagName {
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["port-forwarding-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["port-forwarding-delete"].Params["id"].CompleteFunc
 	}
@@ -584,8 +552,6 @@ func VPCRouterFirewallAddCompleteFlags(ctx command.Context, params *params.Firew
 		comp = define.Resources["VPCRouter"].Commands["firewall-add"].Params["enable-logging"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["VPCRouter"].Commands["firewall-add"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["firewall-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["firewall-add"].Params["id"].CompleteFunc
 	}
@@ -622,8 +588,6 @@ func VPCRouterFirewallUpdateCompleteFlags(ctx command.Context, params *params.Fi
 		comp = define.Resources["VPCRouter"].Commands["firewall-update"].Params["enable-logging"].CompleteFunc
 	case "description", "desc":
 		comp = define.Resources["VPCRouter"].Commands["firewall-update"].Params["description"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["firewall-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["firewall-update"].Params["id"].CompleteFunc
 	}
@@ -644,8 +608,6 @@ func VPCRouterFirewallDeleteCompleteFlags(ctx command.Context, params *params.Fi
 		comp = define.Resources["VPCRouter"].Commands["firewall-delete"].Params["direction"].CompleteFunc
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["firewall-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["firewall-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["firewall-delete"].Params["id"].CompleteFunc
 	}
@@ -686,8 +648,6 @@ func VPCRouterDhcpServerAddCompleteFlags(ctx command.Context, params *params.Dhc
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["range-start"].CompleteFunc
 	case "range-stop", "range-end":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["range-stop"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["id"].CompleteFunc
 	}
@@ -710,8 +670,6 @@ func VPCRouterDhcpServerUpdateCompleteFlags(ctx command.Context, params *params.
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["range-start"].CompleteFunc
 	case "range-stop", "range-end":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["range-stop"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["id"].CompleteFunc
 	}
@@ -730,8 +688,6 @@ func VPCRouterDhcpServerDeleteCompleteFlags(ctx command.Context, params *params.
 	switch flagName {
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["dhcp-server-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-server-delete"].Params["id"].CompleteFunc
 	}
@@ -770,8 +726,6 @@ func VPCRouterDhcpStaticMappingAddCompleteFlags(ctx command.Context, params *par
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-add"].Params["macaddress"].CompleteFunc
 	case "ipaddress", "ip":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-add"].Params["ipaddress"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-add"].Params["id"].CompleteFunc
 	}
@@ -794,8 +748,6 @@ func VPCRouterDhcpStaticMappingUpdateCompleteFlags(ctx command.Context, params *
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-update"].Params["macaddress"].CompleteFunc
 	case "ipaddress", "ip":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-update"].Params["ipaddress"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-update"].Params["id"].CompleteFunc
 	}
@@ -814,8 +766,6 @@ func VPCRouterDhcpStaticMappingDeleteCompleteFlags(ctx command.Context, params *
 	switch flagName {
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["dhcp-static-mapping-delete"].Params["id"].CompleteFunc
 	}
@@ -856,8 +806,6 @@ func VPCRouterPptpServerUpdateCompleteFlags(ctx command.Context, params *params.
 		comp = define.Resources["VPCRouter"].Commands["pptp-server-update"].Params["range-start"].CompleteFunc
 	case "range-stop", "range-end":
 		comp = define.Resources["VPCRouter"].Commands["pptp-server-update"].Params["range-stop"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["pptp-server-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["pptp-server-update"].Params["id"].CompleteFunc
 	}
@@ -900,8 +848,6 @@ func VPCRouterL2tpServerUpdateCompleteFlags(ctx command.Context, params *params.
 		comp = define.Resources["VPCRouter"].Commands["l2tp-server-update"].Params["range-stop"].CompleteFunc
 	case "pre-shared-secret":
 		comp = define.Resources["VPCRouter"].Commands["l2tp-server-update"].Params["pre-shared-secret"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["l2tp-server-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["l2tp-server-update"].Params["id"].CompleteFunc
 	}
@@ -940,8 +886,6 @@ func VPCRouterUserAddCompleteFlags(ctx command.Context, params *params.UserAddVP
 		comp = define.Resources["VPCRouter"].Commands["user-add"].Params["username"].CompleteFunc
 	case "password", "pass":
 		comp = define.Resources["VPCRouter"].Commands["user-add"].Params["password"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["user-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["user-add"].Params["id"].CompleteFunc
 	}
@@ -964,8 +908,6 @@ func VPCRouterUserUpdateCompleteFlags(ctx command.Context, params *params.UserUp
 		comp = define.Resources["VPCRouter"].Commands["user-update"].Params["username"].CompleteFunc
 	case "password", "pass":
 		comp = define.Resources["VPCRouter"].Commands["user-update"].Params["password"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["user-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["user-update"].Params["id"].CompleteFunc
 	}
@@ -984,8 +926,6 @@ func VPCRouterUserDeleteCompleteFlags(ctx command.Context, params *params.UserDe
 	switch flagName {
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["user-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["user-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["user-delete"].Params["id"].CompleteFunc
 	}
@@ -1030,8 +970,6 @@ func VPCRouterSiteToSiteVpnAddCompleteFlags(ctx command.Context, params *params.
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-add"].Params["routes"].CompleteFunc
 	case "local-prefix":
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-add"].Params["local-prefix"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-add"].Params["id"].CompleteFunc
 	}
@@ -1060,8 +998,6 @@ func VPCRouterSiteToSiteVpnUpdateCompleteFlags(ctx command.Context, params *para
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-update"].Params["routes"].CompleteFunc
 	case "local-prefix":
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-update"].Params["local-prefix"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-update"].Params["id"].CompleteFunc
 	}
@@ -1080,8 +1016,6 @@ func VPCRouterSiteToSiteVpnDeleteCompleteFlags(ctx command.Context, params *para
 	switch flagName {
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["site-to-site-vpn-delete"].Params["id"].CompleteFunc
 	}
@@ -1120,8 +1054,6 @@ func VPCRouterStaticRouteAddCompleteFlags(ctx command.Context, params *params.St
 		comp = define.Resources["VPCRouter"].Commands["static-route-add"].Params["prefix"].CompleteFunc
 	case "next-hop":
 		comp = define.Resources["VPCRouter"].Commands["static-route-add"].Params["next-hop"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["static-route-add"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["static-route-add"].Params["id"].CompleteFunc
 	}
@@ -1144,8 +1076,6 @@ func VPCRouterStaticRouteUpdateCompleteFlags(ctx command.Context, params *params
 		comp = define.Resources["VPCRouter"].Commands["static-route-update"].Params["prefix"].CompleteFunc
 	case "next-hop":
 		comp = define.Resources["VPCRouter"].Commands["static-route-update"].Params["next-hop"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["static-route-update"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["static-route-update"].Params["id"].CompleteFunc
 	}
@@ -1164,8 +1094,6 @@ func VPCRouterStaticRouteDeleteCompleteFlags(ctx command.Context, params *params
 	switch flagName {
 	case "index":
 		comp = define.Resources["VPCRouter"].Commands["static-route-delete"].Params["index"].CompleteFunc
-	case "assumeyes", "y":
-		comp = define.Resources["VPCRouter"].Commands["static-route-delete"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["VPCRouter"].Commands["static-route-delete"].Params["id"].CompleteFunc
 	}

--- a/command/completion/web_accel_flags_gen.go
+++ b/command/completion/web_accel_flags_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
-	"github.com/sacloud/usacloud/define"
 	"github.com/sacloud/usacloud/schema"
 )
 
@@ -14,8 +13,6 @@ func WebAccelDeleteCacheCompleteFlags(ctx command.Context, params *params.Delete
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["WebAccel"].Commands["delete-cache"].Params["assumeyes"].CompleteFunc
 	case "output-type", "out":
 		comp = schema.CompleteInStrValues("json", "csv", "tsv")
 	}

--- a/command/completion/zone_flags_gen.go
+++ b/command/completion/zone_flags_gen.go
@@ -40,8 +40,6 @@ func ZoneReadCompleteFlags(ctx command.Context, params *params.ReadZoneParam, fl
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "assumeyes", "y":
-		comp = define.Resources["Zone"].Commands["read"].Params["assumeyes"].CompleteFunc
 	case "id":
 		comp = define.Resources["Zone"].Commands["read"].Params["id"].CompleteFunc
 	case "output-type", "out":

--- a/command/input_option.go
+++ b/command/input_option.go
@@ -1,0 +1,51 @@
+package command
+
+import (
+	"fmt"
+	"github.com/sacloud/usacloud/schema"
+	"io/ioutil"
+)
+
+type InputOption interface {
+	GetParamTemplate() string
+	GetParamTemplateFile() string
+}
+
+func ValidateInputOption(o InputOption) []error {
+
+	t := o.GetParamTemplate()
+	tf := o.GetParamTemplateFile()
+
+	// tmpl and tmpl-file
+	if t != "" && tf != "" {
+		return []error{fmt.Errorf("%q: can't set with --param-template-file", "--param-template")}
+	}
+
+	if tf != "" {
+		errs := schema.ValidateFileExists()("--param-template-file", tf)
+		if len(errs) > 0 {
+			return errs
+		}
+	}
+
+	return []error{}
+
+}
+
+func GetParamTemplateValue(o InputOption) (string, error) {
+	t := o.GetParamTemplate()
+	tf := o.GetParamTemplateFile()
+
+	if t == "" && tf == "" {
+		return "", nil
+	}
+
+	if t != "" {
+		return t, nil
+	}
+	b, err := ioutil.ReadFile(o.GetParamTemplateFile())
+	if err != nil {
+		return "", fmt.Errorf("Read ParameterTemplateFile[%s] is failed: %s", o.GetParamTemplateFile(), err)
+	}
+	return string(b), nil
+}

--- a/command/params/params_archive_gen.go
+++ b/command/params/params_archive_gen.go
@@ -10,20 +10,22 @@ import (
 
 // ListArchiveParam is input parameters for the sacloud API
 type ListArchiveParam struct {
-	Name            []string
-	Id              []int64
-	Scope           string
-	Tags            []string
-	SourceArchiveId int64
-	SourceDiskId    int64
-	From            int
-	Max             int
-	Sort            []string
-	OutputType      string
-	Column          []string
-	Quiet           bool
-	Format          string
-	FormatFile      string
+	Name              []string
+	Id                []int64
+	Scope             string
+	Tags              []string
+	SourceArchiveId   int64
+	SourceDiskId      int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListArchiveParam return new ListArchiveParam
@@ -91,6 +93,12 @@ func (p *ListArchiveParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -196,6 +204,20 @@ func (p *ListArchiveParam) SetSort(v []string) {
 func (p *ListArchiveParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListArchiveParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -234,20 +256,22 @@ func (p *ListArchiveParam) GetFormatFile() string {
 
 // CreateArchiveParam is input parameters for the sacloud API
 type CreateArchiveParam struct {
-	SourceDiskId    int64
-	SourceArchiveId int64
-	Size            int
-	ArchiveFile     string
-	Name            string
-	Description     string
-	Tags            []string
-	IconId          int64
-	Assumeyes       bool
-	OutputType      string
-	Column          []string
-	Quiet           bool
-	Format          string
-	FormatFile      string
+	SourceDiskId      int64
+	SourceArchiveId   int64
+	Size              int
+	ArchiveFile       string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateArchiveParam return new CreateArchiveParam
@@ -372,6 +396,12 @@ func (p *CreateArchiveParam) Validate() []error {
 		}
 	}
 	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
 		errs := validateOutputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
@@ -472,6 +502,20 @@ func (p *CreateArchiveParam) SetAssumeyes(v bool) {
 func (p *CreateArchiveParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateArchiveParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -510,12 +554,14 @@ func (p *CreateArchiveParam) GetFormatFile() string {
 
 // ReadArchiveParam is input parameters for the sacloud API
 type ReadArchiveParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadArchiveParam return new ReadArchiveParam
@@ -537,6 +583,12 @@ func (p *ReadArchiveParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -579,6 +631,20 @@ func (p *ReadArchiveParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadArchiveParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -624,17 +690,19 @@ func (p *ReadArchiveParam) GetId() int64 {
 
 // UpdateArchiveParam is input parameters for the sacloud API
 type UpdateArchiveParam struct {
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateArchiveParam return new UpdateArchiveParam
@@ -684,6 +752,12 @@ func (p *UpdateArchiveParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -761,6 +835,20 @@ func (p *UpdateArchiveParam) SetAssumeyes(v bool) {
 func (p *UpdateArchiveParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateArchiveParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -806,13 +894,15 @@ func (p *UpdateArchiveParam) GetId() int64 {
 
 // DeleteArchiveParam is input parameters for the sacloud API
 type DeleteArchiveParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteArchiveParam return new DeleteArchiveParam
@@ -834,6 +924,12 @@ func (p *DeleteArchiveParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -883,6 +979,20 @@ func (p *DeleteArchiveParam) SetAssumeyes(v bool) {
 func (p *DeleteArchiveParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeleteArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeleteArchiveParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -928,14 +1038,16 @@ func (p *DeleteArchiveParam) GetId() int64 {
 
 // UploadArchiveParam is input parameters for the sacloud API
 type UploadArchiveParam struct {
-	ArchiveFile string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	ArchiveFile       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUploadArchiveParam return new UploadArchiveParam
@@ -971,6 +1083,12 @@ func (p *UploadArchiveParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1027,6 +1145,20 @@ func (p *UploadArchiveParam) SetAssumeyes(v bool) {
 func (p *UploadArchiveParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UploadArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UploadArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UploadArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UploadArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UploadArchiveParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1072,9 +1204,11 @@ func (p *UploadArchiveParam) GetId() int64 {
 
 // DownloadArchiveParam is input parameters for the sacloud API
 type DownloadArchiveParam struct {
-	FileDestination string
-	Assumeyes       bool
-	Id              int64
+	FileDestination   string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDownloadArchiveParam return new DownloadArchiveParam
@@ -1145,6 +1279,20 @@ func (p *DownloadArchiveParam) SetAssumeyes(v bool) {
 func (p *DownloadArchiveParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DownloadArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DownloadArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DownloadArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DownloadArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DownloadArchiveParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1155,13 +1303,15 @@ func (p *DownloadArchiveParam) GetId() int64 {
 
 // FtpOpenArchiveParam is input parameters for the sacloud API
 type FtpOpenArchiveParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewFtpOpenArchiveParam return new FtpOpenArchiveParam
@@ -1183,6 +1333,12 @@ func (p *FtpOpenArchiveParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1232,6 +1388,20 @@ func (p *FtpOpenArchiveParam) SetAssumeyes(v bool) {
 func (p *FtpOpenArchiveParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *FtpOpenArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FtpOpenArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FtpOpenArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FtpOpenArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *FtpOpenArchiveParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1277,8 +1447,10 @@ func (p *FtpOpenArchiveParam) GetId() int64 {
 
 // FtpCloseArchiveParam is input parameters for the sacloud API
 type FtpCloseArchiveParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewFtpCloseArchiveParam return new FtpCloseArchiveParam
@@ -1335,6 +1507,20 @@ func (p *FtpCloseArchiveParam) SetAssumeyes(v bool) {
 func (p *FtpCloseArchiveParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *FtpCloseArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FtpCloseArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FtpCloseArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FtpCloseArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *FtpCloseArchiveParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1345,7 +1531,9 @@ func (p *FtpCloseArchiveParam) GetId() int64 {
 
 // WaitForCopyArchiveParam is input parameters for the sacloud API
 type WaitForCopyArchiveParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForCopyArchiveParam return new WaitForCopyArchiveParam
@@ -1395,6 +1583,20 @@ func (p *WaitForCopyArchiveParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForCopyArchiveParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForCopyArchiveParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForCopyArchiveParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForCopyArchiveParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForCopyArchiveParam) SetId(v int64) {
 	p.Id = v
 }

--- a/command/params/params_auth_status_gen.go
+++ b/command/params/params_auth_status_gen.go
@@ -10,11 +10,13 @@ import (
 
 // ShowAuthStatusParam is input parameters for the sacloud API
 type ShowAuthStatusParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewShowAuthStatusParam return new ShowAuthStatusParam
@@ -29,6 +31,12 @@ func (p *ShowAuthStatusParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -71,6 +79,20 @@ func (p *ShowAuthStatusParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ShowAuthStatusParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShowAuthStatusParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShowAuthStatusParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShowAuthStatusParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShowAuthStatusParam) SetOutputType(v string) {
 	p.OutputType = v
 }

--- a/command/params/params_auto_backup_gen.go
+++ b/command/params/params_auto_backup_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListAutoBackupParam is input parameters for the sacloud API
 type ListAutoBackupParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListAutoBackupParam return new ListAutoBackupParam
@@ -67,6 +69,12 @@ func (p *ListAutoBackupParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListAutoBackupParam) SetSort(v []string) {
 func (p *ListAutoBackupParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListAutoBackupParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListAutoBackupParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListAutoBackupParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListAutoBackupParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListAutoBackupParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,19 +211,21 @@ func (p *ListAutoBackupParam) GetFormatFile() string {
 
 // CreateAutoBackupParam is input parameters for the sacloud API
 type CreateAutoBackupParam struct {
-	DiskId      int64
-	Weekdays    []string
-	Generation  int
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
+	DiskId            int64
+	Weekdays          []string
+	Generation        int
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateAutoBackupParam return new CreateAutoBackupParam
@@ -303,6 +327,12 @@ func (p *CreateAutoBackupParam) Validate() []error {
 		}
 	}
 	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
 		errs := validateOutputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
@@ -396,6 +426,20 @@ func (p *CreateAutoBackupParam) SetAssumeyes(v bool) {
 func (p *CreateAutoBackupParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateAutoBackupParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateAutoBackupParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateAutoBackupParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateAutoBackupParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateAutoBackupParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -434,12 +478,14 @@ func (p *CreateAutoBackupParam) GetFormatFile() string {
 
 // ReadAutoBackupParam is input parameters for the sacloud API
 type ReadAutoBackupParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadAutoBackupParam return new ReadAutoBackupParam
@@ -461,6 +507,12 @@ func (p *ReadAutoBackupParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -503,6 +555,20 @@ func (p *ReadAutoBackupParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadAutoBackupParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadAutoBackupParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadAutoBackupParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadAutoBackupParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadAutoBackupParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -548,19 +614,21 @@ func (p *ReadAutoBackupParam) GetId() int64 {
 
 // UpdateAutoBackupParam is input parameters for the sacloud API
 type UpdateAutoBackupParam struct {
-	Weekdays    []string
-	Generation  int
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Weekdays          []string
+	Generation        int
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateAutoBackupParam return new UpdateAutoBackupParam
@@ -624,6 +692,12 @@ func (p *UpdateAutoBackupParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -715,6 +789,20 @@ func (p *UpdateAutoBackupParam) SetAssumeyes(v bool) {
 func (p *UpdateAutoBackupParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateAutoBackupParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateAutoBackupParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateAutoBackupParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateAutoBackupParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateAutoBackupParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -760,13 +848,15 @@ func (p *UpdateAutoBackupParam) GetId() int64 {
 
 // DeleteAutoBackupParam is input parameters for the sacloud API
 type DeleteAutoBackupParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteAutoBackupParam return new DeleteAutoBackupParam
@@ -788,6 +878,12 @@ func (p *DeleteAutoBackupParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -836,6 +932,20 @@ func (p *DeleteAutoBackupParam) SetAssumeyes(v bool) {
 
 func (p *DeleteAutoBackupParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteAutoBackupParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteAutoBackupParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteAutoBackupParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteAutoBackupParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteAutoBackupParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_bill_gen.go
+++ b/command/params/params_bill_gen.go
@@ -10,9 +10,11 @@ import (
 
 // CsvBillParam is input parameters for the sacloud API
 type CsvBillParam struct {
-	NoHeader   bool
-	BillOutput string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	NoHeader          bool
+	BillOutput        string
+	Id                int64
 }
 
 // NewCsvBillParam return new CsvBillParam
@@ -69,6 +71,20 @@ func (p *CsvBillParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *CsvBillParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CsvBillParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CsvBillParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CsvBillParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CsvBillParam) SetNoHeader(v bool) {
 	p.NoHeader = v
 }
@@ -93,13 +109,15 @@ func (p *CsvBillParam) GetId() int64 {
 
 // ListBillParam is input parameters for the sacloud API
 type ListBillParam struct {
-	Year       int
-	Month      int
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Year              int
+	Month             int
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListBillParam return new ListBillParam
@@ -128,6 +146,12 @@ func (p *ListBillParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -183,6 +207,20 @@ func (p *ListBillParam) SetMonth(v int) {
 
 func (p *ListBillParam) GetMonth() int {
 	return p.Month
+}
+func (p *ListBillParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListBillParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListBillParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListBillParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ListBillParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_bridge_gen.go
+++ b/command/params/params_bridge_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListBridgeParam is input parameters for the sacloud API
 type ListBridgeParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListBridgeParam return new ListBridgeParam
@@ -59,6 +61,12 @@ func (p *ListBridgeParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListBridgeParam) SetSort(v []string) {
 func (p *ListBridgeParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListBridgeParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListBridgeParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListBridgeParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListBridgeParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListBridgeParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,14 +196,16 @@ func (p *ListBridgeParam) GetFormatFile() string {
 
 // CreateBridgeParam is input parameters for the sacloud API
 type CreateBridgeParam struct {
-	Name        string
-	Description string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
+	Name              string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateBridgeParam return new CreateBridgeParam
@@ -217,6 +241,12 @@ func (p *CreateBridgeParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -280,6 +310,20 @@ func (p *CreateBridgeParam) SetAssumeyes(v bool) {
 func (p *CreateBridgeParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateBridgeParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateBridgeParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateBridgeParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateBridgeParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateBridgeParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -318,12 +362,14 @@ func (p *CreateBridgeParam) GetFormatFile() string {
 
 // ReadBridgeParam is input parameters for the sacloud API
 type ReadBridgeParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadBridgeParam return new ReadBridgeParam
@@ -345,6 +391,12 @@ func (p *ReadBridgeParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -387,6 +439,20 @@ func (p *ReadBridgeParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadBridgeParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadBridgeParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadBridgeParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadBridgeParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadBridgeParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -432,15 +498,17 @@ func (p *ReadBridgeParam) GetId() int64 {
 
 // UpdateBridgeParam is input parameters for the sacloud API
 type UpdateBridgeParam struct {
-	Name        string
-	Description string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateBridgeParam return new UpdateBridgeParam
@@ -476,6 +544,12 @@ func (p *UpdateBridgeParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -539,6 +613,20 @@ func (p *UpdateBridgeParam) SetAssumeyes(v bool) {
 func (p *UpdateBridgeParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateBridgeParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateBridgeParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateBridgeParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateBridgeParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateBridgeParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -584,13 +672,15 @@ func (p *UpdateBridgeParam) GetId() int64 {
 
 // DeleteBridgeParam is input parameters for the sacloud API
 type DeleteBridgeParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteBridgeParam return new DeleteBridgeParam
@@ -612,6 +702,12 @@ func (p *DeleteBridgeParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -660,6 +756,20 @@ func (p *DeleteBridgeParam) SetAssumeyes(v bool) {
 
 func (p *DeleteBridgeParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteBridgeParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteBridgeParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteBridgeParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteBridgeParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteBridgeParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_database_gen.go
+++ b/command/params/params_database_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListDatabaseParam is input parameters for the sacloud API
 type ListDatabaseParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListDatabaseParam return new ListDatabaseParam
@@ -67,6 +69,12 @@ func (p *ListDatabaseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListDatabaseParam) SetSort(v []string) {
 func (p *ListDatabaseParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListDatabaseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,28 +211,30 @@ func (p *ListDatabaseParam) GetFormatFile() string {
 
 // CreateDatabaseParam is input parameters for the sacloud API
 type CreateDatabaseParam struct {
-	SwitchId       int64
-	Plan           int
-	Database       string
-	Username       string
-	Password       string
-	SourceNetworks []string
-	EnableWebUi    bool
-	BackupTime     string
-	Port           int
-	Ipaddress1     string
-	NwMaskLen      int
-	DefaultRoute   string
-	Name           string
-	Description    string
-	Tags           []string
-	IconId         int64
-	Assumeyes      bool
-	OutputType     string
-	Column         []string
-	Quiet          bool
-	Format         string
-	FormatFile     string
+	SwitchId          int64
+	Plan              int
+	Database          string
+	Username          string
+	Password          string
+	SourceNetworks    []string
+	EnableWebUi       bool
+	BackupTime        string
+	Port              int
+	Ipaddress1        string
+	NwMaskLen         int
+	DefaultRoute      string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateDatabaseParam return new CreateDatabaseParam
@@ -401,6 +425,12 @@ func (p *CreateDatabaseParam) Validate() []error {
 		}
 	}
 	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
 		errs := validateOutputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
@@ -557,6 +587,20 @@ func (p *CreateDatabaseParam) SetAssumeyes(v bool) {
 func (p *CreateDatabaseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateDatabaseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -595,12 +639,14 @@ func (p *CreateDatabaseParam) GetFormatFile() string {
 
 // ReadDatabaseParam is input parameters for the sacloud API
 type ReadDatabaseParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadDatabaseParam return new ReadDatabaseParam
@@ -622,6 +668,12 @@ func (p *ReadDatabaseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -664,6 +716,20 @@ func (p *ReadDatabaseParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadDatabaseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -709,22 +775,24 @@ func (p *ReadDatabaseParam) GetId() int64 {
 
 // UpdateDatabaseParam is input parameters for the sacloud API
 type UpdateDatabaseParam struct {
-	Password       string
-	Port           int
-	SourceNetworks []string
-	EnableWebUi    bool
-	BackupTime     string
-	Name           string
-	Description    string
-	Tags           []string
-	IconId         int64
-	Assumeyes      bool
-	OutputType     string
-	Column         []string
-	Quiet          bool
-	Format         string
-	FormatFile     string
-	Id             int64
+	Password          string
+	Port              int
+	SourceNetworks    []string
+	EnableWebUi       bool
+	BackupTime        string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateDatabaseParam return new UpdateDatabaseParam
@@ -802,6 +870,12 @@ func (p *UpdateDatabaseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -914,6 +988,20 @@ func (p *UpdateDatabaseParam) SetAssumeyes(v bool) {
 func (p *UpdateDatabaseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateDatabaseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -959,14 +1047,16 @@ func (p *UpdateDatabaseParam) GetId() int64 {
 
 // DeleteDatabaseParam is input parameters for the sacloud API
 type DeleteDatabaseParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Force      bool
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Force             bool
+	Id                int64
 }
 
 // NewDeleteDatabaseParam return new DeleteDatabaseParam
@@ -988,6 +1078,12 @@ func (p *DeleteDatabaseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1036,6 +1132,20 @@ func (p *DeleteDatabaseParam) SetAssumeyes(v bool) {
 
 func (p *DeleteDatabaseParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteDatabaseParam) SetOutputType(v string) {
 	p.OutputType = v
@@ -1089,8 +1199,10 @@ func (p *DeleteDatabaseParam) GetId() int64 {
 
 // BootDatabaseParam is input parameters for the sacloud API
 type BootDatabaseParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewBootDatabaseParam return new BootDatabaseParam
@@ -1147,6 +1259,20 @@ func (p *BootDatabaseParam) SetAssumeyes(v bool) {
 func (p *BootDatabaseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *BootDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *BootDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *BootDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *BootDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *BootDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1157,8 +1283,10 @@ func (p *BootDatabaseParam) GetId() int64 {
 
 // ShutdownDatabaseParam is input parameters for the sacloud API
 type ShutdownDatabaseParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownDatabaseParam return new ShutdownDatabaseParam
@@ -1215,6 +1343,20 @@ func (p *ShutdownDatabaseParam) SetAssumeyes(v bool) {
 func (p *ShutdownDatabaseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1225,8 +1367,10 @@ func (p *ShutdownDatabaseParam) GetId() int64 {
 
 // ShutdownForceDatabaseParam is input parameters for the sacloud API
 type ShutdownForceDatabaseParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownForceDatabaseParam return new ShutdownForceDatabaseParam
@@ -1283,6 +1427,20 @@ func (p *ShutdownForceDatabaseParam) SetAssumeyes(v bool) {
 func (p *ShutdownForceDatabaseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownForceDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownForceDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownForceDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownForceDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownForceDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1293,8 +1451,10 @@ func (p *ShutdownForceDatabaseParam) GetId() int64 {
 
 // ResetDatabaseParam is input parameters for the sacloud API
 type ResetDatabaseParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewResetDatabaseParam return new ResetDatabaseParam
@@ -1351,6 +1511,20 @@ func (p *ResetDatabaseParam) SetAssumeyes(v bool) {
 func (p *ResetDatabaseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ResetDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResetDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResetDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResetDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ResetDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1361,7 +1535,9 @@ func (p *ResetDatabaseParam) GetId() int64 {
 
 // WaitForBootDatabaseParam is input parameters for the sacloud API
 type WaitForBootDatabaseParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForBootDatabaseParam return new WaitForBootDatabaseParam
@@ -1411,6 +1587,20 @@ func (p *WaitForBootDatabaseParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForBootDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForBootDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForBootDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForBootDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForBootDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1421,7 +1611,9 @@ func (p *WaitForBootDatabaseParam) GetId() int64 {
 
 // WaitForDownDatabaseParam is input parameters for the sacloud API
 type WaitForDownDatabaseParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForDownDatabaseParam return new WaitForDownDatabaseParam
@@ -1471,6 +1663,20 @@ func (p *WaitForDownDatabaseParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForDownDatabaseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForDownDatabaseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForDownDatabaseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForDownDatabaseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForDownDatabaseParam) SetId(v int64) {
 	p.Id = v
 }

--- a/command/params/params_disk_gen.go
+++ b/command/params/params_disk_gen.go
@@ -10,20 +10,22 @@ import (
 
 // ListDiskParam is input parameters for the sacloud API
 type ListDiskParam struct {
-	Name            []string
-	Id              []int64
-	Scope           string
-	Tags            []string
-	SourceArchiveId int64
-	SourceDiskId    int64
-	From            int
-	Max             int
-	Sort            []string
-	OutputType      string
-	Column          []string
-	Quiet           bool
-	Format          string
-	FormatFile      string
+	Name              []string
+	Id                []int64
+	Scope             string
+	Tags              []string
+	SourceArchiveId   int64
+	SourceDiskId      int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListDiskParam return new ListDiskParam
@@ -91,6 +93,12 @@ func (p *ListDiskParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -196,6 +204,20 @@ func (p *ListDiskParam) SetSort(v []string) {
 func (p *ListDiskParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListDiskParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -234,22 +256,24 @@ func (p *ListDiskParam) GetFormatFile() string {
 
 // CreateDiskParam is input parameters for the sacloud API
 type CreateDiskParam struct {
-	Plan            string
-	Connection      string
-	SourceArchiveId int64
-	SourceDiskId    int64
-	Size            int
-	DistantFrom     []int64
-	Name            string
-	Description     string
-	Tags            []string
-	IconId          int64
-	Assumeyes       bool
-	OutputType      string
-	Column          []string
-	Quiet           bool
-	Format          string
-	FormatFile      string
+	Plan              string
+	Connection        string
+	SourceArchiveId   int64
+	SourceDiskId      int64
+	Size              int
+	DistantFrom       []int64
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateDiskParam return new CreateDiskParam
@@ -392,6 +416,12 @@ func (p *CreateDiskParam) Validate() []error {
 		}
 	}
 	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
 		errs := validateOutputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
@@ -506,6 +536,20 @@ func (p *CreateDiskParam) SetAssumeyes(v bool) {
 func (p *CreateDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateDiskParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -544,12 +588,14 @@ func (p *CreateDiskParam) GetFormatFile() string {
 
 // ReadDiskParam is input parameters for the sacloud API
 type ReadDiskParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadDiskParam return new ReadDiskParam
@@ -571,6 +617,12 @@ func (p *ReadDiskParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -613,6 +665,20 @@ func (p *ReadDiskParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadDiskParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -658,18 +724,20 @@ func (p *ReadDiskParam) GetId() int64 {
 
 // UpdateDiskParam is input parameters for the sacloud API
 type UpdateDiskParam struct {
-	Connection  string
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Connection        string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateDiskParam return new UpdateDiskParam
@@ -726,6 +794,12 @@ func (p *UpdateDiskParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -810,6 +884,20 @@ func (p *UpdateDiskParam) SetAssumeyes(v bool) {
 func (p *UpdateDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateDiskParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -855,13 +943,15 @@ func (p *UpdateDiskParam) GetId() int64 {
 
 // DeleteDiskParam is input parameters for the sacloud API
 type DeleteDiskParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteDiskParam return new DeleteDiskParam
@@ -883,6 +973,12 @@ func (p *DeleteDiskParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -931,6 +1027,20 @@ func (p *DeleteDiskParam) SetAssumeyes(v bool) {
 
 func (p *DeleteDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteDiskParam) SetOutputType(v string) {
 	p.OutputType = v
@@ -986,6 +1096,8 @@ type EditDiskParam struct {
 	NwMasklen           int
 	StartupScriptIds    []int64
 	Assumeyes           bool
+	ParamTemplate       string
+	ParamTemplateFile   string
 	OutputType          string
 	Column              []string
 	Quiet               bool
@@ -1037,6 +1149,12 @@ func (p *EditDiskParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1142,6 +1260,20 @@ func (p *EditDiskParam) SetAssumeyes(v bool) {
 func (p *EditDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *EditDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *EditDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *EditDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *EditDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *EditDiskParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1187,10 +1319,12 @@ func (p *EditDiskParam) GetId() int64 {
 
 // ReinstallFromArchiveDiskParam is input parameters for the sacloud API
 type ReinstallFromArchiveDiskParam struct {
-	SourceArchiveId int64
-	DistantFrom     []int64
-	Assumeyes       bool
-	Id              int64
+	SourceArchiveId   int64
+	DistantFrom       []int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewReinstallFromArchiveDiskParam return new ReinstallFromArchiveDiskParam
@@ -1282,6 +1416,20 @@ func (p *ReinstallFromArchiveDiskParam) SetAssumeyes(v bool) {
 func (p *ReinstallFromArchiveDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ReinstallFromArchiveDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReinstallFromArchiveDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReinstallFromArchiveDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReinstallFromArchiveDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReinstallFromArchiveDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1292,10 +1440,12 @@ func (p *ReinstallFromArchiveDiskParam) GetId() int64 {
 
 // ReinstallFromDiskDiskParam is input parameters for the sacloud API
 type ReinstallFromDiskDiskParam struct {
-	SourceDiskId int64
-	DistantFrom  []int64
-	Assumeyes    bool
-	Id           int64
+	SourceDiskId      int64
+	DistantFrom       []int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewReinstallFromDiskDiskParam return new ReinstallFromDiskDiskParam
@@ -1387,6 +1537,20 @@ func (p *ReinstallFromDiskDiskParam) SetAssumeyes(v bool) {
 func (p *ReinstallFromDiskDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ReinstallFromDiskDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReinstallFromDiskDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReinstallFromDiskDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReinstallFromDiskDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReinstallFromDiskDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1397,9 +1561,11 @@ func (p *ReinstallFromDiskDiskParam) GetId() int64 {
 
 // ReinstallToBlankDiskParam is input parameters for the sacloud API
 type ReinstallToBlankDiskParam struct {
-	DistantFrom []int64
-	Assumeyes   bool
-	Id          int64
+	DistantFrom       []int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewReinstallToBlankDiskParam return new ReinstallToBlankDiskParam
@@ -1470,6 +1636,20 @@ func (p *ReinstallToBlankDiskParam) SetAssumeyes(v bool) {
 func (p *ReinstallToBlankDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ReinstallToBlankDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReinstallToBlankDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReinstallToBlankDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReinstallToBlankDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReinstallToBlankDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1480,9 +1660,11 @@ func (p *ReinstallToBlankDiskParam) GetId() int64 {
 
 // ServerConnectDiskParam is input parameters for the sacloud API
 type ServerConnectDiskParam struct {
-	ServerId  int64
-	Assumeyes bool
-	Id        int64
+	ServerId          int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewServerConnectDiskParam return new ServerConnectDiskParam
@@ -1560,6 +1742,20 @@ func (p *ServerConnectDiskParam) SetAssumeyes(v bool) {
 func (p *ServerConnectDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerConnectDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerConnectDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerConnectDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerConnectDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerConnectDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1570,8 +1766,10 @@ func (p *ServerConnectDiskParam) GetId() int64 {
 
 // ServerDisconnectDiskParam is input parameters for the sacloud API
 type ServerDisconnectDiskParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewServerDisconnectDiskParam return new ServerDisconnectDiskParam
@@ -1628,6 +1826,20 @@ func (p *ServerDisconnectDiskParam) SetAssumeyes(v bool) {
 func (p *ServerDisconnectDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerDisconnectDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerDisconnectDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerDisconnectDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerDisconnectDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerDisconnectDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1638,15 +1850,17 @@ func (p *ServerDisconnectDiskParam) GetId() int64 {
 
 // MonitorDiskParam is input parameters for the sacloud API
 type MonitorDiskParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	End        string
-	Id         int64
-	KeyFormat  string
-	Start      string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	End               string
+	Id                int64
+	KeyFormat         string
+	Start             string
 }
 
 // NewMonitorDiskParam return new MonitorDiskParam
@@ -1697,6 +1911,12 @@ func (p *MonitorDiskParam) Validate() []error {
 		}
 	}
 	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
 		errs := validateOutputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
@@ -1734,6 +1954,20 @@ func (p *MonitorDiskParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *MonitorDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MonitorDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MonitorDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MonitorDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *MonitorDiskParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1800,7 +2034,9 @@ func (p *MonitorDiskParam) GetStart() string {
 
 // WaitForCopyDiskParam is input parameters for the sacloud API
 type WaitForCopyDiskParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForCopyDiskParam return new WaitForCopyDiskParam
@@ -1850,6 +2086,20 @@ func (p *WaitForCopyDiskParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForCopyDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForCopyDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForCopyDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForCopyDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForCopyDiskParam) SetId(v int64) {
 	p.Id = v
 }

--- a/command/params/params_dns_gen.go
+++ b/command/params/params_dns_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListDNSParam is input parameters for the sacloud API
 type ListDNSParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListDNSParam return new ListDNSParam
@@ -67,6 +69,12 @@ func (p *ListDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListDNSParam) SetSort(v []string) {
 func (p *ListDNSParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,12 +211,14 @@ func (p *ListDNSParam) GetFormatFile() string {
 
 // RecordInfoDNSParam is input parameters for the sacloud API
 type RecordInfoDNSParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRecordInfoDNSParam return new RecordInfoDNSParam
@@ -216,6 +240,12 @@ func (p *RecordInfoDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -258,6 +288,20 @@ func (p *RecordInfoDNSParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *RecordInfoDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RecordInfoDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RecordInfoDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RecordInfoDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RecordInfoDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -303,16 +347,18 @@ func (p *RecordInfoDNSParam) GetId() int64 {
 
 // CreateDNSParam is input parameters for the sacloud API
 type CreateDNSParam struct {
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateDNSParam return new CreateDNSParam
@@ -362,6 +408,12 @@ func (p *CreateDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -439,6 +491,20 @@ func (p *CreateDNSParam) SetAssumeyes(v bool) {
 func (p *CreateDNSParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -477,22 +543,24 @@ func (p *CreateDNSParam) GetFormatFile() string {
 
 // RecordAddDNSParam is input parameters for the sacloud API
 type RecordAddDNSParam struct {
-	Name        string
-	Type        string
-	Value       string
-	Ttl         int
-	MxPriority  int
-	SrvPriority int
-	SrvWeight   int
-	SrvPort     int
-	SrvTarget   string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Type              string
+	Value             string
+	Ttl               int
+	MxPriority        int
+	SrvPriority       int
+	SrvWeight         int
+	SrvPort           int
+	SrvTarget         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRecordAddDNSParam return new RecordAddDNSParam
@@ -589,6 +657,12 @@ func (p *RecordAddDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -701,6 +775,20 @@ func (p *RecordAddDNSParam) SetAssumeyes(v bool) {
 func (p *RecordAddDNSParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *RecordAddDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RecordAddDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RecordAddDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RecordAddDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RecordAddDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -746,12 +834,14 @@ func (p *RecordAddDNSParam) GetId() int64 {
 
 // ReadDNSParam is input parameters for the sacloud API
 type ReadDNSParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadDNSParam return new ReadDNSParam
@@ -773,6 +863,12 @@ func (p *ReadDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -815,6 +911,20 @@ func (p *ReadDNSParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -860,23 +970,25 @@ func (p *ReadDNSParam) GetId() int64 {
 
 // RecordUpdateDNSParam is input parameters for the sacloud API
 type RecordUpdateDNSParam struct {
-	Index       int
-	Name        string
-	Type        string
-	Value       string
-	Ttl         int
-	MxPriority  int
-	SrvPriority int
-	SrvWeight   int
-	SrvPort     int
-	SrvTarget   string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Index             int
+	Name              string
+	Type              string
+	Value             string
+	Ttl               int
+	MxPriority        int
+	SrvPriority       int
+	SrvWeight         int
+	SrvPort           int
+	SrvTarget         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRecordUpdateDNSParam return new RecordUpdateDNSParam
@@ -961,6 +1073,12 @@ func (p *RecordUpdateDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1080,6 +1198,20 @@ func (p *RecordUpdateDNSParam) SetAssumeyes(v bool) {
 func (p *RecordUpdateDNSParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *RecordUpdateDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RecordUpdateDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RecordUpdateDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RecordUpdateDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RecordUpdateDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1125,14 +1257,16 @@ func (p *RecordUpdateDNSParam) GetId() int64 {
 
 // RecordDeleteDNSParam is input parameters for the sacloud API
 type RecordDeleteDNSParam struct {
-	Index      int
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRecordDeleteDNSParam return new RecordDeleteDNSParam
@@ -1161,6 +1295,12 @@ func (p *RecordDeleteDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1217,6 +1357,20 @@ func (p *RecordDeleteDNSParam) SetAssumeyes(v bool) {
 func (p *RecordDeleteDNSParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *RecordDeleteDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RecordDeleteDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RecordDeleteDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RecordDeleteDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RecordDeleteDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1262,16 +1416,18 @@ func (p *RecordDeleteDNSParam) GetId() int64 {
 
 // UpdateDNSParam is input parameters for the sacloud API
 type UpdateDNSParam struct {
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateDNSParam return new UpdateDNSParam
@@ -1314,6 +1470,12 @@ func (p *UpdateDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1384,6 +1546,20 @@ func (p *UpdateDNSParam) SetAssumeyes(v bool) {
 func (p *UpdateDNSParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateDNSParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1429,13 +1605,15 @@ func (p *UpdateDNSParam) GetId() int64 {
 
 // DeleteDNSParam is input parameters for the sacloud API
 type DeleteDNSParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteDNSParam return new DeleteDNSParam
@@ -1457,6 +1635,12 @@ func (p *DeleteDNSParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1505,6 +1689,20 @@ func (p *DeleteDNSParam) SetAssumeyes(v bool) {
 
 func (p *DeleteDNSParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteDNSParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_gslb_gen.go
+++ b/command/params/params_gslb_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListGSLBParam is input parameters for the sacloud API
 type ListGSLBParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListGSLBParam return new ListGSLBParam
@@ -67,6 +69,12 @@ func (p *ListGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListGSLBParam) SetSort(v []string) {
 func (p *ListGSLBParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,12 +211,14 @@ func (p *ListGSLBParam) GetFormatFile() string {
 
 // ServerInfoGSLBParam is input parameters for the sacloud API
 type ServerInfoGSLBParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewServerInfoGSLBParam return new ServerInfoGSLBParam
@@ -216,6 +240,12 @@ func (p *ServerInfoGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -258,6 +288,20 @@ func (p *ServerInfoGSLBParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ServerInfoGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerInfoGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerInfoGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerInfoGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerInfoGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -303,24 +347,26 @@ func (p *ServerInfoGSLBParam) GetId() int64 {
 
 // CreateGSLBParam is input parameters for the sacloud API
 type CreateGSLBParam struct {
-	Protocol     string
-	HostHeader   string
-	Path         string
-	ResponseCode int
-	Port         int
-	DelayLoop    int
-	Weighted     bool
-	SorryServer  string
-	Name         string
-	Description  string
-	Tags         []string
-	IconId       int64
-	Assumeyes    bool
-	OutputType   string
-	Column       []string
-	Quiet        bool
-	Format       string
-	FormatFile   string
+	Protocol          string
+	HostHeader        string
+	Path              string
+	ResponseCode      int
+	Port              int
+	DelayLoop         int
+	Weighted          bool
+	SorryServer       string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateGSLBParam return new CreateGSLBParam
@@ -416,6 +462,12 @@ func (p *CreateGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -549,6 +601,20 @@ func (p *CreateGSLBParam) SetAssumeyes(v bool) {
 func (p *CreateGSLBParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -587,16 +653,18 @@ func (p *CreateGSLBParam) GetFormatFile() string {
 
 // ServerAddGSLBParam is input parameters for the sacloud API
 type ServerAddGSLBParam struct {
-	Ipaddress  string
-	Enabled    bool
-	Weight     int
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Ipaddress         string
+	Enabled           bool
+	Weight            int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewServerAddGSLBParam return new ServerAddGSLBParam
@@ -635,6 +703,12 @@ func (p *ServerAddGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -705,6 +779,20 @@ func (p *ServerAddGSLBParam) SetAssumeyes(v bool) {
 func (p *ServerAddGSLBParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerAddGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerAddGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerAddGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerAddGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerAddGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -750,12 +838,14 @@ func (p *ServerAddGSLBParam) GetId() int64 {
 
 // ReadGSLBParam is input parameters for the sacloud API
 type ReadGSLBParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadGSLBParam return new ReadGSLBParam
@@ -777,6 +867,12 @@ func (p *ReadGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -819,6 +915,20 @@ func (p *ReadGSLBParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -864,17 +974,19 @@ func (p *ReadGSLBParam) GetId() int64 {
 
 // ServerUpdateGSLBParam is input parameters for the sacloud API
 type ServerUpdateGSLBParam struct {
-	Index      int
-	Ipaddress  string
-	Enabled    bool
-	Weight     int
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Index             int
+	Ipaddress         string
+	Enabled           bool
+	Weight            int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewServerUpdateGSLBParam return new ServerUpdateGSLBParam
@@ -917,6 +1029,12 @@ func (p *ServerUpdateGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -994,6 +1112,20 @@ func (p *ServerUpdateGSLBParam) SetAssumeyes(v bool) {
 func (p *ServerUpdateGSLBParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerUpdateGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerUpdateGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerUpdateGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerUpdateGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerUpdateGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1039,14 +1171,16 @@ func (p *ServerUpdateGSLBParam) GetId() int64 {
 
 // ServerDeleteGSLBParam is input parameters for the sacloud API
 type ServerDeleteGSLBParam struct {
-	Index      int
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewServerDeleteGSLBParam return new ServerDeleteGSLBParam
@@ -1075,6 +1209,12 @@ func (p *ServerDeleteGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1131,6 +1271,20 @@ func (p *ServerDeleteGSLBParam) SetAssumeyes(v bool) {
 func (p *ServerDeleteGSLBParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerDeleteGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerDeleteGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerDeleteGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerDeleteGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerDeleteGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1176,25 +1330,27 @@ func (p *ServerDeleteGSLBParam) GetId() int64 {
 
 // UpdateGSLBParam is input parameters for the sacloud API
 type UpdateGSLBParam struct {
-	Protocol     string
-	HostHeader   string
-	Path         string
-	ResponseCode int
-	Port         int
-	DelayLoop    int
-	Weighted     bool
-	SorryServer  string
-	Name         string
-	Description  string
-	Tags         []string
-	IconId       int64
-	Assumeyes    bool
-	OutputType   string
-	Column       []string
-	Quiet        bool
-	Format       string
-	FormatFile   string
-	Id           int64
+	Protocol          string
+	HostHeader        string
+	Path              string
+	ResponseCode      int
+	Port              int
+	DelayLoop         int
+	Weighted          bool
+	SorryServer       string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateGSLBParam return new UpdateGSLBParam
@@ -1265,6 +1421,12 @@ func (p *UpdateGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1398,6 +1560,20 @@ func (p *UpdateGSLBParam) SetAssumeyes(v bool) {
 func (p *UpdateGSLBParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateGSLBParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1443,13 +1619,15 @@ func (p *UpdateGSLBParam) GetId() int64 {
 
 // DeleteGSLBParam is input parameters for the sacloud API
 type DeleteGSLBParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteGSLBParam return new DeleteGSLBParam
@@ -1471,6 +1649,12 @@ func (p *DeleteGSLBParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1519,6 +1703,20 @@ func (p *DeleteGSLBParam) SetAssumeyes(v bool) {
 
 func (p *DeleteGSLBParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteGSLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteGSLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteGSLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteGSLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteGSLBParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_icon_gen.go
+++ b/command/params/params_icon_gen.go
@@ -10,18 +10,20 @@ import (
 
 // ListIconParam is input parameters for the sacloud API
 type ListIconParam struct {
-	Name       []string
-	Id         []int64
-	Scope      string
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Scope             string
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListIconParam return new ListIconParam
@@ -75,6 +77,12 @@ func (p *ListIconParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -166,6 +174,20 @@ func (p *ListIconParam) SetSort(v []string) {
 func (p *ListIconParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListIconParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListIconParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListIconParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListIconParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListIconParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -204,15 +226,17 @@ func (p *ListIconParam) GetFormatFile() string {
 
 // CreateIconParam is input parameters for the sacloud API
 type CreateIconParam struct {
-	Image      string
-	Name       string
-	Tags       []string
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Image             string
+	Name              string
+	Tags              []string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateIconParam return new CreateIconParam
@@ -262,6 +286,12 @@ func (p *CreateIconParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -332,6 +362,20 @@ func (p *CreateIconParam) SetAssumeyes(v bool) {
 func (p *CreateIconParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateIconParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateIconParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateIconParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateIconParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateIconParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -370,12 +414,14 @@ func (p *CreateIconParam) GetFormatFile() string {
 
 // ReadIconParam is input parameters for the sacloud API
 type ReadIconParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadIconParam return new ReadIconParam
@@ -397,6 +443,12 @@ func (p *ReadIconParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -439,6 +491,20 @@ func (p *ReadIconParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadIconParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadIconParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadIconParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadIconParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadIconParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -484,15 +550,17 @@ func (p *ReadIconParam) GetId() int64 {
 
 // UpdateIconParam is input parameters for the sacloud API
 type UpdateIconParam struct {
-	Name       string
-	Tags       []string
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Name              string
+	Tags              []string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateIconParam return new UpdateIconParam
@@ -528,6 +596,12 @@ func (p *UpdateIconParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -591,6 +665,20 @@ func (p *UpdateIconParam) SetAssumeyes(v bool) {
 func (p *UpdateIconParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateIconParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateIconParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateIconParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateIconParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateIconParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -636,13 +724,15 @@ func (p *UpdateIconParam) GetId() int64 {
 
 // DeleteIconParam is input parameters for the sacloud API
 type DeleteIconParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteIconParam return new DeleteIconParam
@@ -664,6 +754,12 @@ func (p *DeleteIconParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -712,6 +808,20 @@ func (p *DeleteIconParam) SetAssumeyes(v bool) {
 
 func (p *DeleteIconParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteIconParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteIconParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteIconParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteIconParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteIconParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_interface_gen.go
+++ b/command/params/params_interface_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListInterfaceParam is input parameters for the sacloud API
 type ListInterfaceParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListInterfaceParam return new ListInterfaceParam
@@ -59,6 +61,12 @@ func (p *ListInterfaceParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListInterfaceParam) SetSort(v []string) {
 func (p *ListInterfaceParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListInterfaceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListInterfaceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListInterfaceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListInterfaceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListInterfaceParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,9 +196,11 @@ func (p *ListInterfaceParam) GetFormatFile() string {
 
 // PacketFilterConnectInterfaceParam is input parameters for the sacloud API
 type PacketFilterConnectInterfaceParam struct {
-	PacketFilterId int64
-	Assumeyes      bool
-	Id             int64
+	PacketFilterId    int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewPacketFilterConnectInterfaceParam return new PacketFilterConnectInterfaceParam
@@ -254,6 +278,20 @@ func (p *PacketFilterConnectInterfaceParam) SetAssumeyes(v bool) {
 func (p *PacketFilterConnectInterfaceParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PacketFilterConnectInterfaceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PacketFilterConnectInterfaceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PacketFilterConnectInterfaceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PacketFilterConnectInterfaceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PacketFilterConnectInterfaceParam) SetId(v int64) {
 	p.Id = v
 }
@@ -264,13 +302,15 @@ func (p *PacketFilterConnectInterfaceParam) GetId() int64 {
 
 // CreateInterfaceParam is input parameters for the sacloud API
 type CreateInterfaceParam struct {
-	ServerId   int64
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	ServerId          int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateInterfaceParam return new CreateInterfaceParam
@@ -299,6 +339,12 @@ func (p *CreateInterfaceParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -355,6 +401,20 @@ func (p *CreateInterfaceParam) SetAssumeyes(v bool) {
 func (p *CreateInterfaceParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateInterfaceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateInterfaceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateInterfaceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateInterfaceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateInterfaceParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -393,9 +453,11 @@ func (p *CreateInterfaceParam) GetFormatFile() string {
 
 // PacketFilterDisconnectInterfaceParam is input parameters for the sacloud API
 type PacketFilterDisconnectInterfaceParam struct {
-	PacketFilterId int64
-	Assumeyes      bool
-	Id             int64
+	PacketFilterId    int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewPacketFilterDisconnectInterfaceParam return new PacketFilterDisconnectInterfaceParam
@@ -473,6 +535,20 @@ func (p *PacketFilterDisconnectInterfaceParam) SetAssumeyes(v bool) {
 func (p *PacketFilterDisconnectInterfaceParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PacketFilterDisconnectInterfaceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PacketFilterDisconnectInterfaceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PacketFilterDisconnectInterfaceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PacketFilterDisconnectInterfaceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PacketFilterDisconnectInterfaceParam) SetId(v int64) {
 	p.Id = v
 }
@@ -483,12 +559,14 @@ func (p *PacketFilterDisconnectInterfaceParam) GetId() int64 {
 
 // ReadInterfaceParam is input parameters for the sacloud API
 type ReadInterfaceParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadInterfaceParam return new ReadInterfaceParam
@@ -510,6 +588,12 @@ func (p *ReadInterfaceParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -552,6 +636,20 @@ func (p *ReadInterfaceParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadInterfaceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadInterfaceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadInterfaceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadInterfaceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadInterfaceParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -597,14 +695,16 @@ func (p *ReadInterfaceParam) GetId() int64 {
 
 // UpdateInterfaceParam is input parameters for the sacloud API
 type UpdateInterfaceParam struct {
-	UserIpaddress string
-	Assumeyes     bool
-	OutputType    string
-	Column        []string
-	Quiet         bool
-	Format        string
-	FormatFile    string
-	Id            int64
+	UserIpaddress     string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateInterfaceParam return new UpdateInterfaceParam
@@ -633,6 +733,12 @@ func (p *UpdateInterfaceParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -689,6 +795,20 @@ func (p *UpdateInterfaceParam) SetAssumeyes(v bool) {
 func (p *UpdateInterfaceParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateInterfaceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateInterfaceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateInterfaceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateInterfaceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateInterfaceParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -734,13 +854,15 @@ func (p *UpdateInterfaceParam) GetId() int64 {
 
 // DeleteInterfaceParam is input parameters for the sacloud API
 type DeleteInterfaceParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteInterfaceParam return new DeleteInterfaceParam
@@ -762,6 +884,12 @@ func (p *DeleteInterfaceParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -810,6 +938,20 @@ func (p *DeleteInterfaceParam) SetAssumeyes(v bool) {
 
 func (p *DeleteInterfaceParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteInterfaceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteInterfaceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteInterfaceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteInterfaceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteInterfaceParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_internet_gen.go
+++ b/command/params/params_internet_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListInternetParam is input parameters for the sacloud API
 type ListInternetParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListInternetParam return new ListInternetParam
@@ -67,6 +69,12 @@ func (p *ListInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListInternetParam) SetSort(v []string) {
 func (p *ListInternetParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListInternetParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,15 +211,17 @@ func (p *ListInternetParam) GetFormatFile() string {
 
 // MonitorInternetParam is input parameters for the sacloud API
 type MonitorInternetParam struct {
-	Start      string
-	End        string
-	KeyFormat  string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Start             string
+	End               string
+	KeyFormat         string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewMonitorInternetParam return new MonitorInternetParam
@@ -243,6 +267,12 @@ func (p *MonitorInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -306,6 +336,20 @@ func (p *MonitorInternetParam) SetKeyFormat(v string) {
 func (p *MonitorInternetParam) GetKeyFormat() string {
 	return p.KeyFormat
 }
+func (p *MonitorInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MonitorInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MonitorInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MonitorInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *MonitorInternetParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -351,14 +395,16 @@ func (p *MonitorInternetParam) GetId() int64 {
 
 // UpdateBandwidthInternetParam is input parameters for the sacloud API
 type UpdateBandwidthInternetParam struct {
-	BandWidth  int
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	BandWidth         int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateBandwidthInternetParam return new UpdateBandwidthInternetParam
@@ -397,6 +443,12 @@ func (p *UpdateBandwidthInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -453,6 +505,20 @@ func (p *UpdateBandwidthInternetParam) SetAssumeyes(v bool) {
 func (p *UpdateBandwidthInternetParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateBandwidthInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateBandwidthInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateBandwidthInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateBandwidthInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateBandwidthInternetParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -498,18 +564,20 @@ func (p *UpdateBandwidthInternetParam) GetId() int64 {
 
 // CreateInternetParam is input parameters for the sacloud API
 type CreateInternetParam struct {
-	NwMasklen   int
-	BandWidth   int
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
+	NwMasklen         int
+	BandWidth         int
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateInternetParam return new CreateInternetParam
@@ -592,6 +660,12 @@ func (p *CreateInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -683,6 +757,20 @@ func (p *CreateInternetParam) SetAssumeyes(v bool) {
 func (p *CreateInternetParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateInternetParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -721,12 +809,14 @@ func (p *CreateInternetParam) GetFormatFile() string {
 
 // ReadInternetParam is input parameters for the sacloud API
 type ReadInternetParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadInternetParam return new ReadInternetParam
@@ -748,6 +838,12 @@ func (p *ReadInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -790,6 +886,20 @@ func (p *ReadInternetParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadInternetParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -835,18 +945,20 @@ func (p *ReadInternetParam) GetId() int64 {
 
 // UpdateInternetParam is input parameters for the sacloud API
 type UpdateInternetParam struct {
-	BandWidth   int
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	BandWidth         int
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateInternetParam return new UpdateInternetParam
@@ -903,6 +1015,12 @@ func (p *UpdateInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -987,6 +1105,20 @@ func (p *UpdateInternetParam) SetAssumeyes(v bool) {
 func (p *UpdateInternetParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateInternetParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1032,13 +1164,15 @@ func (p *UpdateInternetParam) GetId() int64 {
 
 // DeleteInternetParam is input parameters for the sacloud API
 type DeleteInternetParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteInternetParam return new DeleteInternetParam
@@ -1060,6 +1194,12 @@ func (p *DeleteInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1108,6 +1248,20 @@ func (p *DeleteInternetParam) SetAssumeyes(v bool) {
 
 func (p *DeleteInternetParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteInternetParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_iso_image_gen.go
+++ b/command/params/params_iso_image_gen.go
@@ -10,18 +10,20 @@ import (
 
 // ListISOImageParam is input parameters for the sacloud API
 type ListISOImageParam struct {
-	Name       []string
-	Id         []int64
-	Scope      string
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Scope             string
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListISOImageParam return new ListISOImageParam
@@ -75,6 +77,12 @@ func (p *ListISOImageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -166,6 +174,20 @@ func (p *ListISOImageParam) SetSort(v []string) {
 func (p *ListISOImageParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListISOImageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -204,18 +226,20 @@ func (p *ListISOImageParam) GetFormatFile() string {
 
 // CreateISOImageParam is input parameters for the sacloud API
 type CreateISOImageParam struct {
-	Size        int
-	IsoFile     string
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
+	Size              int
+	IsoFile           string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateISOImageParam return new CreateISOImageParam
@@ -296,6 +320,12 @@ func (p *CreateISOImageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -387,6 +417,20 @@ func (p *CreateISOImageParam) SetAssumeyes(v bool) {
 func (p *CreateISOImageParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateISOImageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -425,12 +469,14 @@ func (p *CreateISOImageParam) GetFormatFile() string {
 
 // ReadISOImageParam is input parameters for the sacloud API
 type ReadISOImageParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadISOImageParam return new ReadISOImageParam
@@ -452,6 +498,12 @@ func (p *ReadISOImageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -494,6 +546,20 @@ func (p *ReadISOImageParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadISOImageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -539,17 +605,19 @@ func (p *ReadISOImageParam) GetId() int64 {
 
 // UpdateISOImageParam is input parameters for the sacloud API
 type UpdateISOImageParam struct {
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateISOImageParam return new UpdateISOImageParam
@@ -599,6 +667,12 @@ func (p *UpdateISOImageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -676,6 +750,20 @@ func (p *UpdateISOImageParam) SetAssumeyes(v bool) {
 func (p *UpdateISOImageParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateISOImageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -721,13 +809,15 @@ func (p *UpdateISOImageParam) GetId() int64 {
 
 // DeleteISOImageParam is input parameters for the sacloud API
 type DeleteISOImageParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteISOImageParam return new DeleteISOImageParam
@@ -749,6 +839,12 @@ func (p *DeleteISOImageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -798,6 +894,20 @@ func (p *DeleteISOImageParam) SetAssumeyes(v bool) {
 func (p *DeleteISOImageParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeleteISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeleteISOImageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -843,14 +953,16 @@ func (p *DeleteISOImageParam) GetId() int64 {
 
 // UploadISOImageParam is input parameters for the sacloud API
 type UploadISOImageParam struct {
-	IsoFile    string
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	IsoFile           string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUploadISOImageParam return new UploadISOImageParam
@@ -886,6 +998,12 @@ func (p *UploadISOImageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -942,6 +1060,20 @@ func (p *UploadISOImageParam) SetAssumeyes(v bool) {
 func (p *UploadISOImageParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UploadISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UploadISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UploadISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UploadISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UploadISOImageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -987,9 +1119,11 @@ func (p *UploadISOImageParam) GetId() int64 {
 
 // DownloadISOImageParam is input parameters for the sacloud API
 type DownloadISOImageParam struct {
-	FileDestination string
-	Assumeyes       bool
-	Id              int64
+	FileDestination   string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDownloadISOImageParam return new DownloadISOImageParam
@@ -1060,6 +1194,20 @@ func (p *DownloadISOImageParam) SetAssumeyes(v bool) {
 func (p *DownloadISOImageParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DownloadISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DownloadISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DownloadISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DownloadISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DownloadISOImageParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1070,13 +1218,15 @@ func (p *DownloadISOImageParam) GetId() int64 {
 
 // FtpOpenISOImageParam is input parameters for the sacloud API
 type FtpOpenISOImageParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewFtpOpenISOImageParam return new FtpOpenISOImageParam
@@ -1098,6 +1248,12 @@ func (p *FtpOpenISOImageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1147,6 +1303,20 @@ func (p *FtpOpenISOImageParam) SetAssumeyes(v bool) {
 func (p *FtpOpenISOImageParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *FtpOpenISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FtpOpenISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FtpOpenISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FtpOpenISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *FtpOpenISOImageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1192,8 +1362,10 @@ func (p *FtpOpenISOImageParam) GetId() int64 {
 
 // FtpCloseISOImageParam is input parameters for the sacloud API
 type FtpCloseISOImageParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewFtpCloseISOImageParam return new FtpCloseISOImageParam
@@ -1249,6 +1421,20 @@ func (p *FtpCloseISOImageParam) SetAssumeyes(v bool) {
 
 func (p *FtpCloseISOImageParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *FtpCloseISOImageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FtpCloseISOImageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FtpCloseISOImageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FtpCloseISOImageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *FtpCloseISOImageParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_license_gen.go
+++ b/command/params/params_license_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListLicenseParam is input parameters for the sacloud API
 type ListLicenseParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListLicenseParam return new ListLicenseParam
@@ -59,6 +61,12 @@ func (p *ListLicenseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListLicenseParam) SetSort(v []string) {
 func (p *ListLicenseParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListLicenseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListLicenseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListLicenseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListLicenseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListLicenseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,14 +196,16 @@ func (p *ListLicenseParam) GetFormatFile() string {
 
 // CreateLicenseParam is input parameters for the sacloud API
 type CreateLicenseParam struct {
-	LicenseInfoId int64
-	Name          string
-	Assumeyes     bool
-	OutputType    string
-	Column        []string
-	Quiet         bool
-	Format        string
-	FormatFile    string
+	LicenseInfoId     int64
+	Name              string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateLicenseParam return new CreateLicenseParam
@@ -210,6 +234,12 @@ func (p *CreateLicenseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -273,6 +303,20 @@ func (p *CreateLicenseParam) SetAssumeyes(v bool) {
 func (p *CreateLicenseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateLicenseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateLicenseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateLicenseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateLicenseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateLicenseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -311,12 +355,14 @@ func (p *CreateLicenseParam) GetFormatFile() string {
 
 // ReadLicenseParam is input parameters for the sacloud API
 type ReadLicenseParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadLicenseParam return new ReadLicenseParam
@@ -338,6 +384,12 @@ func (p *ReadLicenseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -380,6 +432,20 @@ func (p *ReadLicenseParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadLicenseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadLicenseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadLicenseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadLicenseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadLicenseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -425,14 +491,16 @@ func (p *ReadLicenseParam) GetId() int64 {
 
 // UpdateLicenseParam is input parameters for the sacloud API
 type UpdateLicenseParam struct {
-	Name       string
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Name              string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateLicenseParam return new UpdateLicenseParam
@@ -461,6 +529,12 @@ func (p *UpdateLicenseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -517,6 +591,20 @@ func (p *UpdateLicenseParam) SetAssumeyes(v bool) {
 func (p *UpdateLicenseParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateLicenseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateLicenseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateLicenseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateLicenseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateLicenseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -562,13 +650,15 @@ func (p *UpdateLicenseParam) GetId() int64 {
 
 // DeleteLicenseParam is input parameters for the sacloud API
 type DeleteLicenseParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteLicenseParam return new DeleteLicenseParam
@@ -590,6 +680,12 @@ func (p *DeleteLicenseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -638,6 +734,20 @@ func (p *DeleteLicenseParam) SetAssumeyes(v bool) {
 
 func (p *DeleteLicenseParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteLicenseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteLicenseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteLicenseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteLicenseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteLicenseParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_load_balancer_gen.go
+++ b/command/params/params_load_balancer_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListLoadBalancerParam is input parameters for the sacloud API
 type ListLoadBalancerParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListLoadBalancerParam return new ListLoadBalancerParam
@@ -67,6 +69,12 @@ func (p *ListLoadBalancerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListLoadBalancerParam) SetSort(v []string) {
 func (p *ListLoadBalancerParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,24 +211,26 @@ func (p *ListLoadBalancerParam) GetFormatFile() string {
 
 // CreateLoadBalancerParam is input parameters for the sacloud API
 type CreateLoadBalancerParam struct {
-	SwitchId         int64
-	Vrid             int
-	HighAvailability bool
-	Plan             string
-	Ipaddress1       string
-	Ipaddress2       string
-	NwMaskLen        int
-	DefaultRoute     string
-	Name             string
-	Description      string
-	Tags             []string
-	IconId           int64
-	Assumeyes        bool
-	OutputType       string
-	Column           []string
-	Quiet            bool
-	Format           string
-	FormatFile       string
+	SwitchId          int64
+	Vrid              int
+	HighAvailability  bool
+	Plan              string
+	Ipaddress1        string
+	Ipaddress2        string
+	NwMaskLen         int
+	DefaultRoute      string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateLoadBalancerParam return new CreateLoadBalancerParam
@@ -331,6 +355,12 @@ func (p *CreateLoadBalancerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -464,6 +494,20 @@ func (p *CreateLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *CreateLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -502,12 +546,14 @@ func (p *CreateLoadBalancerParam) GetFormatFile() string {
 
 // ReadLoadBalancerParam is input parameters for the sacloud API
 type ReadLoadBalancerParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadLoadBalancerParam return new ReadLoadBalancerParam
@@ -529,6 +575,12 @@ func (p *ReadLoadBalancerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -571,6 +623,20 @@ func (p *ReadLoadBalancerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -616,17 +682,19 @@ func (p *ReadLoadBalancerParam) GetId() int64 {
 
 // UpdateLoadBalancerParam is input parameters for the sacloud API
 type UpdateLoadBalancerParam struct {
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateLoadBalancerParam return new UpdateLoadBalancerParam
@@ -676,6 +744,12 @@ func (p *UpdateLoadBalancerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -753,6 +827,20 @@ func (p *UpdateLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *UpdateLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -798,14 +886,16 @@ func (p *UpdateLoadBalancerParam) GetId() int64 {
 
 // DeleteLoadBalancerParam is input parameters for the sacloud API
 type DeleteLoadBalancerParam struct {
-	Force      bool
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Force             bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteLoadBalancerParam return new DeleteLoadBalancerParam
@@ -827,6 +917,12 @@ func (p *DeleteLoadBalancerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -883,6 +979,20 @@ func (p *DeleteLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *DeleteLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeleteLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeleteLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -928,8 +1038,10 @@ func (p *DeleteLoadBalancerParam) GetId() int64 {
 
 // BootLoadBalancerParam is input parameters for the sacloud API
 type BootLoadBalancerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewBootLoadBalancerParam return new BootLoadBalancerParam
@@ -986,6 +1098,20 @@ func (p *BootLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *BootLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *BootLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *BootLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *BootLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *BootLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *BootLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -996,8 +1122,10 @@ func (p *BootLoadBalancerParam) GetId() int64 {
 
 // ShutdownLoadBalancerParam is input parameters for the sacloud API
 type ShutdownLoadBalancerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownLoadBalancerParam return new ShutdownLoadBalancerParam
@@ -1054,6 +1182,20 @@ func (p *ShutdownLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *ShutdownLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1064,8 +1206,10 @@ func (p *ShutdownLoadBalancerParam) GetId() int64 {
 
 // ShutdownForceLoadBalancerParam is input parameters for the sacloud API
 type ShutdownForceLoadBalancerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownForceLoadBalancerParam return new ShutdownForceLoadBalancerParam
@@ -1122,6 +1266,20 @@ func (p *ShutdownForceLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *ShutdownForceLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownForceLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownForceLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownForceLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownForceLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownForceLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1132,8 +1290,10 @@ func (p *ShutdownForceLoadBalancerParam) GetId() int64 {
 
 // ResetLoadBalancerParam is input parameters for the sacloud API
 type ResetLoadBalancerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewResetLoadBalancerParam return new ResetLoadBalancerParam
@@ -1190,6 +1350,20 @@ func (p *ResetLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *ResetLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ResetLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResetLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResetLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResetLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ResetLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1200,7 +1374,9 @@ func (p *ResetLoadBalancerParam) GetId() int64 {
 
 // WaitForBootLoadBalancerParam is input parameters for the sacloud API
 type WaitForBootLoadBalancerParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForBootLoadBalancerParam return new WaitForBootLoadBalancerParam
@@ -1250,6 +1426,20 @@ func (p *WaitForBootLoadBalancerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForBootLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForBootLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForBootLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForBootLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForBootLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1260,7 +1450,9 @@ func (p *WaitForBootLoadBalancerParam) GetId() int64 {
 
 // WaitForDownLoadBalancerParam is input parameters for the sacloud API
 type WaitForDownLoadBalancerParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForDownLoadBalancerParam return new WaitForDownLoadBalancerParam
@@ -1310,6 +1502,20 @@ func (p *WaitForDownLoadBalancerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForDownLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForDownLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForDownLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForDownLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForDownLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1320,12 +1526,14 @@ func (p *WaitForDownLoadBalancerParam) GetId() int64 {
 
 // VipInfoLoadBalancerParam is input parameters for the sacloud API
 type VipInfoLoadBalancerParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewVipInfoLoadBalancerParam return new VipInfoLoadBalancerParam
@@ -1347,6 +1555,12 @@ func (p *VipInfoLoadBalancerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1389,6 +1603,20 @@ func (p *VipInfoLoadBalancerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *VipInfoLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *VipInfoLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *VipInfoLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *VipInfoLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *VipInfoLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1434,12 +1662,14 @@ func (p *VipInfoLoadBalancerParam) GetId() int64 {
 
 // VipAddLoadBalancerParam is input parameters for the sacloud API
 type VipAddLoadBalancerParam struct {
-	Vip         string
-	Port        int
-	DelayLoop   int
-	SorryServer string
-	Assumeyes   bool
-	Id          int64
+	Vip               string
+	Port              int
+	DelayLoop         int
+	SorryServer       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewVipAddLoadBalancerParam return new VipAddLoadBalancerParam
@@ -1569,6 +1799,20 @@ func (p *VipAddLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *VipAddLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *VipAddLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *VipAddLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *VipAddLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *VipAddLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *VipAddLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1579,13 +1823,15 @@ func (p *VipAddLoadBalancerParam) GetId() int64 {
 
 // VipUpdateLoadBalancerParam is input parameters for the sacloud API
 type VipUpdateLoadBalancerParam struct {
-	Index       int
-	Vip         string
-	Port        int
-	DelayLoop   int
-	SorryServer string
-	Assumeyes   bool
-	Id          int64
+	Index             int
+	Vip               string
+	Port              int
+	DelayLoop         int
+	SorryServer       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewVipUpdateLoadBalancerParam return new VipUpdateLoadBalancerParam
@@ -1715,6 +1961,20 @@ func (p *VipUpdateLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *VipUpdateLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *VipUpdateLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *VipUpdateLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *VipUpdateLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *VipUpdateLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *VipUpdateLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1725,9 +1985,11 @@ func (p *VipUpdateLoadBalancerParam) GetId() int64 {
 
 // VipDeleteLoadBalancerParam is input parameters for the sacloud API
 type VipDeleteLoadBalancerParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewVipDeleteLoadBalancerParam return new VipDeleteLoadBalancerParam
@@ -1798,6 +2060,20 @@ func (p *VipDeleteLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *VipDeleteLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *VipDeleteLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *VipDeleteLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *VipDeleteLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *VipDeleteLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *VipDeleteLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1808,15 +2084,17 @@ func (p *VipDeleteLoadBalancerParam) GetId() int64 {
 
 // ServerInfoLoadBalancerParam is input parameters for the sacloud API
 type ServerInfoLoadBalancerParam struct {
-	VipIndex   int
-	Vip        string
-	Port       int
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	VipIndex          int
+	Vip               string
+	Port              int
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewServerInfoLoadBalancerParam return new ServerInfoLoadBalancerParam
@@ -1885,6 +2163,12 @@ func (p *ServerInfoLoadBalancerParam) Validate() []error {
 		}
 	}
 	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
 		errs := validateOutputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
@@ -1943,6 +2227,20 @@ func (p *ServerInfoLoadBalancerParam) SetPort(v int) {
 func (p *ServerInfoLoadBalancerParam) GetPort() int {
 	return p.Port
 }
+func (p *ServerInfoLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerInfoLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerInfoLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerInfoLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerInfoLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1988,16 +2286,18 @@ func (p *ServerInfoLoadBalancerParam) GetId() int64 {
 
 // ServerAddLoadBalancerParam is input parameters for the sacloud API
 type ServerAddLoadBalancerParam struct {
-	VipIndex     int
-	Vip          string
-	Port         int
-	Ipaddress    string
-	Protocol     string
-	Path         string
-	ResponseCode int
-	Enabled      bool
-	Assumeyes    bool
-	Id           int64
+	VipIndex          int
+	Vip               string
+	Port              int
+	Ipaddress         string
+	Protocol          string
+	Path              string
+	ResponseCode      int
+	Enabled           bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewServerAddLoadBalancerParam return new ServerAddLoadBalancerParam
@@ -2192,6 +2492,20 @@ func (p *ServerAddLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *ServerAddLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerAddLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerAddLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerAddLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerAddLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerAddLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2202,16 +2516,18 @@ func (p *ServerAddLoadBalancerParam) GetId() int64 {
 
 // ServerUpdateLoadBalancerParam is input parameters for the sacloud API
 type ServerUpdateLoadBalancerParam struct {
-	VipIndex     int
-	Vip          string
-	Port         int
-	Ipaddress    string
-	Protocol     string
-	Path         string
-	ResponseCode int
-	Enabled      bool
-	Assumeyes    bool
-	Id           int64
+	VipIndex          int
+	Vip               string
+	Port              int
+	Ipaddress         string
+	Protocol          string
+	Path              string
+	ResponseCode      int
+	Enabled           bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewServerUpdateLoadBalancerParam return new ServerUpdateLoadBalancerParam
@@ -2387,6 +2703,20 @@ func (p *ServerUpdateLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *ServerUpdateLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerUpdateLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerUpdateLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerUpdateLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerUpdateLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerUpdateLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2397,12 +2727,14 @@ func (p *ServerUpdateLoadBalancerParam) GetId() int64 {
 
 // ServerDeleteLoadBalancerParam is input parameters for the sacloud API
 type ServerDeleteLoadBalancerParam struct {
-	VipIndex  int
-	Vip       string
-	Port      int
-	Ipaddress string
-	Assumeyes bool
-	Id        int64
+	VipIndex          int
+	Vip               string
+	Port              int
+	Ipaddress         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewServerDeleteLoadBalancerParam return new ServerDeleteLoadBalancerParam
@@ -2543,6 +2875,20 @@ func (p *ServerDeleteLoadBalancerParam) SetAssumeyes(v bool) {
 func (p *ServerDeleteLoadBalancerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ServerDeleteLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ServerDeleteLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ServerDeleteLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ServerDeleteLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ServerDeleteLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2553,15 +2899,17 @@ func (p *ServerDeleteLoadBalancerParam) GetId() int64 {
 
 // MonitorLoadBalancerParam is input parameters for the sacloud API
 type MonitorLoadBalancerParam struct {
-	Start      string
-	End        string
-	KeyFormat  string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Start             string
+	End               string
+	KeyFormat         string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewMonitorLoadBalancerParam return new MonitorLoadBalancerParam
@@ -2607,6 +2955,12 @@ func (p *MonitorLoadBalancerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2669,6 +3023,20 @@ func (p *MonitorLoadBalancerParam) SetKeyFormat(v string) {
 
 func (p *MonitorLoadBalancerParam) GetKeyFormat() string {
 	return p.KeyFormat
+}
+func (p *MonitorLoadBalancerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MonitorLoadBalancerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MonitorLoadBalancerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MonitorLoadBalancerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *MonitorLoadBalancerParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_object_storage_gen.go
+++ b/command/params/params_object_storage_gen.go
@@ -10,14 +10,16 @@ import (
 
 // ListObjectStorageParam is input parameters for the sacloud API
 type ListObjectStorageParam struct {
-	AccessKey  string
-	SecretKey  string
-	Bucket     string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	AccessKey         string
+	SecretKey         string
+	Bucket            string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListObjectStorageParam return new ListObjectStorageParam
@@ -46,6 +48,12 @@ func (p *ListObjectStorageParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -109,6 +117,20 @@ func (p *ListObjectStorageParam) SetBucket(v string) {
 func (p *ListObjectStorageParam) GetBucket() string {
 	return p.Bucket
 }
+func (p *ListObjectStorageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListObjectStorageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListObjectStorageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListObjectStorageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListObjectStorageParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -147,12 +169,14 @@ func (p *ListObjectStorageParam) GetFormatFile() string {
 
 // PutObjectStorageParam is input parameters for the sacloud API
 type PutObjectStorageParam struct {
-	AccessKey   string
-	ContentType string
-	Recursive   bool
-	SecretKey   string
-	Bucket      string
-	Assumeyes   bool
+	AccessKey         string
+	ContentType       string
+	Recursive         bool
+	SecretKey         string
+	Bucket            string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
 }
 
 // NewPutObjectStorageParam return new PutObjectStorageParam
@@ -254,13 +278,29 @@ func (p *PutObjectStorageParam) SetAssumeyes(v bool) {
 func (p *PutObjectStorageParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PutObjectStorageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PutObjectStorageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PutObjectStorageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PutObjectStorageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 
 // GetObjectStorageParam is input parameters for the sacloud API
 type GetObjectStorageParam struct {
-	AccessKey string
-	Recursive bool
-	SecretKey string
-	Bucket    string
+	AccessKey         string
+	Recursive         bool
+	SecretKey         string
+	Bucket            string
+	ParamTemplate     string
+	ParamTemplateFile string
 }
 
 // NewGetObjectStorageParam return new GetObjectStorageParam
@@ -345,14 +385,30 @@ func (p *GetObjectStorageParam) SetBucket(v string) {
 func (p *GetObjectStorageParam) GetBucket() string {
 	return p.Bucket
 }
+func (p *GetObjectStorageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *GetObjectStorageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *GetObjectStorageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *GetObjectStorageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 
 // DeleteObjectStorageParam is input parameters for the sacloud API
 type DeleteObjectStorageParam struct {
-	AccessKey string
-	Recursive bool
-	SecretKey string
-	Bucket    string
-	Assumeyes bool
+	AccessKey         string
+	Recursive         bool
+	SecretKey         string
+	Bucket            string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
 }
 
 // NewDeleteObjectStorageParam return new DeleteObjectStorageParam
@@ -443,4 +499,18 @@ func (p *DeleteObjectStorageParam) SetAssumeyes(v bool) {
 
 func (p *DeleteObjectStorageParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteObjectStorageParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteObjectStorageParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteObjectStorageParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteObjectStorageParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }

--- a/command/params/params_packet_filter_gen.go
+++ b/command/params/params_packet_filter_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListPacketFilterParam is input parameters for the sacloud API
 type ListPacketFilterParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListPacketFilterParam return new ListPacketFilterParam
@@ -59,6 +61,12 @@ func (p *ListPacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListPacketFilterParam) SetSort(v []string) {
 func (p *ListPacketFilterParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListPacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListPacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListPacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListPacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListPacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,14 +196,16 @@ func (p *ListPacketFilterParam) GetFormatFile() string {
 
 // CreatePacketFilterParam is input parameters for the sacloud API
 type CreatePacketFilterParam struct {
-	Name        string
-	Description string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
+	Name              string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreatePacketFilterParam return new CreatePacketFilterParam
@@ -217,6 +241,12 @@ func (p *CreatePacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -280,6 +310,20 @@ func (p *CreatePacketFilterParam) SetAssumeyes(v bool) {
 func (p *CreatePacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreatePacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreatePacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreatePacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreatePacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreatePacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -318,12 +362,14 @@ func (p *CreatePacketFilterParam) GetFormatFile() string {
 
 // ReadPacketFilterParam is input parameters for the sacloud API
 type ReadPacketFilterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadPacketFilterParam return new ReadPacketFilterParam
@@ -345,6 +391,12 @@ func (p *ReadPacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -387,6 +439,20 @@ func (p *ReadPacketFilterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadPacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadPacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadPacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadPacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadPacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -432,15 +498,17 @@ func (p *ReadPacketFilterParam) GetId() int64 {
 
 // UpdatePacketFilterParam is input parameters for the sacloud API
 type UpdatePacketFilterParam struct {
-	Name        string
-	Description string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdatePacketFilterParam return new UpdatePacketFilterParam
@@ -476,6 +544,12 @@ func (p *UpdatePacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -539,6 +613,20 @@ func (p *UpdatePacketFilterParam) SetAssumeyes(v bool) {
 func (p *UpdatePacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdatePacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdatePacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdatePacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdatePacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdatePacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -584,13 +672,15 @@ func (p *UpdatePacketFilterParam) GetId() int64 {
 
 // DeletePacketFilterParam is input parameters for the sacloud API
 type DeletePacketFilterParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeletePacketFilterParam return new DeletePacketFilterParam
@@ -612,6 +702,12 @@ func (p *DeletePacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -661,6 +757,20 @@ func (p *DeletePacketFilterParam) SetAssumeyes(v bool) {
 func (p *DeletePacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeletePacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeletePacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeletePacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeletePacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeletePacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -706,12 +816,14 @@ func (p *DeletePacketFilterParam) GetId() int64 {
 
 // RuleInfoPacketFilterParam is input parameters for the sacloud API
 type RuleInfoPacketFilterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRuleInfoPacketFilterParam return new RuleInfoPacketFilterParam
@@ -733,6 +845,12 @@ func (p *RuleInfoPacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -775,6 +893,20 @@ func (p *RuleInfoPacketFilterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *RuleInfoPacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RuleInfoPacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RuleInfoPacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RuleInfoPacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RuleInfoPacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -820,20 +952,22 @@ func (p *RuleInfoPacketFilterParam) GetId() int64 {
 
 // RuleAddPacketFilterParam is input parameters for the sacloud API
 type RuleAddPacketFilterParam struct {
-	Index           int
-	Protocol        string
-	SourceNetwork   string
-	SourcePort      string
-	DestinationPort string
-	Action          string
-	Description     string
-	Assumeyes       bool
-	OutputType      string
-	Column          []string
-	Quiet           bool
-	Format          string
-	FormatFile      string
-	Id              int64
+	Index             int
+	Protocol          string
+	SourceNetwork     string
+	SourcePort        string
+	DestinationPort   string
+	Action            string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRuleAddPacketFilterParam return new RuleAddPacketFilterParam
@@ -900,6 +1034,12 @@ func (p *RuleAddPacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -998,6 +1138,20 @@ func (p *RuleAddPacketFilterParam) SetAssumeyes(v bool) {
 func (p *RuleAddPacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *RuleAddPacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RuleAddPacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RuleAddPacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RuleAddPacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RuleAddPacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1043,20 +1197,22 @@ func (p *RuleAddPacketFilterParam) GetId() int64 {
 
 // RuleUpdatePacketFilterParam is input parameters for the sacloud API
 type RuleUpdatePacketFilterParam struct {
-	Index           int
-	Protocol        string
-	SourceNetwork   string
-	SourcePort      string
-	DestinationPort string
-	Action          string
-	Description     string
-	Assumeyes       bool
-	OutputType      string
-	Column          []string
-	Quiet           bool
-	Format          string
-	FormatFile      string
-	Id              int64
+	Index             int
+	Protocol          string
+	SourceNetwork     string
+	SourcePort        string
+	DestinationPort   string
+	Action            string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRuleUpdatePacketFilterParam return new RuleUpdatePacketFilterParam
@@ -1127,6 +1283,12 @@ func (p *RuleUpdatePacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1225,6 +1387,20 @@ func (p *RuleUpdatePacketFilterParam) SetAssumeyes(v bool) {
 func (p *RuleUpdatePacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *RuleUpdatePacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RuleUpdatePacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RuleUpdatePacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RuleUpdatePacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RuleUpdatePacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1270,14 +1446,16 @@ func (p *RuleUpdatePacketFilterParam) GetId() int64 {
 
 // RuleDeletePacketFilterParam is input parameters for the sacloud API
 type RuleDeletePacketFilterParam struct {
-	Index      int
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewRuleDeletePacketFilterParam return new RuleDeletePacketFilterParam
@@ -1306,6 +1484,12 @@ func (p *RuleDeletePacketFilterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1362,6 +1546,20 @@ func (p *RuleDeletePacketFilterParam) SetAssumeyes(v bool) {
 func (p *RuleDeletePacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *RuleDeletePacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RuleDeletePacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RuleDeletePacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RuleDeletePacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *RuleDeletePacketFilterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1407,9 +1605,11 @@ func (p *RuleDeletePacketFilterParam) GetId() int64 {
 
 // InterfaceConnectPacketFilterParam is input parameters for the sacloud API
 type InterfaceConnectPacketFilterParam struct {
-	InterfaceId int64
-	Assumeyes   bool
-	Id          int64
+	InterfaceId       int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceConnectPacketFilterParam return new InterfaceConnectPacketFilterParam
@@ -1487,6 +1687,20 @@ func (p *InterfaceConnectPacketFilterParam) SetAssumeyes(v bool) {
 func (p *InterfaceConnectPacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceConnectPacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceConnectPacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceConnectPacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceConnectPacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceConnectPacketFilterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1497,9 +1711,11 @@ func (p *InterfaceConnectPacketFilterParam) GetId() int64 {
 
 // InterfaceDisconnectPacketFilterParam is input parameters for the sacloud API
 type InterfaceDisconnectPacketFilterParam struct {
-	InterfaceId int64
-	Assumeyes   bool
-	Id          int64
+	InterfaceId       int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceDisconnectPacketFilterParam return new InterfaceDisconnectPacketFilterParam
@@ -1576,6 +1792,20 @@ func (p *InterfaceDisconnectPacketFilterParam) SetAssumeyes(v bool) {
 
 func (p *InterfaceDisconnectPacketFilterParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *InterfaceDisconnectPacketFilterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceDisconnectPacketFilterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceDisconnectPacketFilterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceDisconnectPacketFilterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *InterfaceDisconnectPacketFilterParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_price_gen.go
+++ b/command/params/params_price_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListPriceParam is input parameters for the sacloud API
 type ListPriceParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListPriceParam return new ListPriceParam
@@ -59,6 +61,12 @@ func (p *ListPriceParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -135,6 +143,20 @@ func (p *ListPriceParam) SetSort(v []string) {
 
 func (p *ListPriceParam) GetSort() []string {
 	return p.Sort
+}
+func (p *ListPriceParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListPriceParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListPriceParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListPriceParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ListPriceParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_product_disk_gen.go
+++ b/command/params/params_product_disk_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListProductDiskParam is input parameters for the sacloud API
 type ListProductDiskParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListProductDiskParam return new ListProductDiskParam
@@ -59,6 +61,12 @@ func (p *ListProductDiskParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListProductDiskParam) SetSort(v []string) {
 func (p *ListProductDiskParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListProductDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListProductDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListProductDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListProductDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListProductDiskParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,13 +196,15 @@ func (p *ListProductDiskParam) GetFormatFile() string {
 
 // ReadProductDiskParam is input parameters for the sacloud API
 type ReadProductDiskParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadProductDiskParam return new ReadProductDiskParam
@@ -209,6 +233,12 @@ func (p *ReadProductDiskParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -257,6 +287,20 @@ func (p *ReadProductDiskParam) SetAssumeyes(v bool) {
 
 func (p *ReadProductDiskParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *ReadProductDiskParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadProductDiskParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadProductDiskParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadProductDiskParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ReadProductDiskParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_product_internet_gen.go
+++ b/command/params/params_product_internet_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListProductInternetParam is input parameters for the sacloud API
 type ListProductInternetParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListProductInternetParam return new ListProductInternetParam
@@ -59,6 +61,12 @@ func (p *ListProductInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListProductInternetParam) SetSort(v []string) {
 func (p *ListProductInternetParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListProductInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListProductInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListProductInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListProductInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListProductInternetParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,13 +196,15 @@ func (p *ListProductInternetParam) GetFormatFile() string {
 
 // ReadProductInternetParam is input parameters for the sacloud API
 type ReadProductInternetParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadProductInternetParam return new ReadProductInternetParam
@@ -209,6 +233,12 @@ func (p *ReadProductInternetParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -257,6 +287,20 @@ func (p *ReadProductInternetParam) SetAssumeyes(v bool) {
 
 func (p *ReadProductInternetParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *ReadProductInternetParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadProductInternetParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadProductInternetParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadProductInternetParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ReadProductInternetParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_product_license_gen.go
+++ b/command/params/params_product_license_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListProductLicenseParam is input parameters for the sacloud API
 type ListProductLicenseParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListProductLicenseParam return new ListProductLicenseParam
@@ -59,6 +61,12 @@ func (p *ListProductLicenseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListProductLicenseParam) SetSort(v []string) {
 func (p *ListProductLicenseParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListProductLicenseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListProductLicenseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListProductLicenseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListProductLicenseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListProductLicenseParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,13 +196,15 @@ func (p *ListProductLicenseParam) GetFormatFile() string {
 
 // ReadProductLicenseParam is input parameters for the sacloud API
 type ReadProductLicenseParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadProductLicenseParam return new ReadProductLicenseParam
@@ -209,6 +233,12 @@ func (p *ReadProductLicenseParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -257,6 +287,20 @@ func (p *ReadProductLicenseParam) SetAssumeyes(v bool) {
 
 func (p *ReadProductLicenseParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *ReadProductLicenseParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadProductLicenseParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadProductLicenseParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadProductLicenseParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ReadProductLicenseParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_product_server_gen.go
+++ b/command/params/params_product_server_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListProductServerParam is input parameters for the sacloud API
 type ListProductServerParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListProductServerParam return new ListProductServerParam
@@ -59,6 +61,12 @@ func (p *ListProductServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListProductServerParam) SetSort(v []string) {
 func (p *ListProductServerParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListProductServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListProductServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListProductServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListProductServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListProductServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,13 +196,15 @@ func (p *ListProductServerParam) GetFormatFile() string {
 
 // ReadProductServerParam is input parameters for the sacloud API
 type ReadProductServerParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadProductServerParam return new ReadProductServerParam
@@ -209,6 +233,12 @@ func (p *ReadProductServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -257,6 +287,20 @@ func (p *ReadProductServerParam) SetAssumeyes(v bool) {
 
 func (p *ReadProductServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *ReadProductServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadProductServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadProductServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadProductServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ReadProductServerParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_region_gen.go
+++ b/command/params/params_region_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListRegionParam is input parameters for the sacloud API
 type ListRegionParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListRegionParam return new ListRegionParam
@@ -59,6 +61,12 @@ func (p *ListRegionParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListRegionParam) SetSort(v []string) {
 func (p *ListRegionParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListRegionParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListRegionParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListRegionParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListRegionParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListRegionParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,13 +196,15 @@ func (p *ListRegionParam) GetFormatFile() string {
 
 // ReadRegionParam is input parameters for the sacloud API
 type ReadRegionParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadRegionParam return new ReadRegionParam
@@ -209,6 +233,12 @@ func (p *ReadRegionParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -257,6 +287,20 @@ func (p *ReadRegionParam) SetAssumeyes(v bool) {
 
 func (p *ReadRegionParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *ReadRegionParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadRegionParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadRegionParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadRegionParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ReadRegionParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_server_gen.go
+++ b/command/params/params_server_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListServerParam is input parameters for the sacloud API
 type ListServerParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListServerParam return new ListServerParam
@@ -67,6 +69,12 @@ func (p *ListServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListServerParam) SetSort(v []string) {
 func (p *ListServerParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -228,6 +250,8 @@ type BuildServerParam struct {
 	Tags                    []string
 	IconId                  int64
 	Assumeyes               bool
+	ParamTemplate           string
+	ParamTemplateFile       string
 	OutputType              string
 	Column                  []string
 	Quiet                   bool
@@ -482,6 +506,12 @@ func (p *BuildServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -797,6 +827,20 @@ func (p *BuildServerParam) SetAssumeyes(v bool) {
 func (p *BuildServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *BuildServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *BuildServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *BuildServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *BuildServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *BuildServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -849,12 +893,14 @@ func (p *BuildServerParam) GetDisableBootAfterCreate() bool {
 
 // ReadServerParam is input parameters for the sacloud API
 type ReadServerParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadServerParam return new ReadServerParam
@@ -876,6 +922,12 @@ func (p *ReadServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -918,6 +970,20 @@ func (p *ReadServerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -963,17 +1029,19 @@ func (p *ReadServerParam) GetId() int64 {
 
 // UpdateServerParam is input parameters for the sacloud API
 type UpdateServerParam struct {
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateServerParam return new UpdateServerParam
@@ -1023,6 +1091,12 @@ func (p *UpdateServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1100,6 +1174,20 @@ func (p *UpdateServerParam) SetAssumeyes(v bool) {
 func (p *UpdateServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1145,15 +1233,17 @@ func (p *UpdateServerParam) GetId() int64 {
 
 // DeleteServerParam is input parameters for the sacloud API
 type DeleteServerParam struct {
-	Force       bool
-	WithoutDisk bool
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Force             bool
+	WithoutDisk       bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteServerParam return new DeleteServerParam
@@ -1175,6 +1265,12 @@ func (p *DeleteServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1238,6 +1334,20 @@ func (p *DeleteServerParam) SetAssumeyes(v bool) {
 func (p *DeleteServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeleteServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeleteServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1283,15 +1393,17 @@ func (p *DeleteServerParam) GetId() int64 {
 
 // PlanChangeServerParam is input parameters for the sacloud API
 type PlanChangeServerParam struct {
-	Core       int
-	Memory     int
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Core              int
+	Memory            int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewPlanChangeServerParam return new PlanChangeServerParam
@@ -1327,6 +1439,12 @@ func (p *PlanChangeServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1390,6 +1508,20 @@ func (p *PlanChangeServerParam) SetAssumeyes(v bool) {
 func (p *PlanChangeServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PlanChangeServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PlanChangeServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PlanChangeServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PlanChangeServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PlanChangeServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1435,8 +1567,10 @@ func (p *PlanChangeServerParam) GetId() int64 {
 
 // BootServerParam is input parameters for the sacloud API
 type BootServerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewBootServerParam return new BootServerParam
@@ -1493,6 +1627,20 @@ func (p *BootServerParam) SetAssumeyes(v bool) {
 func (p *BootServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *BootServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *BootServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *BootServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *BootServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *BootServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1503,8 +1651,10 @@ func (p *BootServerParam) GetId() int64 {
 
 // ShutdownServerParam is input parameters for the sacloud API
 type ShutdownServerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownServerParam return new ShutdownServerParam
@@ -1561,6 +1711,20 @@ func (p *ShutdownServerParam) SetAssumeyes(v bool) {
 func (p *ShutdownServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1571,8 +1735,10 @@ func (p *ShutdownServerParam) GetId() int64 {
 
 // ShutdownForceServerParam is input parameters for the sacloud API
 type ShutdownForceServerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownForceServerParam return new ShutdownForceServerParam
@@ -1629,6 +1795,20 @@ func (p *ShutdownForceServerParam) SetAssumeyes(v bool) {
 func (p *ShutdownForceServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownForceServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownForceServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownForceServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownForceServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownForceServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1639,8 +1819,10 @@ func (p *ShutdownForceServerParam) GetId() int64 {
 
 // ResetServerParam is input parameters for the sacloud API
 type ResetServerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewResetServerParam return new ResetServerParam
@@ -1697,6 +1879,20 @@ func (p *ResetServerParam) SetAssumeyes(v bool) {
 func (p *ResetServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ResetServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResetServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResetServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResetServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ResetServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1707,7 +1903,9 @@ func (p *ResetServerParam) GetId() int64 {
 
 // WaitForBootServerParam is input parameters for the sacloud API
 type WaitForBootServerParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForBootServerParam return new WaitForBootServerParam
@@ -1757,6 +1955,20 @@ func (p *WaitForBootServerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForBootServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForBootServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForBootServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForBootServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForBootServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1767,7 +1979,9 @@ func (p *WaitForBootServerParam) GetId() int64 {
 
 // WaitForDownServerParam is input parameters for the sacloud API
 type WaitForDownServerParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForDownServerParam return new WaitForDownServerParam
@@ -1817,6 +2031,20 @@ func (p *WaitForDownServerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForDownServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForDownServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForDownServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForDownServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForDownServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1827,12 +2055,14 @@ func (p *WaitForDownServerParam) GetId() int64 {
 
 // SshServerParam is input parameters for the sacloud API
 type SshServerParam struct {
-	Key      string
-	User     string
-	Port     int
-	Password string
-	Quiet    bool
-	Id       int64
+	Key               string
+	User              string
+	Port              int
+	Password          string
+	ParamTemplate     string
+	ParamTemplateFile string
+	Quiet             bool
+	Id                int64
 }
 
 // NewSshServerParam return new SshServerParam
@@ -1927,6 +2157,20 @@ func (p *SshServerParam) SetPassword(v string) {
 func (p *SshServerParam) GetPassword() string {
 	return p.Password
 }
+func (p *SshServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SshServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SshServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SshServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *SshServerParam) SetQuiet(v bool) {
 	p.Quiet = v
 }
@@ -1944,12 +2188,14 @@ func (p *SshServerParam) GetId() int64 {
 
 // SshExecServerParam is input parameters for the sacloud API
 type SshExecServerParam struct {
-	Key      string
-	User     string
-	Port     int
-	Password string
-	Quiet    bool
-	Id       int64
+	Key               string
+	User              string
+	Port              int
+	Password          string
+	ParamTemplate     string
+	ParamTemplateFile string
+	Quiet             bool
+	Id                int64
 }
 
 // NewSshExecServerParam return new SshExecServerParam
@@ -2044,6 +2290,20 @@ func (p *SshExecServerParam) SetPassword(v string) {
 func (p *SshExecServerParam) GetPassword() string {
 	return p.Password
 }
+func (p *SshExecServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SshExecServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SshExecServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SshExecServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *SshExecServerParam) SetQuiet(v bool) {
 	p.Quiet = v
 }
@@ -2061,13 +2321,15 @@ func (p *SshExecServerParam) GetId() int64 {
 
 // ScpServerParam is input parameters for the sacloud API
 type ScpServerParam struct {
-	Key       string
-	Recursive bool
-	User      string
-	Port      int
-	Password  string
-	Assumeyes bool
-	Quiet     bool
+	Key               string
+	Recursive         bool
+	User              string
+	Port              int
+	Password          string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Quiet             bool
 }
 
 // NewScpServerParam return new ScpServerParam
@@ -2169,6 +2431,20 @@ func (p *ScpServerParam) SetAssumeyes(v bool) {
 func (p *ScpServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ScpServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ScpServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ScpServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ScpServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ScpServerParam) SetQuiet(v bool) {
 	p.Quiet = v
 }
@@ -2179,9 +2455,11 @@ func (p *ScpServerParam) GetQuiet() bool {
 
 // VncServerParam is input parameters for the sacloud API
 type VncServerParam struct {
-	WaitForBoot bool
-	Assumeyes   bool
-	Id          int64
+	WaitForBoot       bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewVncServerParam return new VncServerParam
@@ -2245,6 +2523,20 @@ func (p *VncServerParam) SetAssumeyes(v bool) {
 func (p *VncServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *VncServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *VncServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *VncServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *VncServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *VncServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2255,13 +2547,15 @@ func (p *VncServerParam) GetId() int64 {
 
 // VncInfoServerParam is input parameters for the sacloud API
 type VncInfoServerParam struct {
-	WaitForBoot bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	WaitForBoot       bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewVncInfoServerParam return new VncInfoServerParam
@@ -2283,6 +2577,12 @@ func (p *VncInfoServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2332,6 +2632,20 @@ func (p *VncInfoServerParam) SetWaitForBoot(v bool) {
 func (p *VncInfoServerParam) GetWaitForBoot() bool {
 	return p.WaitForBoot
 }
+func (p *VncInfoServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *VncInfoServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *VncInfoServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *VncInfoServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *VncInfoServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -2377,18 +2691,20 @@ func (p *VncInfoServerParam) GetId() int64 {
 
 // VncSendServerParam is input parameters for the sacloud API
 type VncSendServerParam struct {
-	Command       string
-	CommandFile   string
-	UseUsKeyboard bool
-	Debug         bool
-	WaitForBoot   bool
-	Assumeyes     bool
-	OutputType    string
-	Column        []string
-	Quiet         bool
-	Format        string
-	FormatFile    string
-	Id            int64
+	Command           string
+	CommandFile       string
+	UseUsKeyboard     bool
+	Debug             bool
+	WaitForBoot       bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewVncSendServerParam return new VncSendServerParam
@@ -2426,6 +2742,12 @@ func (p *VncSendServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2510,6 +2832,20 @@ func (p *VncSendServerParam) SetAssumeyes(v bool) {
 func (p *VncSendServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *VncSendServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *VncSendServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *VncSendServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *VncSendServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *VncSendServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -2555,12 +2891,14 @@ func (p *VncSendServerParam) GetId() int64 {
 
 // DiskInfoServerParam is input parameters for the sacloud API
 type DiskInfoServerParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDiskInfoServerParam return new DiskInfoServerParam
@@ -2582,6 +2920,12 @@ func (p *DiskInfoServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2624,6 +2968,20 @@ func (p *DiskInfoServerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *DiskInfoServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DiskInfoServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DiskInfoServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DiskInfoServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DiskInfoServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -2669,9 +3027,11 @@ func (p *DiskInfoServerParam) GetId() int64 {
 
 // DiskConnectServerParam is input parameters for the sacloud API
 type DiskConnectServerParam struct {
-	DiskId    int64
-	Assumeyes bool
-	Id        int64
+	DiskId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDiskConnectServerParam return new DiskConnectServerParam
@@ -2749,6 +3109,20 @@ func (p *DiskConnectServerParam) SetAssumeyes(v bool) {
 func (p *DiskConnectServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DiskConnectServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DiskConnectServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DiskConnectServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DiskConnectServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DiskConnectServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2759,9 +3133,11 @@ func (p *DiskConnectServerParam) GetId() int64 {
 
 // DiskDisconnectServerParam is input parameters for the sacloud API
 type DiskDisconnectServerParam struct {
-	DiskId    int64
-	Assumeyes bool
-	Id        int64
+	DiskId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDiskDisconnectServerParam return new DiskDisconnectServerParam
@@ -2839,6 +3215,20 @@ func (p *DiskDisconnectServerParam) SetAssumeyes(v bool) {
 func (p *DiskDisconnectServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DiskDisconnectServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DiskDisconnectServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DiskDisconnectServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DiskDisconnectServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DiskDisconnectServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2849,12 +3239,14 @@ func (p *DiskDisconnectServerParam) GetId() int64 {
 
 // InterfaceInfoServerParam is input parameters for the sacloud API
 type InterfaceInfoServerParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewInterfaceInfoServerParam return new InterfaceInfoServerParam
@@ -2876,6 +3268,12 @@ func (p *InterfaceInfoServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2918,6 +3316,20 @@ func (p *InterfaceInfoServerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *InterfaceInfoServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceInfoServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceInfoServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceInfoServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceInfoServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -2963,9 +3375,11 @@ func (p *InterfaceInfoServerParam) GetId() int64 {
 
 // InterfaceAddForInternetServerParam is input parameters for the sacloud API
 type InterfaceAddForInternetServerParam struct {
-	WithoutDiskEdit bool
-	Assumeyes       bool
-	Id              int64
+	WithoutDiskEdit   bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceAddForInternetServerParam return new InterfaceAddForInternetServerParam
@@ -3029,6 +3443,20 @@ func (p *InterfaceAddForInternetServerParam) SetAssumeyes(v bool) {
 func (p *InterfaceAddForInternetServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceAddForInternetServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceAddForInternetServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceAddForInternetServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceAddForInternetServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceAddForInternetServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3039,13 +3467,15 @@ func (p *InterfaceAddForInternetServerParam) GetId() int64 {
 
 // InterfaceAddForRouterServerParam is input parameters for the sacloud API
 type InterfaceAddForRouterServerParam struct {
-	SwitchId        int64
-	WithoutDiskEdit bool
-	Ipaddress       string
-	DefaultRoute    string
-	NwMasklen       int
-	Assumeyes       bool
-	Id              int64
+	SwitchId          int64
+	WithoutDiskEdit   bool
+	Ipaddress         string
+	DefaultRoute      string
+	NwMasklen         int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceAddForRouterServerParam return new InterfaceAddForRouterServerParam
@@ -3175,6 +3605,20 @@ func (p *InterfaceAddForRouterServerParam) SetAssumeyes(v bool) {
 func (p *InterfaceAddForRouterServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceAddForRouterServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceAddForRouterServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceAddForRouterServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceAddForRouterServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceAddForRouterServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3185,13 +3629,15 @@ func (p *InterfaceAddForRouterServerParam) GetId() int64 {
 
 // InterfaceAddForSwitchServerParam is input parameters for the sacloud API
 type InterfaceAddForSwitchServerParam struct {
-	SwitchId        int64
-	WithoutDiskEdit bool
-	Ipaddress       string
-	DefaultRoute    string
-	NwMasklen       int
-	Assumeyes       bool
-	Id              int64
+	SwitchId          int64
+	WithoutDiskEdit   bool
+	Ipaddress         string
+	DefaultRoute      string
+	NwMasklen         int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceAddForSwitchServerParam return new InterfaceAddForSwitchServerParam
@@ -3321,6 +3767,20 @@ func (p *InterfaceAddForSwitchServerParam) SetAssumeyes(v bool) {
 func (p *InterfaceAddForSwitchServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceAddForSwitchServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceAddForSwitchServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceAddForSwitchServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceAddForSwitchServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceAddForSwitchServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3331,8 +3791,10 @@ func (p *InterfaceAddForSwitchServerParam) GetId() int64 {
 
 // InterfaceAddDisconnectedServerParam is input parameters for the sacloud API
 type InterfaceAddDisconnectedServerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceAddDisconnectedServerParam return new InterfaceAddDisconnectedServerParam
@@ -3389,6 +3851,20 @@ func (p *InterfaceAddDisconnectedServerParam) SetAssumeyes(v bool) {
 func (p *InterfaceAddDisconnectedServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceAddDisconnectedServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceAddDisconnectedServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceAddDisconnectedServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceAddDisconnectedServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceAddDisconnectedServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3399,12 +3875,14 @@ func (p *InterfaceAddDisconnectedServerParam) GetId() int64 {
 
 // IsoInfoServerParam is input parameters for the sacloud API
 type IsoInfoServerParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewIsoInfoServerParam return new IsoInfoServerParam
@@ -3426,6 +3904,12 @@ func (p *IsoInfoServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3468,6 +3952,20 @@ func (p *IsoInfoServerParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *IsoInfoServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *IsoInfoServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *IsoInfoServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *IsoInfoServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *IsoInfoServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -3513,15 +4011,17 @@ func (p *IsoInfoServerParam) GetId() int64 {
 
 // IsoInsertServerParam is input parameters for the sacloud API
 type IsoInsertServerParam struct {
-	IsoImageId  int64
-	Size        int
-	IsoFile     string
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	Id          int64
+	IsoImageId        int64
+	Size              int
+	IsoFile           string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewIsoInsertServerParam return new IsoInsertServerParam
@@ -3672,6 +4172,20 @@ func (p *IsoInsertServerParam) SetAssumeyes(v bool) {
 func (p *IsoInsertServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *IsoInsertServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *IsoInsertServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *IsoInsertServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *IsoInsertServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *IsoInsertServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3682,8 +4196,10 @@ func (p *IsoInsertServerParam) GetId() int64 {
 
 // IsoEjectServerParam is input parameters for the sacloud API
 type IsoEjectServerParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewIsoEjectServerParam return new IsoEjectServerParam
@@ -3740,6 +4256,20 @@ func (p *IsoEjectServerParam) SetAssumeyes(v bool) {
 func (p *IsoEjectServerParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *IsoEjectServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *IsoEjectServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *IsoEjectServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *IsoEjectServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *IsoEjectServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3750,15 +4280,17 @@ func (p *IsoEjectServerParam) GetId() int64 {
 
 // MonitorCpuServerParam is input parameters for the sacloud API
 type MonitorCpuServerParam struct {
-	Start      string
-	End        string
-	KeyFormat  string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Start             string
+	End               string
+	KeyFormat         string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewMonitorCpuServerParam return new MonitorCpuServerParam
@@ -3804,6 +4336,12 @@ func (p *MonitorCpuServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3867,6 +4405,20 @@ func (p *MonitorCpuServerParam) SetKeyFormat(v string) {
 func (p *MonitorCpuServerParam) GetKeyFormat() string {
 	return p.KeyFormat
 }
+func (p *MonitorCpuServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MonitorCpuServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MonitorCpuServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MonitorCpuServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *MonitorCpuServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -3912,16 +4464,18 @@ func (p *MonitorCpuServerParam) GetId() int64 {
 
 // MonitorNicServerParam is input parameters for the sacloud API
 type MonitorNicServerParam struct {
-	Start      string
-	End        string
-	Index      []int64
-	KeyFormat  string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Start             string
+	End               string
+	Index             []int64
+	KeyFormat         string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewMonitorNicServerParam return new MonitorNicServerParam
@@ -3967,6 +4521,12 @@ func (p *MonitorNicServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4037,6 +4597,20 @@ func (p *MonitorNicServerParam) SetKeyFormat(v string) {
 func (p *MonitorNicServerParam) GetKeyFormat() string {
 	return p.KeyFormat
 }
+func (p *MonitorNicServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MonitorNicServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MonitorNicServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MonitorNicServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *MonitorNicServerParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -4082,16 +4656,18 @@ func (p *MonitorNicServerParam) GetId() int64 {
 
 // MonitorDiskServerParam is input parameters for the sacloud API
 type MonitorDiskServerParam struct {
-	Start      string
-	End        string
-	Index      []int64
-	KeyFormat  string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Start             string
+	End               string
+	Index             []int64
+	KeyFormat         string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewMonitorDiskServerParam return new MonitorDiskServerParam
@@ -4137,6 +4713,12 @@ func (p *MonitorDiskServerParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4206,6 +4788,20 @@ func (p *MonitorDiskServerParam) SetKeyFormat(v string) {
 
 func (p *MonitorDiskServerParam) GetKeyFormat() string {
 	return p.KeyFormat
+}
+func (p *MonitorDiskServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MonitorDiskServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MonitorDiskServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MonitorDiskServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *MonitorDiskServerParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_simple_monitor_gen.go
+++ b/command/params/params_simple_monitor_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListSimpleMonitorParam is input parameters for the sacloud API
 type ListSimpleMonitorParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListSimpleMonitorParam return new ListSimpleMonitorParam
@@ -67,6 +69,12 @@ func (p *ListSimpleMonitorParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListSimpleMonitorParam) SetSort(v []string) {
 func (p *ListSimpleMonitorParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListSimpleMonitorParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListSimpleMonitorParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListSimpleMonitorParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListSimpleMonitorParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListSimpleMonitorParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,28 +211,30 @@ func (p *ListSimpleMonitorParam) GetFormatFile() string {
 
 // CreateSimpleMonitorParam is input parameters for the sacloud API
 type CreateSimpleMonitorParam struct {
-	Target       string
-	Protocol     string
-	Port         int
-	DelayLoop    int
-	Enabled      bool
-	HostHeader   string
-	Path         string
-	ResponseCode int
-	DnsQname     string
-	DnsExcepted  string
-	NotifyEmail  bool
-	EmailType    string
-	SlackWebhook string
-	Description  string
-	Tags         []string
-	IconId       int64
-	Assumeyes    bool
-	OutputType   string
-	Column       []string
-	Quiet        bool
-	Format       string
-	FormatFile   string
+	Target            string
+	Protocol          string
+	Port              int
+	DelayLoop         int
+	Enabled           bool
+	HostHeader        string
+	Path              string
+	ResponseCode      int
+	DnsQname          string
+	DnsExcepted       string
+	NotifyEmail       bool
+	EmailType         string
+	SlackWebhook      string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateSimpleMonitorParam return new CreateSimpleMonitorParam
@@ -311,6 +335,12 @@ func (p *CreateSimpleMonitorParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -472,6 +502,20 @@ func (p *CreateSimpleMonitorParam) SetAssumeyes(v bool) {
 func (p *CreateSimpleMonitorParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateSimpleMonitorParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateSimpleMonitorParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateSimpleMonitorParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateSimpleMonitorParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateSimpleMonitorParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -510,12 +554,14 @@ func (p *CreateSimpleMonitorParam) GetFormatFile() string {
 
 // ReadSimpleMonitorParam is input parameters for the sacloud API
 type ReadSimpleMonitorParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadSimpleMonitorParam return new ReadSimpleMonitorParam
@@ -537,6 +583,12 @@ func (p *ReadSimpleMonitorParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -579,6 +631,20 @@ func (p *ReadSimpleMonitorParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadSimpleMonitorParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadSimpleMonitorParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadSimpleMonitorParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadSimpleMonitorParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadSimpleMonitorParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -624,28 +690,30 @@ func (p *ReadSimpleMonitorParam) GetId() int64 {
 
 // UpdateSimpleMonitorParam is input parameters for the sacloud API
 type UpdateSimpleMonitorParam struct {
-	Protocol     string
-	Port         int
-	DelayLoop    int
-	Enabled      bool
-	HostHeader   string
-	Path         string
-	ResponseCode int
-	DnsQname     string
-	DnsExcepted  string
-	NotifyEmail  bool
-	EmailType    string
-	SlackWebhook string
-	Description  string
-	Tags         []string
-	IconId       int64
-	Assumeyes    bool
-	OutputType   string
-	Column       []string
-	Quiet        bool
-	Format       string
-	FormatFile   string
-	Id           int64
+	Protocol          string
+	Port              int
+	DelayLoop         int
+	Enabled           bool
+	HostHeader        string
+	Path              string
+	ResponseCode      int
+	DnsQname          string
+	DnsExcepted       string
+	NotifyEmail       bool
+	EmailType         string
+	SlackWebhook      string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateSimpleMonitorParam return new UpdateSimpleMonitorParam
@@ -716,6 +784,12 @@ func (p *UpdateSimpleMonitorParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -870,6 +944,20 @@ func (p *UpdateSimpleMonitorParam) SetAssumeyes(v bool) {
 func (p *UpdateSimpleMonitorParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateSimpleMonitorParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateSimpleMonitorParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateSimpleMonitorParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateSimpleMonitorParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateSimpleMonitorParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -915,13 +1003,15 @@ func (p *UpdateSimpleMonitorParam) GetId() int64 {
 
 // DeleteSimpleMonitorParam is input parameters for the sacloud API
 type DeleteSimpleMonitorParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteSimpleMonitorParam return new DeleteSimpleMonitorParam
@@ -943,6 +1033,12 @@ func (p *DeleteSimpleMonitorParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -991,6 +1087,20 @@ func (p *DeleteSimpleMonitorParam) SetAssumeyes(v bool) {
 
 func (p *DeleteSimpleMonitorParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteSimpleMonitorParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteSimpleMonitorParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteSimpleMonitorParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteSimpleMonitorParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteSimpleMonitorParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_ssh_key_gen.go
+++ b/command/params/params_ssh_key_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListSSHKeyParam is input parameters for the sacloud API
 type ListSSHKeyParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListSSHKeyParam return new ListSSHKeyParam
@@ -59,6 +61,12 @@ func (p *ListSSHKeyParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListSSHKeyParam) SetSort(v []string) {
 func (p *ListSSHKeyParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListSSHKeyParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListSSHKeyParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListSSHKeyParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListSSHKeyParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListSSHKeyParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,16 +196,18 @@ func (p *ListSSHKeyParam) GetFormatFile() string {
 
 // CreateSSHKeyParam is input parameters for the sacloud API
 type CreateSSHKeyParam struct {
-	PublicKey        string
-	Name             string
-	Description      string
-	Assumeyes        bool
-	PublicKeyContent string
-	OutputType       string
-	Column           []string
-	Quiet            bool
-	Format           string
-	FormatFile       string
+	PublicKey         string
+	Name              string
+	Description       string
+	Assumeyes         bool
+	PublicKeyContent  string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateSSHKeyParam return new CreateSSHKeyParam
@@ -235,6 +259,12 @@ func (p *CreateSSHKeyParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -312,6 +342,20 @@ func (p *CreateSSHKeyParam) SetPublicKeyContent(v string) {
 func (p *CreateSSHKeyParam) GetPublicKeyContent() string {
 	return p.PublicKeyContent
 }
+func (p *CreateSSHKeyParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateSSHKeyParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateSSHKeyParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateSSHKeyParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateSSHKeyParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -350,12 +394,14 @@ func (p *CreateSSHKeyParam) GetFormatFile() string {
 
 // ReadSSHKeyParam is input parameters for the sacloud API
 type ReadSSHKeyParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadSSHKeyParam return new ReadSSHKeyParam
@@ -377,6 +423,12 @@ func (p *ReadSSHKeyParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -419,6 +471,20 @@ func (p *ReadSSHKeyParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadSSHKeyParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadSSHKeyParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadSSHKeyParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadSSHKeyParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadSSHKeyParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -464,15 +530,17 @@ func (p *ReadSSHKeyParam) GetId() int64 {
 
 // UpdateSSHKeyParam is input parameters for the sacloud API
 type UpdateSSHKeyParam struct {
-	Name        string
-	Description string
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateSSHKeyParam return new UpdateSSHKeyParam
@@ -508,6 +576,12 @@ func (p *UpdateSSHKeyParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -571,6 +645,20 @@ func (p *UpdateSSHKeyParam) SetAssumeyes(v bool) {
 func (p *UpdateSSHKeyParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateSSHKeyParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateSSHKeyParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateSSHKeyParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateSSHKeyParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateSSHKeyParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -616,13 +704,15 @@ func (p *UpdateSSHKeyParam) GetId() int64 {
 
 // DeleteSSHKeyParam is input parameters for the sacloud API
 type DeleteSSHKeyParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteSSHKeyParam return new DeleteSSHKeyParam
@@ -644,6 +734,12 @@ func (p *DeleteSSHKeyParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -693,6 +789,20 @@ func (p *DeleteSSHKeyParam) SetAssumeyes(v bool) {
 func (p *DeleteSSHKeyParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeleteSSHKeyParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteSSHKeyParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteSSHKeyParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteSSHKeyParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeleteSSHKeyParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -738,16 +848,18 @@ func (p *DeleteSSHKeyParam) GetId() int64 {
 
 // GenerateSSHKeyParam is input parameters for the sacloud API
 type GenerateSSHKeyParam struct {
-	PassPhrase       string
-	Name             string
-	Description      string
-	Assumeyes        bool
-	OutputType       string
-	PrivateKeyOutput string
-	Column           []string
-	Quiet            bool
-	Format           string
-	FormatFile       string
+	PassPhrase        string
+	Name              string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	PrivateKeyOutput  string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewGenerateSSHKeyParam return new GenerateSSHKeyParam
@@ -790,6 +902,12 @@ func (p *GenerateSSHKeyParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -859,6 +977,20 @@ func (p *GenerateSSHKeyParam) SetAssumeyes(v bool) {
 
 func (p *GenerateSSHKeyParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *GenerateSSHKeyParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *GenerateSSHKeyParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *GenerateSSHKeyParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *GenerateSSHKeyParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *GenerateSSHKeyParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_startup_script_gen.go
+++ b/command/params/params_startup_script_gen.go
@@ -10,18 +10,20 @@ import (
 
 // ListStartupScriptParam is input parameters for the sacloud API
 type ListStartupScriptParam struct {
-	Name       []string
-	Id         []int64
-	Scope      string
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Scope             string
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListStartupScriptParam return new ListStartupScriptParam
@@ -75,6 +77,12 @@ func (p *ListStartupScriptParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -166,6 +174,20 @@ func (p *ListStartupScriptParam) SetSort(v []string) {
 func (p *ListStartupScriptParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListStartupScriptParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListStartupScriptParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListStartupScriptParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListStartupScriptParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListStartupScriptParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -204,17 +226,19 @@ func (p *ListStartupScriptParam) GetFormatFile() string {
 
 // CreateStartupScriptParam is input parameters for the sacloud API
 type CreateStartupScriptParam struct {
-	Script        string
-	ScriptContent string
-	Name          string
-	Tags          []string
-	IconId        int64
-	Assumeyes     bool
-	OutputType    string
-	Column        []string
-	Quiet         bool
-	Format        string
-	FormatFile    string
+	Script            string
+	ScriptContent     string
+	Name              string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateStartupScriptParam return new CreateStartupScriptParam
@@ -273,6 +297,12 @@ func (p *CreateStartupScriptParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -357,6 +387,20 @@ func (p *CreateStartupScriptParam) SetAssumeyes(v bool) {
 func (p *CreateStartupScriptParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateStartupScriptParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateStartupScriptParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateStartupScriptParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateStartupScriptParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateStartupScriptParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -395,12 +439,14 @@ func (p *CreateStartupScriptParam) GetFormatFile() string {
 
 // ReadStartupScriptParam is input parameters for the sacloud API
 type ReadStartupScriptParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadStartupScriptParam return new ReadStartupScriptParam
@@ -422,6 +468,12 @@ func (p *ReadStartupScriptParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -464,6 +516,20 @@ func (p *ReadStartupScriptParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadStartupScriptParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadStartupScriptParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadStartupScriptParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadStartupScriptParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadStartupScriptParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -509,18 +575,20 @@ func (p *ReadStartupScriptParam) GetId() int64 {
 
 // UpdateStartupScriptParam is input parameters for the sacloud API
 type UpdateStartupScriptParam struct {
-	Script        string
-	ScriptContent string
-	Name          string
-	Tags          []string
-	IconId        int64
-	Assumeyes     bool
-	OutputType    string
-	Column        []string
-	Quiet         bool
-	Format        string
-	FormatFile    string
-	Id            int64
+	Script            string
+	ScriptContent     string
+	Name              string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateStartupScriptParam return new UpdateStartupScriptParam
@@ -586,6 +654,12 @@ func (p *UpdateStartupScriptParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -670,6 +744,20 @@ func (p *UpdateStartupScriptParam) SetAssumeyes(v bool) {
 func (p *UpdateStartupScriptParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateStartupScriptParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateStartupScriptParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateStartupScriptParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateStartupScriptParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateStartupScriptParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -715,13 +803,15 @@ func (p *UpdateStartupScriptParam) GetId() int64 {
 
 // DeleteStartupScriptParam is input parameters for the sacloud API
 type DeleteStartupScriptParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteStartupScriptParam return new DeleteStartupScriptParam
@@ -743,6 +833,12 @@ func (p *DeleteStartupScriptParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -791,6 +887,20 @@ func (p *DeleteStartupScriptParam) SetAssumeyes(v bool) {
 
 func (p *DeleteStartupScriptParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteStartupScriptParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteStartupScriptParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteStartupScriptParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteStartupScriptParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteStartupScriptParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_switch_gen.go
+++ b/command/params/params_switch_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListSwitchParam is input parameters for the sacloud API
 type ListSwitchParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListSwitchParam return new ListSwitchParam
@@ -67,6 +69,12 @@ func (p *ListSwitchParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListSwitchParam) SetSort(v []string) {
 func (p *ListSwitchParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListSwitchParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListSwitchParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListSwitchParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListSwitchParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListSwitchParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,16 +211,18 @@ func (p *ListSwitchParam) GetFormatFile() string {
 
 // CreateSwitchParam is input parameters for the sacloud API
 type CreateSwitchParam struct {
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateSwitchParam return new CreateSwitchParam
@@ -248,6 +272,12 @@ func (p *CreateSwitchParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -325,6 +355,20 @@ func (p *CreateSwitchParam) SetAssumeyes(v bool) {
 func (p *CreateSwitchParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateSwitchParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateSwitchParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateSwitchParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateSwitchParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateSwitchParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -363,12 +407,14 @@ func (p *CreateSwitchParam) GetFormatFile() string {
 
 // ReadSwitchParam is input parameters for the sacloud API
 type ReadSwitchParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadSwitchParam return new ReadSwitchParam
@@ -390,6 +436,12 @@ func (p *ReadSwitchParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -432,6 +484,20 @@ func (p *ReadSwitchParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadSwitchParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadSwitchParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadSwitchParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadSwitchParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadSwitchParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -477,17 +543,19 @@ func (p *ReadSwitchParam) GetId() int64 {
 
 // UpdateSwitchParam is input parameters for the sacloud API
 type UpdateSwitchParam struct {
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateSwitchParam return new UpdateSwitchParam
@@ -537,6 +605,12 @@ func (p *UpdateSwitchParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -614,6 +688,20 @@ func (p *UpdateSwitchParam) SetAssumeyes(v bool) {
 func (p *UpdateSwitchParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateSwitchParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateSwitchParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateSwitchParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateSwitchParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateSwitchParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -659,13 +747,15 @@ func (p *UpdateSwitchParam) GetId() int64 {
 
 // DeleteSwitchParam is input parameters for the sacloud API
 type DeleteSwitchParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteSwitchParam return new DeleteSwitchParam
@@ -687,6 +777,12 @@ func (p *DeleteSwitchParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -736,6 +832,20 @@ func (p *DeleteSwitchParam) SetAssumeyes(v bool) {
 func (p *DeleteSwitchParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeleteSwitchParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteSwitchParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteSwitchParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteSwitchParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeleteSwitchParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -781,9 +891,11 @@ func (p *DeleteSwitchParam) GetId() int64 {
 
 // BridgeConnectSwitchParam is input parameters for the sacloud API
 type BridgeConnectSwitchParam struct {
-	BridgeId  int64
-	Assumeyes bool
-	Id        int64
+	BridgeId          int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewBridgeConnectSwitchParam return new BridgeConnectSwitchParam
@@ -861,6 +973,20 @@ func (p *BridgeConnectSwitchParam) SetAssumeyes(v bool) {
 func (p *BridgeConnectSwitchParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *BridgeConnectSwitchParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *BridgeConnectSwitchParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *BridgeConnectSwitchParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *BridgeConnectSwitchParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *BridgeConnectSwitchParam) SetId(v int64) {
 	p.Id = v
 }
@@ -871,8 +997,10 @@ func (p *BridgeConnectSwitchParam) GetId() int64 {
 
 // BridgeDisconnectSwitchParam is input parameters for the sacloud API
 type BridgeDisconnectSwitchParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewBridgeDisconnectSwitchParam return new BridgeDisconnectSwitchParam
@@ -928,6 +1056,20 @@ func (p *BridgeDisconnectSwitchParam) SetAssumeyes(v bool) {
 
 func (p *BridgeDisconnectSwitchParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *BridgeDisconnectSwitchParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *BridgeDisconnectSwitchParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *BridgeDisconnectSwitchParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *BridgeDisconnectSwitchParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *BridgeDisconnectSwitchParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_vpc_router_gen.go
+++ b/command/params/params_vpc_router_gen.go
@@ -10,17 +10,19 @@ import (
 
 // ListVPCRouterParam is input parameters for the sacloud API
 type ListVPCRouterParam struct {
-	Name       []string
-	Id         []int64
-	Tags       []string
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	Tags              []string
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListVPCRouterParam return new ListVPCRouterParam
@@ -67,6 +69,12 @@ func (p *ListVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -151,6 +159,20 @@ func (p *ListVPCRouterParam) SetSort(v []string) {
 func (p *ListVPCRouterParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -189,23 +211,25 @@ func (p *ListVPCRouterParam) GetFormatFile() string {
 
 // CreateVPCRouterParam is input parameters for the sacloud API
 type CreateVPCRouterParam struct {
-	Plan            string
-	SwitchId        int64
-	Vrid            int
-	Vip             string
-	Ipaddress1      string
-	Ipaddress2      string
-	BootAfterCreate bool
-	Name            string
-	Description     string
-	Tags            []string
-	IconId          int64
-	Assumeyes       bool
-	OutputType      string
-	Column          []string
-	Quiet           bool
-	Format          string
-	FormatFile      string
+	Plan              string
+	SwitchId          int64
+	Vrid              int
+	Vip               string
+	Ipaddress1        string
+	Ipaddress2        string
+	BootAfterCreate   bool
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewCreateVPCRouterParam return new CreateVPCRouterParam
@@ -309,6 +333,12 @@ func (p *CreateVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -435,6 +465,20 @@ func (p *CreateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *CreateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *CreateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *CreateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *CreateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *CreateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *CreateVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -473,12 +517,14 @@ func (p *CreateVPCRouterParam) GetFormatFile() string {
 
 // ReadVPCRouterParam is input parameters for the sacloud API
 type ReadVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadVPCRouterParam return new ReadVPCRouterParam
@@ -500,6 +546,12 @@ func (p *ReadVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -542,6 +594,20 @@ func (p *ReadVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *ReadVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ReadVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -587,18 +653,20 @@ func (p *ReadVPCRouterParam) GetId() int64 {
 
 // UpdateVPCRouterParam is input parameters for the sacloud API
 type UpdateVPCRouterParam struct {
-	SyslogHost  string
-	Name        string
-	Description string
-	Tags        []string
-	IconId      int64
-	Assumeyes   bool
-	OutputType  string
-	Column      []string
-	Quiet       bool
-	Format      string
-	FormatFile  string
-	Id          int64
+	SyslogHost        string
+	Name              string
+	Description       string
+	Tags              []string
+	IconId            int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUpdateVPCRouterParam return new UpdateVPCRouterParam
@@ -655,6 +723,12 @@ func (p *UpdateVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -739,6 +813,20 @@ func (p *UpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *UpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UpdateVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -784,14 +872,16 @@ func (p *UpdateVPCRouterParam) GetId() int64 {
 
 // DeleteVPCRouterParam is input parameters for the sacloud API
 type DeleteVPCRouterParam struct {
-	Force      bool
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Force             bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDeleteVPCRouterParam return new DeleteVPCRouterParam
@@ -813,6 +903,12 @@ func (p *DeleteVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -869,6 +965,20 @@ func (p *DeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *DeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DeleteVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -914,8 +1024,10 @@ func (p *DeleteVPCRouterParam) GetId() int64 {
 
 // BootVPCRouterParam is input parameters for the sacloud API
 type BootVPCRouterParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewBootVPCRouterParam return new BootVPCRouterParam
@@ -972,6 +1084,20 @@ func (p *BootVPCRouterParam) SetAssumeyes(v bool) {
 func (p *BootVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *BootVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *BootVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *BootVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *BootVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *BootVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -982,8 +1108,10 @@ func (p *BootVPCRouterParam) GetId() int64 {
 
 // ShutdownVPCRouterParam is input parameters for the sacloud API
 type ShutdownVPCRouterParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownVPCRouterParam return new ShutdownVPCRouterParam
@@ -1040,6 +1168,20 @@ func (p *ShutdownVPCRouterParam) SetAssumeyes(v bool) {
 func (p *ShutdownVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1050,8 +1192,10 @@ func (p *ShutdownVPCRouterParam) GetId() int64 {
 
 // ShutdownForceVPCRouterParam is input parameters for the sacloud API
 type ShutdownForceVPCRouterParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewShutdownForceVPCRouterParam return new ShutdownForceVPCRouterParam
@@ -1108,6 +1252,20 @@ func (p *ShutdownForceVPCRouterParam) SetAssumeyes(v bool) {
 func (p *ShutdownForceVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ShutdownForceVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ShutdownForceVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ShutdownForceVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ShutdownForceVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ShutdownForceVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1118,8 +1276,10 @@ func (p *ShutdownForceVPCRouterParam) GetId() int64 {
 
 // ResetVPCRouterParam is input parameters for the sacloud API
 type ResetVPCRouterParam struct {
-	Assumeyes bool
-	Id        int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewResetVPCRouterParam return new ResetVPCRouterParam
@@ -1176,6 +1336,20 @@ func (p *ResetVPCRouterParam) SetAssumeyes(v bool) {
 func (p *ResetVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *ResetVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResetVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResetVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResetVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ResetVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1186,7 +1360,9 @@ func (p *ResetVPCRouterParam) GetId() int64 {
 
 // WaitForBootVPCRouterParam is input parameters for the sacloud API
 type WaitForBootVPCRouterParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForBootVPCRouterParam return new WaitForBootVPCRouterParam
@@ -1236,6 +1412,20 @@ func (p *WaitForBootVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForBootVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForBootVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForBootVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForBootVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForBootVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1246,7 +1436,9 @@ func (p *WaitForBootVPCRouterParam) GetId() int64 {
 
 // WaitForDownVPCRouterParam is input parameters for the sacloud API
 type WaitForDownVPCRouterParam struct {
-	Id int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewWaitForDownVPCRouterParam return new WaitForDownVPCRouterParam
@@ -1296,6 +1488,20 @@ func (p *WaitForDownVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *WaitForDownVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *WaitForDownVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *WaitForDownVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *WaitForDownVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *WaitForDownVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1306,12 +1512,14 @@ func (p *WaitForDownVPCRouterParam) GetId() int64 {
 
 // InterfaceInfoVPCRouterParam is input parameters for the sacloud API
 type InterfaceInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewInterfaceInfoVPCRouterParam return new InterfaceInfoVPCRouterParam
@@ -1333,6 +1541,12 @@ func (p *InterfaceInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1375,6 +1589,20 @@ func (p *InterfaceInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *InterfaceInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -1420,15 +1648,17 @@ func (p *InterfaceInfoVPCRouterParam) GetId() int64 {
 
 // InterfaceConnectVPCRouterParam is input parameters for the sacloud API
 type InterfaceConnectVPCRouterParam struct {
-	Index      string
-	Ipaddress  string
-	WithReboot bool
-	Ipaddress1 string
-	SwitchId   int64
-	Ipaddress2 string
-	NwMasklen  int
-	Assumeyes  bool
-	Id         int64
+	Index             string
+	Ipaddress         string
+	WithReboot        bool
+	Ipaddress1        string
+	SwitchId          int64
+	Ipaddress2        string
+	NwMasklen         int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceConnectVPCRouterParam return new InterfaceConnectVPCRouterParam
@@ -1600,6 +1830,20 @@ func (p *InterfaceConnectVPCRouterParam) SetAssumeyes(v bool) {
 func (p *InterfaceConnectVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceConnectVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceConnectVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceConnectVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceConnectVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceConnectVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1610,16 +1854,18 @@ func (p *InterfaceConnectVPCRouterParam) GetId() int64 {
 
 // InterfaceUpdateVPCRouterParam is input parameters for the sacloud API
 type InterfaceUpdateVPCRouterParam struct {
-	Index      string
-	Ipaddress  string
-	WithReboot bool
-	Ipaddress1 string
-	SwitchId   int64
-	Ipaddress2 string
-	Alias      []string
-	NwMasklen  int
-	Assumeyes  bool
-	Id         int64
+	Index             string
+	Ipaddress         string
+	WithReboot        bool
+	Ipaddress1        string
+	SwitchId          int64
+	Ipaddress2        string
+	Alias             []string
+	NwMasklen         int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceUpdateVPCRouterParam return new InterfaceUpdateVPCRouterParam
@@ -1791,6 +2037,20 @@ func (p *InterfaceUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *InterfaceUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1801,10 +2061,12 @@ func (p *InterfaceUpdateVPCRouterParam) GetId() int64 {
 
 // InterfaceDisconnectVPCRouterParam is input parameters for the sacloud API
 type InterfaceDisconnectVPCRouterParam struct {
-	Index      string
-	WithReboot bool
-	Assumeyes  bool
-	Id         int64
+	Index             string
+	WithReboot        bool
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewInterfaceDisconnectVPCRouterParam return new InterfaceDisconnectVPCRouterParam
@@ -1889,6 +2151,20 @@ func (p *InterfaceDisconnectVPCRouterParam) SetAssumeyes(v bool) {
 func (p *InterfaceDisconnectVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *InterfaceDisconnectVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *InterfaceDisconnectVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *InterfaceDisconnectVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *InterfaceDisconnectVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *InterfaceDisconnectVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1899,12 +2175,14 @@ func (p *InterfaceDisconnectVPCRouterParam) GetId() int64 {
 
 // StaticNatInfoVPCRouterParam is input parameters for the sacloud API
 type StaticNatInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewStaticNatInfoVPCRouterParam return new StaticNatInfoVPCRouterParam
@@ -1926,6 +2204,12 @@ func (p *StaticNatInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1968,6 +2252,20 @@ func (p *StaticNatInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *StaticNatInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticNatInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticNatInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticNatInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticNatInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -2013,11 +2311,13 @@ func (p *StaticNatInfoVPCRouterParam) GetId() int64 {
 
 // StaticNatAddVPCRouterParam is input parameters for the sacloud API
 type StaticNatAddVPCRouterParam struct {
-	Global      string
-	Private     string
-	Description string
-	Assumeyes   bool
-	Id          int64
+	Global            string
+	Private           string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewStaticNatAddVPCRouterParam return new StaticNatAddVPCRouterParam
@@ -2130,6 +2430,20 @@ func (p *StaticNatAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *StaticNatAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *StaticNatAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticNatAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticNatAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticNatAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticNatAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2140,12 +2454,14 @@ func (p *StaticNatAddVPCRouterParam) GetId() int64 {
 
 // StaticNatUpdateVPCRouterParam is input parameters for the sacloud API
 type StaticNatUpdateVPCRouterParam struct {
-	Index       int
-	Global      string
-	Private     string
-	Description string
-	Assumeyes   bool
-	Id          int64
+	Index             int
+	Global            string
+	Private           string
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewStaticNatUpdateVPCRouterParam return new StaticNatUpdateVPCRouterParam
@@ -2258,6 +2574,20 @@ func (p *StaticNatUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *StaticNatUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *StaticNatUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticNatUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticNatUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticNatUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticNatUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2268,9 +2598,11 @@ func (p *StaticNatUpdateVPCRouterParam) GetId() int64 {
 
 // StaticNatDeleteVPCRouterParam is input parameters for the sacloud API
 type StaticNatDeleteVPCRouterParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewStaticNatDeleteVPCRouterParam return new StaticNatDeleteVPCRouterParam
@@ -2341,6 +2673,20 @@ func (p *StaticNatDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *StaticNatDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *StaticNatDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticNatDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticNatDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticNatDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticNatDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2351,12 +2697,14 @@ func (p *StaticNatDeleteVPCRouterParam) GetId() int64 {
 
 // PortForwardingInfoVPCRouterParam is input parameters for the sacloud API
 type PortForwardingInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewPortForwardingInfoVPCRouterParam return new PortForwardingInfoVPCRouterParam
@@ -2378,6 +2726,12 @@ func (p *PortForwardingInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2420,6 +2774,20 @@ func (p *PortForwardingInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *PortForwardingInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PortForwardingInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PortForwardingInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PortForwardingInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PortForwardingInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -2465,13 +2833,15 @@ func (p *PortForwardingInfoVPCRouterParam) GetId() int64 {
 
 // PortForwardingAddVPCRouterParam is input parameters for the sacloud API
 type PortForwardingAddVPCRouterParam struct {
-	Protocol         string
-	GlobalPort       int
-	PrivateIpaddress string
-	PrivatePort      int
-	Description      string
-	Assumeyes        bool
-	Id               int64
+	Protocol          string
+	GlobalPort        int
+	PrivateIpaddress  string
+	PrivatePort       int
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewPortForwardingAddVPCRouterParam return new PortForwardingAddVPCRouterParam
@@ -2626,6 +2996,20 @@ func (p *PortForwardingAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *PortForwardingAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PortForwardingAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PortForwardingAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PortForwardingAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PortForwardingAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PortForwardingAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2636,14 +3020,16 @@ func (p *PortForwardingAddVPCRouterParam) GetId() int64 {
 
 // PortForwardingUpdateVPCRouterParam is input parameters for the sacloud API
 type PortForwardingUpdateVPCRouterParam struct {
-	Index            int
-	Protocol         string
-	GlobalPort       int
-	PrivateIpaddress string
-	PrivatePort      int
-	Description      string
-	Assumeyes        bool
-	Id               int64
+	Index             int
+	Protocol          string
+	GlobalPort        int
+	PrivateIpaddress  string
+	PrivatePort       int
+	Description       string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewPortForwardingUpdateVPCRouterParam return new PortForwardingUpdateVPCRouterParam
@@ -2784,6 +3170,20 @@ func (p *PortForwardingUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *PortForwardingUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PortForwardingUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PortForwardingUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PortForwardingUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PortForwardingUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PortForwardingUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2794,9 +3194,11 @@ func (p *PortForwardingUpdateVPCRouterParam) GetId() int64 {
 
 // PortForwardingDeleteVPCRouterParam is input parameters for the sacloud API
 type PortForwardingDeleteVPCRouterParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewPortForwardingDeleteVPCRouterParam return new PortForwardingDeleteVPCRouterParam
@@ -2867,6 +3269,20 @@ func (p *PortForwardingDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *PortForwardingDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PortForwardingDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PortForwardingDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PortForwardingDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PortForwardingDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PortForwardingDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2877,13 +3293,15 @@ func (p *PortForwardingDeleteVPCRouterParam) GetId() int64 {
 
 // FirewallInfoVPCRouterParam is input parameters for the sacloud API
 type FirewallInfoVPCRouterParam struct {
-	Direction  string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Direction         string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewFirewallInfoVPCRouterParam return new FirewallInfoVPCRouterParam
@@ -2922,6 +3340,12 @@ func (p *FirewallInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2970,6 +3394,20 @@ func (p *FirewallInfoVPCRouterParam) SetDirection(v string) {
 
 func (p *FirewallInfoVPCRouterParam) GetDirection() string {
 	return p.Direction
+}
+func (p *FirewallInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FirewallInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FirewallInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FirewallInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *FirewallInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
@@ -3026,6 +3464,8 @@ type FirewallAddVPCRouterParam struct {
 	EnableLogging      bool
 	Description        string
 	Assumeyes          bool
+	ParamTemplate      string
+	ParamTemplateFile  string
 	Id                 int64
 }
 
@@ -3228,6 +3668,20 @@ func (p *FirewallAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *FirewallAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *FirewallAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FirewallAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FirewallAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FirewallAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *FirewallAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3249,6 +3703,8 @@ type FirewallUpdateVPCRouterParam struct {
 	EnableLogging      bool
 	Description        string
 	Assumeyes          bool
+	ParamTemplate      string
+	ParamTemplateFile  string
 	Id                 int64
 }
 
@@ -3451,6 +3907,20 @@ func (p *FirewallUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *FirewallUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *FirewallUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FirewallUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FirewallUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FirewallUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *FirewallUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3461,10 +3931,12 @@ func (p *FirewallUpdateVPCRouterParam) GetId() int64 {
 
 // FirewallDeleteVPCRouterParam is input parameters for the sacloud API
 type FirewallDeleteVPCRouterParam struct {
-	Direction string
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Direction         string
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewFirewallDeleteVPCRouterParam return new FirewallDeleteVPCRouterParam
@@ -3559,6 +4031,20 @@ func (p *FirewallDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *FirewallDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *FirewallDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *FirewallDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *FirewallDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *FirewallDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *FirewallDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3569,12 +4055,14 @@ func (p *FirewallDeleteVPCRouterParam) GetId() int64 {
 
 // DhcpServerInfoVPCRouterParam is input parameters for the sacloud API
 type DhcpServerInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDhcpServerInfoVPCRouterParam return new DhcpServerInfoVPCRouterParam
@@ -3596,6 +4084,12 @@ func (p *DhcpServerInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3638,6 +4132,20 @@ func (p *DhcpServerInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *DhcpServerInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpServerInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpServerInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpServerInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpServerInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -3683,11 +4191,13 @@ func (p *DhcpServerInfoVPCRouterParam) GetId() int64 {
 
 // DhcpServerAddVPCRouterParam is input parameters for the sacloud API
 type DhcpServerAddVPCRouterParam struct {
-	Index      int
-	RangeStart string
-	RangeStop  string
-	Assumeyes  bool
-	Id         int64
+	Index             int
+	RangeStart        string
+	RangeStop         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDhcpServerAddVPCRouterParam return new DhcpServerAddVPCRouterParam
@@ -3807,6 +4317,20 @@ func (p *DhcpServerAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *DhcpServerAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DhcpServerAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpServerAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpServerAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpServerAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpServerAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3817,11 +4341,13 @@ func (p *DhcpServerAddVPCRouterParam) GetId() int64 {
 
 // DhcpServerUpdateVPCRouterParam is input parameters for the sacloud API
 type DhcpServerUpdateVPCRouterParam struct {
-	Index      int
-	RangeStart string
-	RangeStop  string
-	Assumeyes  bool
-	Id         int64
+	Index             int
+	RangeStart        string
+	RangeStop         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDhcpServerUpdateVPCRouterParam return new DhcpServerUpdateVPCRouterParam
@@ -3927,6 +4453,20 @@ func (p *DhcpServerUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *DhcpServerUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DhcpServerUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpServerUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpServerUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpServerUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpServerUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3937,9 +4477,11 @@ func (p *DhcpServerUpdateVPCRouterParam) GetId() int64 {
 
 // DhcpServerDeleteVPCRouterParam is input parameters for the sacloud API
 type DhcpServerDeleteVPCRouterParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDhcpServerDeleteVPCRouterParam return new DhcpServerDeleteVPCRouterParam
@@ -4017,6 +4559,20 @@ func (p *DhcpServerDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *DhcpServerDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DhcpServerDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpServerDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpServerDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpServerDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpServerDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4027,12 +4583,14 @@ func (p *DhcpServerDeleteVPCRouterParam) GetId() int64 {
 
 // DhcpStaticMappingInfoVPCRouterParam is input parameters for the sacloud API
 type DhcpStaticMappingInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewDhcpStaticMappingInfoVPCRouterParam return new DhcpStaticMappingInfoVPCRouterParam
@@ -4054,6 +4612,12 @@ func (p *DhcpStaticMappingInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4096,6 +4660,20 @@ func (p *DhcpStaticMappingInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *DhcpStaticMappingInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpStaticMappingInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpStaticMappingInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpStaticMappingInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpStaticMappingInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -4141,10 +4719,12 @@ func (p *DhcpStaticMappingInfoVPCRouterParam) GetId() int64 {
 
 // DhcpStaticMappingAddVPCRouterParam is input parameters for the sacloud API
 type DhcpStaticMappingAddVPCRouterParam struct {
-	Macaddress string
-	Ipaddress  string
-	Assumeyes  bool
-	Id         int64
+	Macaddress        string
+	Ipaddress         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDhcpStaticMappingAddVPCRouterParam return new DhcpStaticMappingAddVPCRouterParam
@@ -4243,6 +4823,20 @@ func (p *DhcpStaticMappingAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *DhcpStaticMappingAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DhcpStaticMappingAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpStaticMappingAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpStaticMappingAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpStaticMappingAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpStaticMappingAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4253,11 +4847,13 @@ func (p *DhcpStaticMappingAddVPCRouterParam) GetId() int64 {
 
 // DhcpStaticMappingUpdateVPCRouterParam is input parameters for the sacloud API
 type DhcpStaticMappingUpdateVPCRouterParam struct {
-	Index      int
-	Macaddress string
-	Ipaddress  string
-	Assumeyes  bool
-	Id         int64
+	Index             int
+	Macaddress        string
+	Ipaddress         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDhcpStaticMappingUpdateVPCRouterParam return new DhcpStaticMappingUpdateVPCRouterParam
@@ -4356,6 +4952,20 @@ func (p *DhcpStaticMappingUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *DhcpStaticMappingUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DhcpStaticMappingUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpStaticMappingUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpStaticMappingUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpStaticMappingUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpStaticMappingUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4366,9 +4976,11 @@ func (p *DhcpStaticMappingUpdateVPCRouterParam) GetId() int64 {
 
 // DhcpStaticMappingDeleteVPCRouterParam is input parameters for the sacloud API
 type DhcpStaticMappingDeleteVPCRouterParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewDhcpStaticMappingDeleteVPCRouterParam return new DhcpStaticMappingDeleteVPCRouterParam
@@ -4439,6 +5051,20 @@ func (p *DhcpStaticMappingDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *DhcpStaticMappingDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *DhcpStaticMappingDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DhcpStaticMappingDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DhcpStaticMappingDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DhcpStaticMappingDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *DhcpStaticMappingDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4449,12 +5075,14 @@ func (p *DhcpStaticMappingDeleteVPCRouterParam) GetId() int64 {
 
 // PptpServerInfoVPCRouterParam is input parameters for the sacloud API
 type PptpServerInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewPptpServerInfoVPCRouterParam return new PptpServerInfoVPCRouterParam
@@ -4476,6 +5104,12 @@ func (p *PptpServerInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4518,6 +5152,20 @@ func (p *PptpServerInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *PptpServerInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PptpServerInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PptpServerInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PptpServerInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PptpServerInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -4563,11 +5211,13 @@ func (p *PptpServerInfoVPCRouterParam) GetId() int64 {
 
 // PptpServerUpdateVPCRouterParam is input parameters for the sacloud API
 type PptpServerUpdateVPCRouterParam struct {
-	Enabled    string
-	RangeStart string
-	RangeStop  string
-	Assumeyes  bool
-	Id         int64
+	Enabled           string
+	RangeStart        string
+	RangeStop         string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewPptpServerUpdateVPCRouterParam return new PptpServerUpdateVPCRouterParam
@@ -4673,6 +5323,20 @@ func (p *PptpServerUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *PptpServerUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *PptpServerUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *PptpServerUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *PptpServerUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *PptpServerUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *PptpServerUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4683,12 +5347,14 @@ func (p *PptpServerUpdateVPCRouterParam) GetId() int64 {
 
 // L2tpServerInfoVPCRouterParam is input parameters for the sacloud API
 type L2tpServerInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewL2tpServerInfoVPCRouterParam return new L2tpServerInfoVPCRouterParam
@@ -4710,6 +5376,12 @@ func (p *L2tpServerInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4752,6 +5424,20 @@ func (p *L2tpServerInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *L2tpServerInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *L2tpServerInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *L2tpServerInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *L2tpServerInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *L2tpServerInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -4797,12 +5483,14 @@ func (p *L2tpServerInfoVPCRouterParam) GetId() int64 {
 
 // L2tpServerUpdateVPCRouterParam is input parameters for the sacloud API
 type L2tpServerUpdateVPCRouterParam struct {
-	Enabled         string
-	RangeStart      string
-	RangeStop       string
-	PreSharedSecret string
-	Assumeyes       bool
-	Id              int64
+	Enabled           string
+	RangeStart        string
+	RangeStop         string
+	PreSharedSecret   string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewL2tpServerUpdateVPCRouterParam return new L2tpServerUpdateVPCRouterParam
@@ -4922,6 +5610,20 @@ func (p *L2tpServerUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *L2tpServerUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *L2tpServerUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *L2tpServerUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *L2tpServerUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *L2tpServerUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *L2tpServerUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4932,12 +5634,14 @@ func (p *L2tpServerUpdateVPCRouterParam) GetId() int64 {
 
 // UserInfoVPCRouterParam is input parameters for the sacloud API
 type UserInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewUserInfoVPCRouterParam return new UserInfoVPCRouterParam
@@ -4959,6 +5663,12 @@ func (p *UserInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5001,6 +5711,20 @@ func (p *UserInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *UserInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UserInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UserInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UserInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UserInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -5046,10 +5770,12 @@ func (p *UserInfoVPCRouterParam) GetId() int64 {
 
 // UserAddVPCRouterParam is input parameters for the sacloud API
 type UserAddVPCRouterParam struct {
-	Username  string
-	Password  string
-	Assumeyes bool
-	Id        int64
+	Username          string
+	Password          string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewUserAddVPCRouterParam return new UserAddVPCRouterParam
@@ -5148,6 +5874,20 @@ func (p *UserAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *UserAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UserAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UserAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UserAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UserAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UserAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5158,11 +5898,13 @@ func (p *UserAddVPCRouterParam) GetId() int64 {
 
 // UserUpdateVPCRouterParam is input parameters for the sacloud API
 type UserUpdateVPCRouterParam struct {
-	Index     int
-	Username  string
-	Password  string
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Username          string
+	Password          string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewUserUpdateVPCRouterParam return new UserUpdateVPCRouterParam
@@ -5261,6 +6003,20 @@ func (p *UserUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *UserUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UserUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UserUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UserUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UserUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UserUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5271,9 +6027,11 @@ func (p *UserUpdateVPCRouterParam) GetId() int64 {
 
 // UserDeleteVPCRouterParam is input parameters for the sacloud API
 type UserDeleteVPCRouterParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewUserDeleteVPCRouterParam return new UserDeleteVPCRouterParam
@@ -5344,6 +6102,20 @@ func (p *UserDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *UserDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *UserDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *UserDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *UserDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *UserDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *UserDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5354,12 +6126,14 @@ func (p *UserDeleteVPCRouterParam) GetId() int64 {
 
 // SiteToSiteVpnInfoVPCRouterParam is input parameters for the sacloud API
 type SiteToSiteVpnInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewSiteToSiteVpnInfoVPCRouterParam return new SiteToSiteVpnInfoVPCRouterParam
@@ -5381,6 +6155,12 @@ func (p *SiteToSiteVpnInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5423,6 +6203,20 @@ func (p *SiteToSiteVpnInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *SiteToSiteVpnInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SiteToSiteVpnInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SiteToSiteVpnInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SiteToSiteVpnInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *SiteToSiteVpnInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -5468,13 +6262,15 @@ func (p *SiteToSiteVpnInfoVPCRouterParam) GetId() int64 {
 
 // SiteToSiteVpnAddVPCRouterParam is input parameters for the sacloud API
 type SiteToSiteVpnAddVPCRouterParam struct {
-	Peer            string
-	RemoteId        string
-	PreSharedSecret string
-	Routes          []string
-	LocalPrefix     []string
-	Assumeyes       bool
-	Id              int64
+	Peer              string
+	RemoteId          string
+	PreSharedSecret   string
+	Routes            []string
+	LocalPrefix       []string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewSiteToSiteVpnAddVPCRouterParam return new SiteToSiteVpnAddVPCRouterParam
@@ -5629,6 +6425,20 @@ func (p *SiteToSiteVpnAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *SiteToSiteVpnAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *SiteToSiteVpnAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SiteToSiteVpnAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SiteToSiteVpnAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SiteToSiteVpnAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *SiteToSiteVpnAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5639,14 +6449,16 @@ func (p *SiteToSiteVpnAddVPCRouterParam) GetId() int64 {
 
 // SiteToSiteVpnUpdateVPCRouterParam is input parameters for the sacloud API
 type SiteToSiteVpnUpdateVPCRouterParam struct {
-	Index           int
-	Peer            string
-	RemoteId        string
-	PreSharedSecret string
-	Routes          []string
-	LocalPrefix     []string
-	Assumeyes       bool
-	Id              int64
+	Index             int
+	Peer              string
+	RemoteId          string
+	PreSharedSecret   string
+	Routes            []string
+	LocalPrefix       []string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewSiteToSiteVpnUpdateVPCRouterParam return new SiteToSiteVpnUpdateVPCRouterParam
@@ -5780,6 +6592,20 @@ func (p *SiteToSiteVpnUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *SiteToSiteVpnUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *SiteToSiteVpnUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SiteToSiteVpnUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SiteToSiteVpnUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SiteToSiteVpnUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *SiteToSiteVpnUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5790,9 +6616,11 @@ func (p *SiteToSiteVpnUpdateVPCRouterParam) GetId() int64 {
 
 // SiteToSiteVpnDeleteVPCRouterParam is input parameters for the sacloud API
 type SiteToSiteVpnDeleteVPCRouterParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewSiteToSiteVpnDeleteVPCRouterParam return new SiteToSiteVpnDeleteVPCRouterParam
@@ -5863,6 +6691,20 @@ func (p *SiteToSiteVpnDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *SiteToSiteVpnDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *SiteToSiteVpnDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SiteToSiteVpnDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SiteToSiteVpnDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SiteToSiteVpnDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *SiteToSiteVpnDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5873,12 +6715,14 @@ func (p *SiteToSiteVpnDeleteVPCRouterParam) GetId() int64 {
 
 // StaticRouteInfoVPCRouterParam is input parameters for the sacloud API
 type StaticRouteInfoVPCRouterParam struct {
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewStaticRouteInfoVPCRouterParam return new StaticRouteInfoVPCRouterParam
@@ -5900,6 +6744,12 @@ func (p *StaticRouteInfoVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5942,6 +6792,20 @@ func (p *StaticRouteInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *StaticRouteInfoVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticRouteInfoVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticRouteInfoVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticRouteInfoVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticRouteInfoVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -5987,10 +6851,12 @@ func (p *StaticRouteInfoVPCRouterParam) GetId() int64 {
 
 // StaticRouteAddVPCRouterParam is input parameters for the sacloud API
 type StaticRouteAddVPCRouterParam struct {
-	Prefix    string
-	NextHop   string
-	Assumeyes bool
-	Id        int64
+	Prefix            string
+	NextHop           string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewStaticRouteAddVPCRouterParam return new StaticRouteAddVPCRouterParam
@@ -6089,6 +6955,20 @@ func (p *StaticRouteAddVPCRouterParam) SetAssumeyes(v bool) {
 func (p *StaticRouteAddVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *StaticRouteAddVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticRouteAddVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticRouteAddVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticRouteAddVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticRouteAddVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -6099,11 +6979,13 @@ func (p *StaticRouteAddVPCRouterParam) GetId() int64 {
 
 // StaticRouteUpdateVPCRouterParam is input parameters for the sacloud API
 type StaticRouteUpdateVPCRouterParam struct {
-	Index     int
-	Prefix    string
-	NextHop   string
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Prefix            string
+	NextHop           string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewStaticRouteUpdateVPCRouterParam return new StaticRouteUpdateVPCRouterParam
@@ -6202,6 +7084,20 @@ func (p *StaticRouteUpdateVPCRouterParam) SetAssumeyes(v bool) {
 func (p *StaticRouteUpdateVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *StaticRouteUpdateVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticRouteUpdateVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticRouteUpdateVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticRouteUpdateVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticRouteUpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -6212,9 +7108,11 @@ func (p *StaticRouteUpdateVPCRouterParam) GetId() int64 {
 
 // StaticRouteDeleteVPCRouterParam is input parameters for the sacloud API
 type StaticRouteDeleteVPCRouterParam struct {
-	Index     int
-	Assumeyes bool
-	Id        int64
+	Index             int
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	Id                int64
 }
 
 // NewStaticRouteDeleteVPCRouterParam return new StaticRouteDeleteVPCRouterParam
@@ -6285,6 +7183,20 @@ func (p *StaticRouteDeleteVPCRouterParam) SetAssumeyes(v bool) {
 func (p *StaticRouteDeleteVPCRouterParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
+func (p *StaticRouteDeleteVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticRouteDeleteVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticRouteDeleteVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticRouteDeleteVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *StaticRouteDeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -6295,16 +7207,18 @@ func (p *StaticRouteDeleteVPCRouterParam) GetId() int64 {
 
 // MonitorVPCRouterParam is input parameters for the sacloud API
 type MonitorVPCRouterParam struct {
-	Index      string
-	Start      string
-	End        string
-	KeyFormat  string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Index             string
+	Start             string
+	End               string
+	KeyFormat         string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewMonitorVPCRouterParam return new MonitorVPCRouterParam
@@ -6366,6 +7280,12 @@ func (p *MonitorVPCRouterParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6435,6 +7355,20 @@ func (p *MonitorVPCRouterParam) SetKeyFormat(v string) {
 
 func (p *MonitorVPCRouterParam) GetKeyFormat() string {
 	return p.KeyFormat
+}
+func (p *MonitorVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MonitorVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MonitorVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MonitorVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *MonitorVPCRouterParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_web_accel_gen.go
+++ b/command/params/params_web_accel_gen.go
@@ -10,12 +10,14 @@ import (
 
 // DeleteCacheWebAccelParam is input parameters for the sacloud API
 type DeleteCacheWebAccelParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewDeleteCacheWebAccelParam return new DeleteCacheWebAccelParam
@@ -30,6 +32,12 @@ func (p *DeleteCacheWebAccelParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -78,6 +86,20 @@ func (p *DeleteCacheWebAccelParam) SetAssumeyes(v bool) {
 
 func (p *DeleteCacheWebAccelParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *DeleteCacheWebAccelParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DeleteCacheWebAccelParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DeleteCacheWebAccelParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DeleteCacheWebAccelParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *DeleteCacheWebAccelParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/params_zone_gen.go
+++ b/command/params/params_zone_gen.go
@@ -10,16 +10,18 @@ import (
 
 // ListZoneParam is input parameters for the sacloud API
 type ListZoneParam struct {
-	Name       []string
-	Id         []int64
-	From       int
-	Max        int
-	Sort       []string
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
+	Name              []string
+	Id                []int64
+	From              int
+	Max               int
+	Sort              []string
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
 }
 
 // NewListZoneParam return new ListZoneParam
@@ -59,6 +61,12 @@ func (p *ListZoneParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -136,6 +144,20 @@ func (p *ListZoneParam) SetSort(v []string) {
 func (p *ListZoneParam) GetSort() []string {
 	return p.Sort
 }
+func (p *ListZoneParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ListZoneParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ListZoneParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ListZoneParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
 func (p *ListZoneParam) SetOutputType(v string) {
 	p.OutputType = v
 }
@@ -174,13 +196,15 @@ func (p *ListZoneParam) GetFormatFile() string {
 
 // ReadZoneParam is input parameters for the sacloud API
 type ReadZoneParam struct {
-	Assumeyes  bool
-	OutputType string
-	Column     []string
-	Quiet      bool
-	Format     string
-	FormatFile string
-	Id         int64
+	Assumeyes         bool
+	ParamTemplate     string
+	ParamTemplateFile string
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+	Id                int64
 }
 
 // NewReadZoneParam return new ReadZoneParam
@@ -209,6 +233,12 @@ func (p *ReadZoneParam) Validate() []error {
 	{
 		validator := schema.ValidateInStrValues("json", "csv", "tsv")
 		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -257,6 +287,20 @@ func (p *ReadZoneParam) SetAssumeyes(v bool) {
 
 func (p *ReadZoneParam) GetAssumeyes() bool {
 	return p.Assumeyes
+}
+func (p *ReadZoneParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ReadZoneParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ReadZoneParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ReadZoneParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
 }
 func (p *ReadZoneParam) SetOutputType(v string) {
 	p.OutputType = v

--- a/command/params/validators.go
+++ b/command/params/validators.go
@@ -36,3 +36,7 @@ func validateBetween(fieldName string, object interface{}, min int, max int) []e
 func validateOutputOption(o output.Option) []error {
 	return command.ValidateOutputOption(o)
 }
+
+func validateInputOption(o command.InputOption) []error {
+	return command.ValidateInputOption(o)
+}

--- a/schema/command.go
+++ b/schema/command.go
@@ -84,7 +84,7 @@ func (c *Command) BuildedParams() SortableParams {
 			c.Params["id"] = &Schema{
 				Type:        TypeInt64,
 				HandlerType: HandlerPathThrough,
-				Description: "set target ID",
+				Description: "Set target ID",
 				SakuraID:    true,
 				Hidden:      true,
 			}
@@ -96,13 +96,33 @@ func (c *Command) BuildedParams() SortableParams {
 			c.Params["assumeyes"] = &Schema{
 				Type:        TypeBool,
 				HandlerType: HandlerNoop,
-				Description: "assume that the answer to any question which would be asked is yes",
+				Description: "Assume that the answer to any question which would be asked is yes",
 				Category:    "input",
 				Order:       10,
 				Aliases:     []string{"y"},
 			}
 		}
 	}
+
+	if _, ok := c.Params["param-template"]; !ok {
+		c.Params["param-template"] = &Schema{
+			Type:        TypeString,
+			HandlerType: HandlerNoop,
+			Description: "Set input parameter from string(JSON)",
+			Category:    "input",
+			Order:       20,
+		}
+	}
+	if _, ok := c.Params["param-template-file"]; !ok {
+		c.Params["param-template-file"] = &Schema{
+			Type:        TypeString,
+			HandlerType: HandlerNoop,
+			Description: "Set input parameter from file",
+			Category:    "input",
+			Order:       30,
+		}
+	}
+
 	if !c.NoOutput {
 		if _, ok := c.Params["output-type"]; !ok {
 			c.Params["output-type"] = &Schema{

--- a/tools/gen-input-models/main.go
+++ b/tools/gen-input-models/main.go
@@ -316,6 +316,12 @@ func (p *{{.Name}}) Validate() []error{
 		}
 	}
 	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors , errs...)
+		}
+	}
+	{
 		errs := validateOutputOption(p)
 		if errs != nil {
 			errors = append(errors , errs...)

--- a/vendor/github.com/imdario/mergo/LICENSE
+++ b/vendor/github.com/imdario/mergo/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2013 Dario Castañé. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/imdario/mergo/README.md
+++ b/vendor/github.com/imdario/mergo/README.md
@@ -1,0 +1,141 @@
+# Mergo
+
+A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
+
+Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the Province of Ancona in the Italian region Marche.
+
+![Mergo dall'alto](http://www.comune.mergo.an.it/Siti/Mergo/Immagini/Foto/mergo_dall_alto.jpg)
+
+## Status
+
+It is ready for production use. It works fine after extensive use in the wild.
+
+[![Build Status][1]][2]
+[![GoDoc][3]][4]
+[![GoCard][5]][6]
+
+[1]: https://travis-ci.org/imdario/mergo.png
+[2]: https://travis-ci.org/imdario/mergo
+[3]: https://godoc.org/github.com/imdario/mergo?status.svg
+[4]: https://godoc.org/github.com/imdario/mergo
+[5]: https://goreportcard.com/badge/imdario/mergo
+[6]: https://goreportcard.com/report/github.com/imdario/mergo
+
+### Important note
+
+Mergo is intended to assign **only** zero value fields on destination with source value. Since April 6th it works like this. Before it didn't work properly, causing some random overwrites. After some issues and PRs I found it didn't merge as I designed it. Thanks to [imdario/mergo#8](https://github.com/imdario/mergo/pull/8) overwriting functions were added and the wrong behavior was clearly detected.
+
+If you were using Mergo **before** April 6th 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause (I hope it won't!) in existing projects after the change (release 0.2.0).
+
+### Mergo in the wild
+
+- [docker/docker](https://github.com/docker/docker/)
+- [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+- [imdario/zas](https://github.com/imdario/zas)
+- [soniah/dnsmadeeasy](https://github.com/soniah/dnsmadeeasy)
+- [EagerIO/Stout](https://github.com/EagerIO/Stout)
+- [lynndylanhurley/defsynth-api](https://github.com/lynndylanhurley/defsynth-api)
+- [russross/canvasassignments](https://github.com/russross/canvasassignments)
+- [rdegges/cryptly-api](https://github.com/rdegges/cryptly-api)
+- [casualjim/exeggutor](https://github.com/casualjim/exeggutor)
+- [divshot/gitling](https://github.com/divshot/gitling)
+- [RWJMurphy/gorl](https://github.com/RWJMurphy/gorl)
+- [andrerocker/deploy42](https://github.com/andrerocker/deploy42)
+- [elwinar/rambler](https://github.com/elwinar/rambler)
+- [tmaiaroto/gopartman](https://github.com/tmaiaroto/gopartman)
+- [jfbus/impressionist](https://github.com/jfbus/impressionist)
+- [Jmeyering/zealot](https://github.com/Jmeyering/zealot)
+- [godep-migrator/rigger-host](https://github.com/godep-migrator/rigger-host)
+- [Dronevery/MultiwaySwitch-Go](https://github.com/Dronevery/MultiwaySwitch-Go)
+- [thoas/picfit](https://github.com/thoas/picfit)
+- [mantasmatelis/whooplist-server](https://github.com/mantasmatelis/whooplist-server)
+- [jnuthong/item_search](https://github.com/jnuthong/item_search)
+- [Iris Web Framework](https://github.com/kataras/iris)
+
+## Installation
+
+    go get github.com/imdario/mergo
+
+    // use in your .go code
+    import (
+        "github.com/imdario/mergo"
+    )
+
+## Usage
+
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
+
+```go
+if err := mergo.Merge(&dst, src); err != nil {
+    // ...
+}
+```
+
+Also, you can merge overwriting values using MergeWithOverwrite.
+
+```go
+if err := mergo.MergeWithOverwrite(&dst, src); err != nil {
+    // ...
+}
+```
+
+Additionally, you can map a map[string]interface{} to a struct (and otherwise, from struct to map), following the same restrictions as in Merge(). Keys are capitalized to find each corresponding exported field.
+
+```go
+if err := mergo.Map(&dst, srcMap); err != nil {
+    // ...
+}
+```
+
+Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as map[string]interface{}. They will be just assigned as values.
+
+More information and examples in [godoc documentation](http://godoc.org/github.com/imdario/mergo).
+
+### Nice example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/imdario/mergo"
+)
+
+type Foo struct {
+	A string
+	B int64
+}
+
+func main() {
+	src := Foo{
+		A: "one",
+		B: 2,
+	}
+
+	dest := Foo{
+		A: "two",
+	}
+
+	mergo.Merge(&dest, src)
+
+	fmt.Println(dest)
+	// Will print
+	// {two 2}
+}
+```
+
+Note: if test are failing due missing package, please execute:
+
+    go get gopkg.in/yaml.v1
+
+## Contact me
+
+If I can help you, you have an idea or you are using Mergo in your projects, don't hesitate to drop me a line (or a pull request): [@im_dario](https://twitter.com/im_dario)
+
+## About
+
+Written by [Dario Castañé](http://dario.im).
+
+## License
+
+[BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause) license, as [Go language](http://golang.org/LICENSE).

--- a/vendor/github.com/imdario/mergo/doc.go
+++ b/vendor/github.com/imdario/mergo/doc.go
@@ -1,0 +1,44 @@
+// Copyright 2013 Dario Castañé. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package mergo merges same-type structs and maps by setting default values in zero-value fields.
+
+Mergo won't merge unexported (private) fields but will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+
+Usage
+
+From my own work-in-progress project:
+
+	type networkConfig struct {
+		Protocol string
+		Address string
+		ServerType string `json: "server_type"`
+		Port uint16
+	}
+
+	type FssnConfig struct {
+		Network networkConfig
+	}
+
+	var fssnDefault = FssnConfig {
+		networkConfig {
+			"tcp",
+			"127.0.0.1",
+			"http",
+			31560,
+		},
+	}
+
+	// Inside a function [...]
+
+	if err := mergo.Merge(&config, fssnDefault); err != nil {
+		log.Fatal(err)
+	}
+
+	// More code [...]
+
+*/
+package mergo

--- a/vendor/github.com/imdario/mergo/map.go
+++ b/vendor/github.com/imdario/mergo/map.go
@@ -1,0 +1,156 @@
+// Copyright 2014 Dario Castañé. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Based on src/pkg/reflect/deepequal.go from official
+// golang's stdlib.
+
+package mergo
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+)
+
+func changeInitialCase(s string, mapper func(rune) rune) string {
+	if s == "" {
+		return s
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(mapper(r)) + s[n:]
+}
+
+func isExported(field reflect.StructField) bool {
+	r, _ := utf8.DecodeRuneInString(field.Name)
+	return r >= 'A' && r <= 'Z'
+}
+
+// Traverses recursively both values, assigning src's fields values to dst.
+// The map argument tracks comparisons that have already been seen, which allows
+// short circuiting on recursive types.
+func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, overwrite bool) (err error) {
+	if dst.CanAddr() {
+		addr := dst.UnsafeAddr()
+		h := 17 * addr
+		seen := visited[h]
+		typ := dst.Type()
+		for p := seen; p != nil; p = p.next {
+			if p.ptr == addr && p.typ == typ {
+				return nil
+			}
+		}
+		// Remember, remember...
+		visited[h] = &visit{addr, typ, seen}
+	}
+	zeroValue := reflect.Value{}
+	switch dst.Kind() {
+	case reflect.Map:
+		dstMap := dst.Interface().(map[string]interface{})
+		for i, n := 0, src.NumField(); i < n; i++ {
+			srcType := src.Type()
+			field := srcType.Field(i)
+			if !isExported(field) {
+				continue
+			}
+			fieldName := field.Name
+			fieldName = changeInitialCase(fieldName, unicode.ToLower)
+			if v, ok := dstMap[fieldName]; !ok || (isEmptyValue(reflect.ValueOf(v)) || overwrite) {
+				dstMap[fieldName] = src.Field(i).Interface()
+			}
+		}
+	case reflect.Struct:
+		srcMap := src.Interface().(map[string]interface{})
+		for key := range srcMap {
+			srcValue := srcMap[key]
+			fieldName := changeInitialCase(key, unicode.ToUpper)
+			dstElement := dst.FieldByName(fieldName)
+			if dstElement == zeroValue {
+				// We discard it because the field doesn't exist.
+				continue
+			}
+			srcElement := reflect.ValueOf(srcValue)
+			dstKind := dstElement.Kind()
+			srcKind := srcElement.Kind()
+			if srcKind == reflect.Ptr && dstKind != reflect.Ptr {
+				srcElement = srcElement.Elem()
+				srcKind = reflect.TypeOf(srcElement.Interface()).Kind()
+			} else if dstKind == reflect.Ptr {
+				// Can this work? I guess it can't.
+				if srcKind != reflect.Ptr && srcElement.CanAddr() {
+					srcPtr := srcElement.Addr()
+					srcElement = reflect.ValueOf(srcPtr)
+					srcKind = reflect.Ptr
+				}
+			}
+			if !srcElement.IsValid() {
+				continue
+			}
+			if srcKind == dstKind {
+				if err = deepMerge(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
+					return
+				}
+			} else {
+				if srcKind == reflect.Map {
+					if err = deepMap(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
+						return
+					}
+				} else {
+					return fmt.Errorf("type mismatch on %s field: found %v, expected %v", fieldName, srcKind, dstKind)
+				}
+			}
+		}
+	}
+	return
+}
+
+// Map sets fields' values in dst from src.
+// src can be a map with string keys or a struct. dst must be the opposite:
+// if src is a map, dst must be a valid pointer to struct. If src is a struct,
+// dst must be map[string]interface{}.
+// It won't merge unexported (private) fields and will do recursively
+// any exported field.
+// If dst is a map, keys will be src fields' names in lower camel case.
+// Missing key in src that doesn't match a field in dst will be skipped. This
+// doesn't apply if dst is a map.
+// This is separated method from Merge because it is cleaner and it keeps sane
+// semantics: merging equal types, mapping different (restricted) types.
+func Map(dst, src interface{}) error {
+	return _map(dst, src, false)
+}
+
+// MapWithOverwrite will do the same as Map except that non-empty dst attributes will be overriden by
+// non-empty src attribute values.
+func MapWithOverwrite(dst, src interface{}) error {
+	return _map(dst, src, true)
+}
+
+func _map(dst, src interface{}, overwrite bool) error {
+	var (
+		vDst, vSrc reflect.Value
+		err        error
+	)
+	if vDst, vSrc, err = resolveValues(dst, src); err != nil {
+		return err
+	}
+	// To be friction-less, we redirect equal-type arguments
+	// to deepMerge. Only because arguments can be anything.
+	if vSrc.Kind() == vDst.Kind() {
+		return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
+	}
+	switch vSrc.Kind() {
+	case reflect.Struct:
+		if vDst.Kind() != reflect.Map {
+			return ErrExpectedMapAsDestination
+		}
+	case reflect.Map:
+		if vDst.Kind() != reflect.Struct {
+			return ErrExpectedStructAsDestination
+		}
+	default:
+		return ErrNotSupported
+	}
+	return deepMap(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
+}

--- a/vendor/github.com/imdario/mergo/merge.go
+++ b/vendor/github.com/imdario/mergo/merge.go
@@ -1,0 +1,123 @@
+// Copyright 2013 Dario Castañé. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Based on src/pkg/reflect/deepequal.go from official
+// golang's stdlib.
+
+package mergo
+
+import (
+	"reflect"
+)
+
+// Traverses recursively both values, assigning src's fields values to dst.
+// The map argument tracks comparisons that have already been seen, which allows
+// short circuiting on recursive types.
+func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, overwrite bool) (err error) {
+	if !src.IsValid() {
+		return
+	}
+	if dst.CanAddr() {
+		addr := dst.UnsafeAddr()
+		h := 17 * addr
+		seen := visited[h]
+		typ := dst.Type()
+		for p := seen; p != nil; p = p.next {
+			if p.ptr == addr && p.typ == typ {
+				return nil
+			}
+		}
+		// Remember, remember...
+		visited[h] = &visit{addr, typ, seen}
+	}
+	switch dst.Kind() {
+	case reflect.Struct:
+		for i, n := 0, dst.NumField(); i < n; i++ {
+			if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, overwrite); err != nil {
+				return
+			}
+		}
+	case reflect.Map:
+		for _, key := range src.MapKeys() {
+			srcElement := src.MapIndex(key)
+			if !srcElement.IsValid() {
+				continue
+			}
+			dstElement := dst.MapIndex(key)
+			switch srcElement.Kind() {
+			case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+				if srcElement.IsNil() {
+					continue
+				}
+				fallthrough
+			default:
+				if !srcElement.CanInterface() {
+					continue
+				}
+				switch reflect.TypeOf(srcElement.Interface()).Kind() {
+				case reflect.Struct:
+					fallthrough
+				case reflect.Ptr:
+					fallthrough
+				case reflect.Map:
+					if err = deepMerge(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
+						return
+					}
+				}
+			}
+			if !isEmptyValue(srcElement) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
+				if dst.IsNil() {
+					dst.Set(reflect.MakeMap(dst.Type()))
+				}
+				dst.SetMapIndex(key, srcElement)
+			}
+		}
+	case reflect.Ptr:
+		fallthrough
+	case reflect.Interface:
+		if src.IsNil() {
+			break
+		} else if dst.IsNil() || overwrite {
+			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+				dst.Set(src)
+			}
+		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, overwrite); err != nil {
+			return
+		}
+	default:
+		if dst.CanSet() && !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) {
+			dst.Set(src)
+		}
+	}
+	return
+}
+
+// Merge will fill any empty for value type attributes on the dst struct using corresponding
+// src attributes if they themselves are not empty. dst and src must be valid same-type structs
+// and dst must be a pointer to struct.
+// It won't merge unexported (private) fields and will do recursively any exported field.
+func Merge(dst, src interface{}) error {
+	return merge(dst, src, false)
+}
+
+// MergeWithOverwrite will do the same as Merge except that non-empty dst attributes will be overriden by
+// non-empty src attribute values.
+func MergeWithOverwrite(dst, src interface{}) error {
+	return merge(dst, src, true)
+}
+
+func merge(dst, src interface{}, overwrite bool) error {
+	var (
+		vDst, vSrc reflect.Value
+		err        error
+	)
+	if vDst, vSrc, err = resolveValues(dst, src); err != nil {
+		return err
+	}
+	if vDst.Type() != vSrc.Type() {
+		return ErrDifferentArgumentsTypes
+	}
+	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
+}

--- a/vendor/github.com/imdario/mergo/mergo.go
+++ b/vendor/github.com/imdario/mergo/mergo.go
@@ -1,0 +1,90 @@
+// Copyright 2013 Dario Castañé. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Based on src/pkg/reflect/deepequal.go from official
+// golang's stdlib.
+
+package mergo
+
+import (
+	"errors"
+	"reflect"
+)
+
+// Errors reported by Mergo when it finds invalid arguments.
+var (
+	ErrNilArguments                = errors.New("src and dst must not be nil")
+	ErrDifferentArgumentsTypes     = errors.New("src and dst must be of same type")
+	ErrNotSupported                = errors.New("only structs and maps are supported")
+	ErrExpectedMapAsDestination    = errors.New("dst was expected to be a map")
+	ErrExpectedStructAsDestination = errors.New("dst was expected to be a struct")
+)
+
+// During deepMerge, must keep track of checks that are
+// in progress.  The comparison algorithm assumes that all
+// checks in progress are true when it reencounters them.
+// Visited are stored in a map indexed by 17 * a1 + a2;
+type visit struct {
+	ptr  uintptr
+	typ  reflect.Type
+	next *visit
+}
+
+// From src/pkg/encoding/json.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func resolveValues(dst, src interface{}) (vDst, vSrc reflect.Value, err error) {
+	if dst == nil || src == nil {
+		err = ErrNilArguments
+		return
+	}
+	vDst = reflect.ValueOf(dst).Elem()
+	if vDst.Kind() != reflect.Struct && vDst.Kind() != reflect.Map {
+		err = ErrNotSupported
+		return
+	}
+	vSrc = reflect.ValueOf(src)
+	// We check if vSrc is a pointer to dereference it.
+	if vSrc.Kind() == reflect.Ptr {
+		vSrc = vSrc.Elem()
+	}
+	return
+}
+
+// Traverses recursively both values, assigning src's fields values to dst.
+// The map argument tracks comparisons that have already been seen, which allows
+// short circuiting on recursive types.
+func deeper(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
+	if dst.CanAddr() {
+		addr := dst.UnsafeAddr()
+		h := 17 * addr
+		seen := visited[h]
+		typ := dst.Type()
+		for p := seen; p != nil; p = p.next {
+			if p.ptr == addr && p.typ == typ {
+				return nil
+			}
+		}
+		// Remember, remember...
+		visited[h] = &visit{addr, typ, seen}
+	}
+	return // TODO refactor
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,6 +39,12 @@
 			"revisionTime": "2015-11-30T12:51:19Z"
 		},
 		{
+			"checksumSHA1": "VBXGouqOkPe3OkeJnyUBkx3aZXA=",
+			"path": "github.com/imdario/mergo",
+			"revision": "d806ba8c21777d504a2090a2ca4913c750dd3a33",
+			"revisionTime": "2017-03-26T20:45:27Z"
+		},
+		{
 			"checksumSHA1": "BOFetxMdGQVex14gI977F2aI9sM=",
 			"path": "github.com/mattn/go-colorable",
 			"revision": "a392f450ea64cee2b268dfaacdc2502b50a22b18",


### PR DESCRIPTION
To fix #147 

---

各コマンドのオプションをファイルなどから与えられるようにする。  
ファイルで与えた値はコマンドラインオプションで上書き可能とする。  

#### 追加するオプション

- `--param-template-file` :  パラメータを記載したJSONファイルで与える
- `--param-template`        : パラメータをJSON文字列で与える


#### 利用方法

```console
#あからじめパラメータを格納したJSONファイルを作成しておく
$ cat switch.json
{
    "Name": "from_json",
    "Description": "description",
    "Tags": [
        "tag1",
        "tag2"
    ]
}

#パラメータファイルを指定してコマンド実行
$ usacloud switch create --param-template-file switch.json

#コマンドラインオプションで上書きもできる
$ usacloud switch create --param-template-file switch.json --name overwrite_json

#直接JSON文字列を指定することも可能
$ usacloud switch create --param-template "`cat switch.json`"

```