### PR TITLE
Release version 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.11 (2017-06-14)
+
+* linuxbrew対応 #138 (yamamoto-febc)
+* --format-fileオプションの追加 #139 (yamamoto-febc)
+* ビルド時にGo1.8(latest)を利用 #140 (yamamoto-febc)
+* Windows上でのgo generate対応 #144 (yamamoto-febc)
+* go generateで生成されるファイルの整理 #145 (yamamoto-febc)
+* コピー元アーカイブ/ディスクID検索パラメータ追加 #146 (yamamoto-febc)
+* コマンドパラメータのテンプレート対応 #149 (yamamoto-febc)
+* パラメータファイルのスケルトン出力機能 #150 (yamamoto-febc)
+
+
 ## 0.0.10 (2017-06-12)
 
 * VNCコマンドへサーバ起動待ち用オプション追加 #130 (yamamoto-febc)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright (C) 2017 Kazumichi Yamamoto.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package/deb/debian/changelog
+++ b/package/deb/debian/changelog
@@ -1,3 +1,24 @@
+usacloud (0.0.11-1) stable; urgency=low
+
+  * linuxbrew対応 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/138>
+  * --format-fileオプションの追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/139>
+  * ビルド時にGo1.8(latest)を利用 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/140>
+  * Windows上でのgo generate対応 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/144>
+  * go generateで生成されるファイルの整理 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/145>
+  * コピー元アーカイブ/ディスクID検索パラメータ追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/146>
+  * コマンドパラメータのテンプレート対応 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/149>
+  * パラメータファイルのスケルトン出力機能 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/150>
+
+ -- usacloud <yamamoto.febc@gmail.com>  Wed, 14 Jun 2017 15:07:04 +0000
+
 usacloud (0.0.10-1) stable; urgency=low
 
   * VNCコマンドへサーバ起動待ち用オプション追加 (by yamamoto-febc)

--- a/package/rpm/usacloud.spec
+++ b/package/rpm/usacloud.spec
@@ -40,6 +40,16 @@ CLI client of the SakuraCloud
 %{_sysconfdir}/bash_completion.d/usacloud
 
 %changelog
+* Wed Jun 14 2017 <yamamoto.febc@gmail.com> - 0.0.11-1
+- linuxbrew対応 (by yamamoto-febc)
+- --format-fileオプションの追加 (by yamamoto-febc)
+- ビルド時にGo1.8(latest)を利用 (by yamamoto-febc)
+- Windows上でのgo generate対応 (by yamamoto-febc)
+- go generateで生成されるファイルの整理 (by yamamoto-febc)
+- コピー元アーカイブ/ディスクID検索パラメータ追加 (by yamamoto-febc)
+- コマンドパラメータのテンプレート対応 (by yamamoto-febc)
+- パラメータファイルのスケルトン出力機能 (by yamamoto-febc)
+
 * Mon Jun 12 2017 <yamamoto.febc@gmail.com> - 0.0.10-1
 - VNCコマンドへサーバ起動待ち用オプション追加 (by yamamoto-febc)
 - タグによる検索機能 (by yamamoto-febc)


### PR DESCRIPTION
- linuxbrew対応 #138
- --format-fileオプションの追加 #139
- ビルド時にGo1.8(latest)を利用 #140
- Windows上でのgo generate対応 #144
- go generateで生成されるファイルの整理 #145
- コピー元アーカイブ/ディスクID検索パラメータ追加 #146
- コマンドパラメータのテンプレート対応 #149
- パラメータファイルのスケルトン出力機能 #150