### PR TITLE
DNSレコードのインデックスを特定しやすくする

### DIFF
--- a/command/cli/cli_dns_gen.go
+++ b/command/cli/cli_dns_gen.go
@@ -335,6 +335,14 @@ func init() {
 				Usage:     "RecordInfo DNS",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "name",
+						Usage: "set name",
+					},
+					&cli.StringFlag{
+						Name:  "type",
+						Usage: "set record type[A/AAAA/NS/CNAME/MX/TXT/SRV]",
+					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
 						Usage: "Set target filter by tag",
@@ -410,6 +418,12 @@ func init() {
 					ctx := command.NewContext(c, realArgs, recordInfoParam)
 
 					// Set option values
+					if c.IsSet("name") {
+						recordInfoParam.Name = c.String("name")
+					}
+					if c.IsSet("type") {
+						recordInfoParam.Type = c.String("type")
+					}
 					if c.IsSet("selector") {
 						recordInfoParam.Selector = c.StringSlice("selector")
 					}
@@ -525,6 +539,12 @@ func init() {
 					}
 
 					// Set option values
+					if c.IsSet("name") {
+						recordInfoParam.Name = c.String("name")
+					}
+					if c.IsSet("type") {
+						recordInfoParam.Type = c.String("type")
+					}
 					if c.IsSet("selector") {
 						recordInfoParam.Selector = c.StringSlice("selector")
 					}
@@ -3746,6 +3766,11 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
+	AppendFlagCategoryMap("dns", "record-info", "name", &schema.Category{
+		Key:         "record",
+		DisplayName: "Record options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("dns", "record-info", "output-type", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3770,6 +3795,11 @@ func init() {
 		Key:         "filter",
 		DisplayName: "Filter options",
 		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("dns", "record-info", "type", &schema.Category{
+		Key:         "record",
+		DisplayName: "Record options",
+		Order:       1,
 	})
 	AppendFlagCategoryMap("dns", "record-update", "assumeyes", &schema.Category{
 		Key:         "Input",

--- a/command/completion/dns_flags_gen.go
+++ b/command/completion/dns_flags_gen.go
@@ -60,6 +60,16 @@ func DNSRecordInfoCompleteFlags(ctx command.Context, params *params.RecordInfoDN
 	var comp schema.CompletionFunc
 
 	switch flagName {
+	case "name":
+		param := define.Resources["DNS"].Commands["record-info"].BuildedParams().Get("name")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "type":
+		param := define.Resources["DNS"].Commands["record-info"].BuildedParams().Get("type")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "selector":
 		param := define.Resources["DNS"].Commands["record-info"].BuildedParams().Get("selector")
 		if param != nil {

--- a/command/funcs/dns_record_add.go
+++ b/command/funcs/dns_record_add.go
@@ -33,6 +33,10 @@ func DNSRecordAdd(ctx command.Context, params *params.RecordAddDNSParam) error {
 	default:
 		record = p.CreateNewRecord(params.Name, t, params.Value, params.Ttl)
 	}
+
+	// save current index
+	index := len(p.Settings.DNS.ResourceRecordSets)
+
 	p.AddRecord(record)
 
 	// update
@@ -42,10 +46,10 @@ func DNSRecordAdd(ctx command.Context, params *params.RecordAddDNSParam) error {
 	}
 
 	list := []interface{}{}
-	for i := range p.Settings.DNS.ResourceRecordSets {
-		list = append(list, &p.Settings.DNS.ResourceRecordSets[i])
-	}
-
+	list = append(list, &dnsRecordValueType{
+		DNSRecordSet: &p.Settings.DNS.ResourceRecordSets[index],
+		Index:        index + 1, // for display
+	})
 	return ctx.GetOutput().Print(list...)
 
 }

--- a/command/funcs/dns_record_delete.go
+++ b/command/funcs/dns_record_delete.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
 )
@@ -27,8 +28,12 @@ func DNSRecordDelete(ctx command.Context, params *params.RecordDeleteDNSParam) e
 	// delete
 	recordSet := p.Settings.DNS.ResourceRecordSets
 	p.ClearRecords()
+
+	var targetRecord *sacloud.DNSRecordSet
 	for i, r := range recordSet {
-		if i != params.Index-1 {
+		if i == params.Index-1 {
+			targetRecord = &r
+		} else {
 			p.Settings.DNS.ResourceRecordSets = append(p.Settings.DNS.ResourceRecordSets, r)
 		}
 	}
@@ -40,9 +45,10 @@ func DNSRecordDelete(ctx command.Context, params *params.RecordDeleteDNSParam) e
 	}
 
 	list := []interface{}{}
-	for i := range p.Settings.DNS.ResourceRecordSets {
-		list = append(list, &p.Settings.DNS.ResourceRecordSets[i])
-	}
+	list = append(list, &dnsRecordValueType{
+		DNSRecordSet: targetRecord,
+		Index:        params.Index, // for display
+	})
 
 	return ctx.GetOutput().Print(list...)
 

--- a/command/funcs/dns_record_info.go
+++ b/command/funcs/dns_record_info.go
@@ -21,8 +21,19 @@ func DNSRecordInfo(ctx command.Context, params *params.RecordInfoDNSParam) error
 	}
 
 	list := []interface{}{}
-	for i := range p.Settings.DNS.ResourceRecordSets {
-		list = append(list, &p.Settings.DNS.ResourceRecordSets[i])
+	for i, r := range p.Settings.DNS.ResourceRecordSets {
+		// filtering
+		if params.Name != "" && params.Name != r.Name {
+			continue
+		}
+		if params.Type != "" && params.Type != r.Type {
+			continue
+		}
+
+		list = append(list, &dnsRecordValueType{
+			DNSRecordSet: &p.Settings.DNS.ResourceRecordSets[i],
+			Index:        i + 1, // for display
+		})
 	}
 
 	return ctx.GetOutput().Print(list...)

--- a/command/funcs/dns_record_update.go
+++ b/command/funcs/dns_record_update.go
@@ -129,9 +129,9 @@ func DNSRecordUpdate(ctx command.Context, params *params.RecordUpdateDNSParam) e
 	}
 
 	list := []interface{}{}
-	for i := range p.Settings.DNS.ResourceRecordSets {
-		list = append(list, &p.Settings.DNS.ResourceRecordSets[i])
-	}
-
+	list = append(list, &dnsRecordValueType{
+		DNSRecordSet: record,
+		Index:        params.Index, // for display
+	})
 	return ctx.GetOutput().Print(list...)
 }

--- a/command/funcs/dns_record_value_type.go
+++ b/command/funcs/dns_record_value_type.go
@@ -1,0 +1,8 @@
+package funcs
+
+import "github.com/sacloud/libsacloud/sacloud"
+
+type dnsRecordValueType struct {
+	*sacloud.DNSRecordSet
+	Index int
+}

--- a/command/params/params_dns_gen.go
+++ b/command/params/params_dns_gen.go
@@ -266,6 +266,8 @@ func (p *ListDNSParam) GetFormatFile() string {
 
 // RecordInfoDNSParam is input parameters for the sacloud API
 type RecordInfoDNSParam struct {
+	Name              string   `json:"name"`
+	Type              string   `json:"type"`
 	Selector          []string `json:"selector"`
 	ParamTemplate     string   `json:"param-template"`
 	ParamTemplateFile string   `json:"param-template-file"`
@@ -285,6 +287,12 @@ func NewRecordInfoDNSParam() *RecordInfoDNSParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *RecordInfoDNSParam) FillValueToSkeleton() {
+	if isEmpty(p.Name) {
+		p.Name = ""
+	}
+	if isEmpty(p.Type) {
+		p.Type = ""
+	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
 	}
@@ -321,6 +329,20 @@ func (p *RecordInfoDNSParam) FillValueToSkeleton() {
 // Validate checks current values in model
 func (p *RecordInfoDNSParam) Validate() []error {
 	errors := []error{}
+	{
+		validator := define.Resources["DNS"].Commands["record-info"].Params["name"].ValidateFunc
+		errs := validator("--name", p.Name)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["DNS"].Commands["record-info"].Params["type"].ValidateFunc
+		errs := validator("--type", p.Type)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
 	{
 		validator := validateSakuraID
 		errs := validator("--id", p.Id)
@@ -380,6 +402,20 @@ func (p *RecordInfoDNSParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *RecordInfoDNSParam) SetName(v string) {
+	p.Name = v
+}
+
+func (p *RecordInfoDNSParam) GetName() string {
+	return p.Name
+}
+func (p *RecordInfoDNSParam) SetType(v string) {
+	p.Type = v
+}
+
+func (p *RecordInfoDNSParam) GetType() string {
+	return p.Type
+}
 func (p *RecordInfoDNSParam) SetSelector(v []string) {
 	p.Selector = v
 }

--- a/define/dns.go
+++ b/define/dns.go
@@ -138,7 +138,7 @@ func dnsListColumns() []output.ColumnDef {
 
 func dnsRecordListColumns() []output.ColumnDef {
 	return []output.ColumnDef{
-		{Name: "__ORDER__"}, // magic column name(generated on demand)
+		{Name: "Index"},
 		{Name: "Type"},
 		{Name: "Name"},
 		{Name: "RData"},
@@ -187,7 +187,25 @@ func dnsDeleteParam() map[string]*schema.Schema {
 }
 
 func dnsRecordListParam() map[string]*schema.Schema {
-	return map[string]*schema.Schema{}
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set name",
+			ValidateFunc: validateStrLen(1, 63),
+			Category:     "record",
+			Order:        10,
+		},
+		"type": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set record type[A/AAAA/NS/CNAME/MX/TXT/SRV]",
+			ValidateFunc: validateInStrValues(allowDNSTypes...),
+			CompleteFunc: completeInStrValues(allowDNSTypes...),
+			Category:     "record",
+			Order:        20,
+		},
+	}
 }
 
 var allowDNSTypes = []string{


### PR DESCRIPTION
To fix #203 

DNSレコードの操作時に対象レコードをアウトプットする。
主にレコード追加時に追加となったレコードのインデックスを特定するため。

```console
$ usacloud dns record-add --name test1 --type A --value 192.168.0.2 example.com
Target resource IDs => [
	123456789012
]
Are you sure you want to delete record?(y/n) [n]: y
+-------+------+-------+-------------+
| Index | Type | Name  |    RData    |
+-------+------+-------+-------------+
| 6     | A    | test1 | 192.168.0.2 |
+-------+------+-------+-------------+
```

また、DNSレコード表示時にタイプと名称からの絞り込みを行えるようにすることで対象レコードのインデックスの特定を行いやすくする。

```console
#TypeがA、かつNameがtest1のレコードのみ表示する
$ usacloud dns record-info --type A --name test1  example.com 
+-------+------+-------+-------------+
| Index | Type | Name  |    RData    |
+-------+------+-------+-------------+
| 6     | A    | test1 | 192.168.0.1 |
| 7     | A    | test1 | 192.168.0.2 |
+-------+------+-------+-------------+
```