### PR TITLE
メンテナンス情報取得コマンド追加

### DIFF
--- a/command/cli/cli_server_gen.go
+++ b/command/cli/cli_server_gen.go
@@ -49,6 +49,7 @@ func init() {
 	monitorCpuParam := params.NewMonitorCpuServerParam()
 	monitorNicParam := params.NewMonitorNicServerParam()
 	monitorDiskParam := params.NewMonitorDiskServerParam()
+	maintenanceInfoParam := params.NewMaintenanceInfoServerParam()
 
 	cliCommand := &cli.Command{
 		Name:  "server",
@@ -9418,6 +9419,226 @@ func init() {
 
 				},
 			},
+			{
+				Name:  "maintenance-info",
+				Usage: "MaintenanceInfo Server",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [json/csv/tsv]",
+					},
+					&cli.StringSliceFlag{
+						Name:    "column",
+						Aliases: []string{"col"},
+						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
+					},
+					&cli.BoolFlag{
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
+					},
+					&cli.StringFlag{
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
+					},
+					&cli.StringFlag{
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, maintenanceInfoParam)
+
+					// Set option values
+					if c.IsSet("param-template") {
+						maintenanceInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						maintenanceInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						maintenanceInfoParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("output-type") {
+						maintenanceInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						maintenanceInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						maintenanceInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						maintenanceInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						maintenanceInfoParam.FormatFile = c.String("format-file")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.ServerMaintenanceInfoCompleteArgs(ctx, maintenanceInfoParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.ServerMaintenanceInfoCompleteArgs(ctx, maintenanceInfoParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.ServerMaintenanceInfoCompleteFlags(ctx, maintenanceInfoParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.ServerMaintenanceInfoCompleteArgs(ctx, maintenanceInfoParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					maintenanceInfoParam.ParamTemplate = c.String("param-template")
+					maintenanceInfoParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(maintenanceInfoParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewMaintenanceInfoServerParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.MergeWithOverwrite(maintenanceInfoParam, p)
+					}
+
+					// Set option values
+					if c.IsSet("param-template") {
+						maintenanceInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						maintenanceInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						maintenanceInfoParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("output-type") {
+						maintenanceInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						maintenanceInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						maintenanceInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						maintenanceInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						maintenanceInfoParam.FormatFile = c.String("format-file")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					// Generate skeleton
+					if maintenanceInfoParam.GenerateSkeleton {
+						maintenanceInfoParam.GenerateSkeleton = false
+						maintenanceInfoParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(maintenanceInfoParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := maintenanceInfoParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), maintenanceInfoParam)
+
+					// Run command with params
+					return funcs.ServerMaintenanceInfo(ctx, maintenanceInfoParam)
+
+				},
+			},
 		},
 	}
 
@@ -9504,6 +9725,11 @@ func init() {
 		Key:         "basics",
 		DisplayName: "Basics",
 		Order:       10,
+	})
+	AppendCommandCategoryMap("server", "maintenance-info", &schema.Category{
+		Key:         "other",
+		DisplayName: "Other",
+		Order:       1000,
 	})
 	AppendCommandCategoryMap("server", "monitor-cpu", &schema.Category{
 		Key:         "monitor",
@@ -10427,6 +10653,46 @@ func init() {
 		Key:         "filter",
 		DisplayName: "Filter options",
 		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "column", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "format", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "format-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "output-type", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "quiet", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
 	})
 	AppendFlagCategoryMap("server", "monitor-cpu", "column", &schema.Category{
 		Key:         "output",

--- a/command/completion/server_args_gen.go
+++ b/command/completion/server_args_gen.go
@@ -916,3 +916,7 @@ func ServerMonitorDiskCompleteArgs(ctx command.Context, params *params.MonitorDi
 	}
 
 }
+
+func ServerMaintenanceInfoCompleteArgs(ctx command.Context, params *params.MaintenanceInfoServerParam, cur, prev, commandName string) {
+
+}

--- a/command/completion/server_flags_gen.go
+++ b/command/completion/server_flags_gen.go
@@ -759,3 +759,19 @@ func ServerMonitorDiskCompleteFlags(ctx command.Context, params *params.MonitorD
 		}
 	}
 }
+
+func ServerMaintenanceInfoCompleteFlags(ctx command.Context, params *params.MaintenanceInfoServerParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "output-type", "out":
+		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}

--- a/command/funcs/server_maintenance_info.go
+++ b/command/funcs/server_maintenance_info.go
@@ -1,0 +1,55 @@
+package funcs
+
+import (
+	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func ServerMaintenanceInfo(ctx command.Context, params *params.MaintenanceInfoServerParam) error {
+
+	client := ctx.GetAPIClient()
+	finder := client.GetServerAPI()
+
+	type mainteInfo struct {
+		*sacloud.Server
+		MaintenanceInfo *sacloud.NewsFeed
+		StartDate       string
+		EndDate         string
+		InfoURL         string
+	}
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return fmt.Errorf("ServerMaintenanceInfo is failed: %s", err)
+	}
+
+	list := []interface{}{}
+	timeLayout := "01/02 15:04"
+	for i, s := range res.Servers {
+		if s.MaintenanceScheduled() {
+
+			info, err := client.NewsFeed.GetFeedByURL(s.GetMaintenanceInfoURL())
+			if err != nil {
+				return fmt.Errorf("GetFeedByURL(%s) is failed: %s", s.GetMaintenanceInfoURL(), err)
+			}
+			if info == nil {
+				continue
+			}
+
+			v := &mainteInfo{
+				Server:          &res.Servers[i],
+				MaintenanceInfo: info,
+				StartDate:       info.EventStart().Format(timeLayout),
+				EndDate:         info.EventEnd().Format(timeLayout),
+				InfoURL:         s.GetMaintenanceInfoURL(),
+			}
+
+			list = append(list, v)
+		}
+	}
+	return ctx.GetOutput().Print(list...)
+
+}

--- a/command/params/params_server_gen.go
+++ b/command/params/params_server_gen.go
@@ -6217,3 +6217,161 @@ func (p *MonitorDiskServerParam) SetId(v int64) {
 func (p *MonitorDiskServerParam) GetId() int64 {
 	return p.Id
 }
+
+// MaintenanceInfoServerParam is input parameters for the sacloud API
+type MaintenanceInfoServerParam struct {
+	ParamTemplate     string
+	ParamTemplateFile string
+	GenerateSkeleton  bool
+	OutputType        string
+	Column            []string
+	Quiet             bool
+	Format            string
+	FormatFile        string
+}
+
+// NewMaintenanceInfoServerParam return new MaintenanceInfoServerParam
+func NewMaintenanceInfoServerParam() *MaintenanceInfoServerParam {
+	return &MaintenanceInfoServerParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *MaintenanceInfoServerParam) FillValueToSkeleton() {
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+
+}
+
+// Validate checks current values in model
+func (p *MaintenanceInfoServerParam) Validate() []error {
+	errors := []error{}
+
+	{
+		validator := schema.ValidateInStrValues("json", "csv", "tsv")
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *MaintenanceInfoServerParam) GetResourceDef() *schema.Resource {
+	return define.Resources["Server"]
+}
+
+func (p *MaintenanceInfoServerParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["maintenance-info"]
+}
+
+func (p *MaintenanceInfoServerParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *MaintenanceInfoServerParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *MaintenanceInfoServerParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *MaintenanceInfoServerParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *MaintenanceInfoServerParam) GetOutputFormat() string {
+	return "table"
+}
+
+func (p *MaintenanceInfoServerParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *MaintenanceInfoServerParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *MaintenanceInfoServerParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *MaintenanceInfoServerParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *MaintenanceInfoServerParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *MaintenanceInfoServerParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *MaintenanceInfoServerParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *MaintenanceInfoServerParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *MaintenanceInfoServerParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *MaintenanceInfoServerParam) GetColumn() []string {
+	return p.Column
+}
+func (p *MaintenanceInfoServerParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *MaintenanceInfoServerParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *MaintenanceInfoServerParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *MaintenanceInfoServerParam) GetFormat() string {
+	return p.Format
+}
+func (p *MaintenanceInfoServerParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *MaintenanceInfoServerParam) GetFormatFile() string {
+	return p.FormatFile
+}

--- a/define/server.go
+++ b/define/server.go
@@ -324,6 +324,15 @@ func ServerResource() *schema.Resource {
 			Category:           "monitor",
 			Order:              30,
 		},
+		"maintenance-info": {
+			Type:               schema.CommandList,
+			Params:             serverMaintenanceInfoParam(),
+			TableType:          output.TableSimple,
+			TableColumnDefines: serverMaintenanceInfoColumns(),
+			UseCustomCommand:   true,
+			Category:           "other",
+			Order:              10,
+		},
 	}
 
 	return &schema.Resource{
@@ -341,10 +350,6 @@ func serverListColumns() []output.ColumnDef {
 	return []output.ColumnDef{
 		{Name: "ID"},
 		{Name: "Name"},
-		{
-			Name:    "Power",
-			Sources: []string{"Instance.Status"},
-		},
 		{
 			Name:    "CPU",
 			Sources: []string{"ServerPlan.CPU"},
@@ -421,6 +426,24 @@ func serverInterfaceListColumns() []output.ColumnDef {
 			Sources: []string{"PacketFilter.Name", "PacketFilter.ID"},
 			Format:  "%s(%s)",
 		},
+	}
+}
+
+func serverMaintenanceInfoColumns() []output.ColumnDef {
+	return []output.ColumnDef{
+		{Name: "ID"},
+		{Name: "Name"},
+		{
+			Name:    "Host",
+			Sources: []string{"Instance.Host.Name"},
+			Format:  "%s",
+		},
+		{
+			Name:    "Date",
+			Sources: []string{"StartDate", "EndDate"},
+			Format:  "%s 〜 %s",
+		},
+		{Name: "InfoURL"},
 	}
 }
 
@@ -1529,4 +1552,8 @@ func serverMonitorDiskColumns() []output.ColumnDef {
 		{Name: "Read"},
 		{Name: "Write"},
 	}
+}
+
+func serverMaintenanceInfoParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
 }

--- a/vendor/github.com/sacloud/libsacloud/api/client.go
+++ b/vendor/github.com/sacloud/libsacloud/api/client.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -97,10 +98,13 @@ func (c *Client) isOkStatus(code int) bool {
 func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error) {
 	var (
 		client = &http.Client{}
-		url    = fmt.Sprintf("%s/%s", c.getEndpoint(), uri)
 		err    error
 		req    *http.Request
 	)
+	var url = uri
+	if !strings.HasPrefix(url, "https://") {
+		url = fmt.Sprintf("%s/%s", c.getEndpoint(), uri)
+	}
 
 	if body != nil {
 		var bodyJSON []byte
@@ -109,7 +113,7 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 			return nil, err
 		}
 		if method == "GET" {
-			url = fmt.Sprintf("%s/%s?%s", c.getEndpoint(), uri, bytes.NewBuffer(bodyJSON))
+			url = fmt.Sprintf("%s?%s", url, bytes.NewBuffer(bodyJSON))
 			req, err = http.NewRequest(method, url, nil)
 		} else {
 			req, err = http.NewRequest(method, url, bytes.NewBuffer(bodyJSON))
@@ -197,6 +201,7 @@ type API struct {
 	IPv6Net       *IPv6NetAPI       // IPv6ネットワークAPI
 	License       *LicenseAPI       // ライセンスAPI
 	LoadBalancer  *LoadBalancerAPI  // ロードバランサーAPI
+	NewsFeed      *NewsFeedAPI      // フィード(障害/メンテナンス情報)API
 	Note          *NoteAPI          // スタートアップスクリプトAPI
 	PacketFilter  *PacketFilterAPI  // パケットフィルタAPI
 	Product       *ProductAPI       // 製品情報API
@@ -307,6 +312,11 @@ func (api *API) GetLicenseAPI() *LicenseAPI {
 // GetLoadBalancerAPI ロードバランサーAPI取得
 func (api *API) GetLoadBalancerAPI() *LoadBalancerAPI {
 	return api.LoadBalancer
+}
+
+// GetNewsFeedAPI フィード(障害/メンテナンス情報)API取得
+func (api *API) GetNewsFeedAPI() *NewsFeedAPI {
+	return api.NewsFeed
 }
 
 // GetNoteAPI スタートアップAPI取得
@@ -453,6 +463,7 @@ func newAPI(client *Client) *API {
 		IPv6Net:      NewIPv6NetAPI(client),
 		License:      NewLicenseAPI(client),
 		LoadBalancer: NewLoadBalancerAPI(client),
+		NewsFeed:     NewNewsFeedAPI(client),
 		Note:         NewNoteAPI(client),
 		PacketFilter: NewPacketFilterAPI(client),
 		Product: &ProductAPI{

--- a/vendor/github.com/sacloud/libsacloud/api/newsfeed.go
+++ b/vendor/github.com/sacloud/libsacloud/api/newsfeed.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"encoding/json"
+	"github.com/sacloud/libsacloud/sacloud"
+)
+
+// NewsFeedAPI フィード(障害/メンテナンス情報)API
+type NewsFeedAPI struct {
+	client *Client
+}
+
+// NewsFeedURL フィード取得URL
+var NewsFeedURL = "https://secure.sakura.ad.jp/rss/sakuranews/getfeeds.php?service=cloud&format=json"
+
+// NewNewsFeedAPI フィード(障害/メンテナンス情報)API
+func NewNewsFeedAPI(client *Client) *NewsFeedAPI {
+	return &NewsFeedAPI{
+		client: client,
+	}
+}
+
+// GetFeed フィード全件取得
+func (api *NewsFeedAPI) GetFeed() ([]sacloud.NewsFeed, error) {
+
+	var res = []sacloud.NewsFeed{}
+	data, err := api.client.newRequest("GET", NewsFeedURL, nil)
+	if err != nil {
+		return res, err
+	}
+
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// GetFeedByURL 指定のURLを持つフィードを取得
+func (api *NewsFeedAPI) GetFeedByURL(url string) (*sacloud.NewsFeed, error) {
+	res, err := api.GetFeed()
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range res {
+		if r.Url == url {
+			return &r, nil
+		}
+	}
+	return nil, nil
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/feed.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/feed.go
@@ -1,0 +1,30 @@
+package sacloud
+
+import (
+	"strconv"
+	"time"
+)
+
+type NewsFeed struct {
+	StrDate       string `json:"date,omitempty"`
+	Description   string `json:"desc,omitempty"`
+	StrEventStart string `json:"event_start,omitempty"`
+	StrEventEnd   string `json:"event_end,omitempty"`
+	Title         string `json:"title,omitempty"`
+	Url           string `json:"url,omitempty"`
+}
+
+func (f *NewsFeed) Date() time.Time {
+	return f.parseTime(f.StrDate)
+}
+func (f *NewsFeed) EventStart() time.Time {
+	return f.parseTime(f.StrEventStart)
+}
+func (f *NewsFeed) EventEnd() time.Time {
+	return f.parseTime(f.StrEventEnd)
+}
+
+func (f *NewsFeed) parseTime(sec string) time.Time {
+	s, _ := strconv.ParseInt(sec, 10, 64)
+	return time.Unix(s, 0)
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/instance.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/instance.go
@@ -24,19 +24,12 @@ type Instance struct {
 	} `json:",omitempty"`
 }
 
-// Storage ストレージ
-type Storage struct {
-	*Resource       // ID
-	propName        // 名称
-	propDescription // 説明
-	propZone        // ゾーン
+// HasInfoURL Host.InfoURLに値があるか
+func (i *Instance) HasInfoURL() bool {
+	return i != nil && i.Host.InfoURL != ""
+}
 
-	Class    string   `json:",omitempty"` // クラス
-	DiskPlan struct { // ディスクプラン
-		*Resource        // ID
-		propName         // 名称
-		propStorageClass // ストレージクラス
-	} `json:",omitempty"`
-
-	//Capacity []string `json:",omitempty"`
+// MaintenanceScheduled メンテナンス予定の有無
+func (i *Instance) MaintenanceScheduled() bool {
+	return i.HasInfoURL()
 }

--- a/vendor/github.com/sacloud/libsacloud/sacloud/packet_filter.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/packet_filter.go
@@ -6,7 +6,7 @@ type PacketFilter struct {
 	propName        // 名称
 	propDescription // 説明
 
-	Expression []*PacketFilterExpression `json:",omitempty"` // ルール
+	Expression []*PacketFilterExpression // ルール
 	Notice     string                    `json:",omitempty"` // Notice
 
 	//HACK API呼び出しルートにより数字/文字列が混在する

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_instance.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_instance.go
@@ -41,3 +41,19 @@ func (p *propInstance) GetInstanceBeforeStatus() string {
 	}
 	return p.Instance.GetBeforeStatus()
 }
+
+// MaintenanceScheduled メンテナンス予定の有無
+func (p *propInstance) MaintenanceScheduled() bool {
+	if p.Instance == nil {
+		return false
+	}
+	return p.Instance.MaintenanceScheduled()
+}
+
+// GetMaintenanceInfoURL メンテナンス情報 URL取得
+func (p *propInstance) GetMaintenanceInfoURL() string {
+	if p.Instance == nil {
+		return ""
+	}
+	return p.Instance.Host.InfoURL
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/storage.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/storage.go
@@ -1,0 +1,18 @@
+package sacloud
+
+// Storage ストレージ
+type Storage struct {
+	*Resource       // ID
+	propName        // 名称
+	propDescription // 説明
+	propZone        // ゾーン
+
+	Class    string   `json:",omitempty"` // クラス
+	DiskPlan struct { // ディスクプラン
+		*Resource        // ID
+		propName         // 名称
+		propStorageClass // ストレージクラス
+	} `json:",omitempty"`
+
+	//Capacity []string `json:",omitempty"`
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -107,32 +107,32 @@
 		{
 			"checksumSHA1": "XI7myxuwZnJ3ySMwSCLTXcpBN4Y=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "22934f497d6ab909f2e3c32886166f86a67b9bdf",
-			"revisionTime": "2017-06-21T08:21:34Z"
+			"revision": "41eb687f5d03ca22bbc7663ea708521a38b50423",
+			"revisionTime": "2017-07-06T11:10:52Z"
 		},
 		{
-			"checksumSHA1": "uJLrlVe4oBM/U6v+BHsRw1YO06k=",
+			"checksumSHA1": "g++bnWe1Cy5fw3ODCSVv8fRZ7uM=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "22934f497d6ab909f2e3c32886166f86a67b9bdf",
-			"revisionTime": "2017-06-21T08:21:34Z"
+			"revision": "41eb687f5d03ca22bbc7663ea708521a38b50423",
+			"revisionTime": "2017-07-06T11:10:52Z"
 		},
 		{
 			"checksumSHA1": "SfRWOR6BdWIy9j30hHs1xaWiTbg=",
 			"path": "github.com/sacloud/libsacloud/builder",
-			"revision": "22934f497d6ab909f2e3c32886166f86a67b9bdf",
-			"revisionTime": "2017-06-21T08:21:34Z"
+			"revision": "41eb687f5d03ca22bbc7663ea708521a38b50423",
+			"revisionTime": "2017-07-06T11:10:52Z"
 		},
 		{
-			"checksumSHA1": "IN2J0BMNuTdZ0Fc7Db3HZ8f+Kic=",
+			"checksumSHA1": "gxXWTcbWaaNrWCrg1HGzi1JjziY=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "22934f497d6ab909f2e3c32886166f86a67b9bdf",
-			"revisionTime": "2017-06-21T08:21:34Z"
+			"revision": "41eb687f5d03ca22bbc7663ea708521a38b50423",
+			"revisionTime": "2017-07-06T11:10:52Z"
 		},
 		{
 			"checksumSHA1": "4ucQjCi7PdIq5xtlNwSJXfxNG/c=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "22934f497d6ab909f2e3c32886166f86a67b9bdf",
-			"revisionTime": "2017-06-21T08:21:34Z"
+			"revision": "41eb687f5d03ca22bbc7663ea708521a38b50423",
+			"revisionTime": "2017-07-06T11:10:52Z"
 		},
 		{
 			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",


### PR DESCRIPTION
メンテナンスが予定されているホストに格納されているサーバを一覧表示する`server maintenance-info`コマンドを追加する。

### 実行例

```console
$ usacloud server maintenance-info

+--------------+------------------+----------------+----------------------------+-------------------------------------------------------------+
|      ID      |       Name       |      Host      |            Date            |                           InfoURL                           |
+--------------+------------------+----------------+----------------------------+-------------------------------------------------------------+
| 123456789012 | your-server-name | sac-is1a-svxxx | 07/20 10:00 〜 07/20 13:00 | http://support.sakura.ad.jp/mainte/mainteentry.php?id=xxxxx |
+--------------+------------------+----------------+----------------------------+-------------------------------------------------------------+
```