### PR TITLE
Release version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.1.0 (2017-08-15)
+
+* VPCルータでのログ出力機能追加 #179 (yamamoto-febc)
+* データベースでのログ出力機能追加 #181 (yamamoto-febc)
+* データベースでのバックアップ機能追加 #183 (yamamoto-febc)
+* データベースでのモニター機能追加 #185 (yamamoto-febc)
+* モニター機能デフォルトキー変更 #187 (yamamoto-febc)
+* 複数のAPIキーの切り替え機能 #188 (yamamoto-febc)
+* summaryコマンドの追加 #190 (yamamoto-febc)
+* interface-driver項目の追加 #192 (yamamoto-febc)
+* 請求CSVでのデフォルトターゲット指定 #194 (yamamoto-febc)
+* パッケージレイアウトのリファクタリング #195 (yamamoto-febc)
+* summaryコマンドヘルプ修正 #197 (yamamoto-febc)
+* データベースのログ名称変更 #198 (yamamoto-febc)
+
+
 ## 0.0.13 (2017-07-11)
 
 * textlint導入 #159 (yamamoto-febc)

--- a/command/cli/cli_database_gen.go
+++ b/command/cli/cli_database_gen.go
@@ -5964,7 +5964,7 @@ func init() {
 			},
 			{
 				Name:      "monitor-memory",
-				Usage:     "Collect Disk(s) monitor values",
+				Usage:     "Collect memory monitor values",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -6692,7 +6692,7 @@ func init() {
 			},
 			{
 				Name:      "monitor-system-disk",
-				Usage:     "Collect Disk(s) monitor values",
+				Usage:     "Collect system-disk monitor values(IO)",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -7056,7 +7056,7 @@ func init() {
 			},
 			{
 				Name:      "monitor-backup-disk",
-				Usage:     "Collect Disk(s) monitor values",
+				Usage:     "Collect backup-disk monitor values(IO)",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -7420,7 +7420,7 @@ func init() {
 			},
 			{
 				Name:      "monitor-system-disk-size",
-				Usage:     "Collect Disk(s) monitor values",
+				Usage:     "Collect system-disk monitor values(usage)",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -7784,7 +7784,7 @@ func init() {
 			},
 			{
 				Name:      "monitor-backup-disk-size",
-				Usage:     "Collect Disk(s) monitor values",
+				Usage:     "Collect backup-disk monitor values(usage)",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{

--- a/define/database.go
+++ b/define/database.go
@@ -192,7 +192,7 @@ func DatabaseResource() *schema.Resource {
 		"monitor-memory": {
 			Type:               schema.CommandRead,
 			Params:             databaseMonitorParam("memory"),
-			Usage:              "Collect Disk(s) monitor values",
+			Usage:              "Collect memory monitor values",
 			TableType:          output.TableSimple,
 			TableColumnDefines: databaseMonitorSizeColumns(),
 			UseCustomCommand:   true,
@@ -212,7 +212,7 @@ func DatabaseResource() *schema.Resource {
 		"monitor-system-disk": {
 			Type:               schema.CommandRead,
 			Params:             databaseMonitorParam("disk1"),
-			Usage:              "Collect Disk(s) monitor values",
+			Usage:              "Collect system-disk monitor values(IO)",
 			TableType:          output.TableSimple,
 			TableColumnDefines: databaseMonitorDiskColumns(),
 			UseCustomCommand:   true,
@@ -222,7 +222,7 @@ func DatabaseResource() *schema.Resource {
 		"monitor-backup-disk": {
 			Type:               schema.CommandRead,
 			Params:             databaseMonitorParam("disk2"),
-			Usage:              "Collect Disk(s) monitor values",
+			Usage:              "Collect backup-disk monitor values(IO)",
 			TableType:          output.TableSimple,
 			TableColumnDefines: databaseMonitorDiskColumns(),
 			UseCustomCommand:   true,
@@ -233,7 +233,7 @@ func DatabaseResource() *schema.Resource {
 		"monitor-system-disk-size": {
 			Type:               schema.CommandRead,
 			Params:             databaseMonitorParam("disk1"),
-			Usage:              "Collect Disk(s) monitor values",
+			Usage:              "Collect system-disk monitor values(usage)",
 			TableType:          output.TableSimple,
 			TableColumnDefines: databaseMonitorSizeColumns(),
 			UseCustomCommand:   true,
@@ -243,7 +243,7 @@ func DatabaseResource() *schema.Resource {
 		"monitor-backup-disk-size": {
 			Type:               schema.CommandRead,
 			Params:             databaseMonitorParam("disk2"),
-			Usage:              "Collect Disk(s) monitor values",
+			Usage:              "Collect backup-disk monitor values(usage)",
 			TableType:          output.TableSimple,
 			TableColumnDefines: databaseMonitorSizeColumns(),
 			UseCustomCommand:   true,

--- a/package/deb/debian/changelog
+++ b/package/deb/debian/changelog
@@ -1,3 +1,32 @@
+usacloud (0.1.0-1) stable; urgency=low
+
+  * VPCルータでのログ出力機能追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/179>
+  * データベースでのログ出力機能追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/181>
+  * データベースでのバックアップ機能追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/183>
+  * データベースでのモニター機能追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/185>
+  * モニター機能デフォルトキー変更 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/187>
+  * 複数のAPIキーの切り替え機能 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/188>
+  * summaryコマンドの追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/190>
+  * interface-driver項目の追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/192>
+  * 請求CSVでのデフォルトターゲット指定 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/194>
+  * パッケージレイアウトのリファクタリング (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/195>
+  * summaryコマンドヘルプ修正 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/197>
+  * データベースのログ名称変更 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/198>
+
+ -- usacloud <yamamoto.febc@gmail.com>  Tue, 15 Aug 2017 13:16:17 +0000
+
 usacloud (0.0.13-1) stable; urgency=low
 
   * textlint導入 (by yamamoto-febc)

--- a/package/rpm/usacloud.spec
+++ b/package/rpm/usacloud.spec
@@ -40,6 +40,20 @@ CLI client of the SakuraCloud
 %{_sysconfdir}/bash_completion.d/usacloud
 
 %changelog
+* Tue Aug 15 2017 <yamamoto.febc@gmail.com> - 0.1.0-1
+- VPCルータでのログ出力機能追加 (by yamamoto-febc)
+- データベースでのログ出力機能追加 (by yamamoto-febc)
+- データベースでのバックアップ機能追加 (by yamamoto-febc)
+- データベースでのモニター機能追加 (by yamamoto-febc)
+- モニター機能デフォルトキー変更 (by yamamoto-febc)
+- 複数のAPIキーの切り替え機能 (by yamamoto-febc)
+- summaryコマンドの追加 (by yamamoto-febc)
+- interface-driver項目の追加 (by yamamoto-febc)
+- 請求CSVでのデフォルトターゲット指定 (by yamamoto-febc)
+- パッケージレイアウトのリファクタリング (by yamamoto-febc)
+- summaryコマンドヘルプ修正 (by yamamoto-febc)
+- データベースのログ名称変更 (by yamamoto-febc)
+
 * Tue Jul 11 2017 <yamamoto.febc@gmail.com> - 0.0.13-1
 - textlint導入 (by yamamoto-febc)
 - Chocolateyでのインストール方法追記 (by yamamoto-febc)


### PR DESCRIPTION
- VPCルータでのログ出力機能追加 #179
- データベースでのログ出力機能追加 #181
- データベースでのバックアップ機能追加 #183
- データベースでのモニター機能追加 #185
- モニター機能デフォルトキー変更 #187
- 複数のAPIキーの切り替え機能 #188
- summaryコマンドの追加 #190
- interface-driver項目の追加 #192
- 請求CSVでのデフォルトターゲット指定 #194
- パッケージレイアウトのリファクタリング #195
- summaryコマンドヘルプ修正 #197
- データベースのログ名称変更 #198