### PR TITLE
quietモードでのIndex列の表示

### DIFF
--- a/output/id_output.go
+++ b/output/id_output.go
@@ -14,7 +14,7 @@ type idOutput struct {
 	Err io.Writer
 }
 
-var idOutputTargetColumns = []string{"ID", "Key", "BillID", "RowNumber"}
+var idOutputTargetColumns = []string{"ID", "Key", "BillID", "Index", "RowNumber"}
 
 func NewIDOutput(out io.Writer, err io.Writer) Output {
 	return &idOutput{


### PR DESCRIPTION
quietモードで表示する対象列候補に`Index`を追加する。
これはRowNumberの代わりに自前でIndex処理をするコマンド(`dns record-info`など)で利用される。