### PR TITLE
対象ゾーンとAPIのルートURL設定用グローバルオプション追加

### DIFF
--- a/command/cli/functions.go
+++ b/command/cli/functions.go
@@ -2,10 +2,14 @@ package cli
 
 import (
 	"fmt"
+	"github.com/sacloud/libsacloud/api"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/profile"
+	"github.com/sacloud/usacloud/define"
 	"github.com/sacloud/usacloud/helper/migration"
+	"os"
 	"strconv"
+	"strings"
 )
 
 func checkConfigVersion() error {
@@ -16,6 +20,7 @@ type FlagHandler interface {
 	IsSet(name string) bool
 	Set(name, value string) error
 	String(name string) string
+	StringSlice(name string) []string
 }
 
 func applyConfigFromFile(c FlagHandler) error {
@@ -46,6 +51,31 @@ func applyConfigFromFile(c FlagHandler) error {
 	if !c.IsSet("zone") && v.Zone != "" {
 		c.Set("zone", v.Zone)
 		command.GlobalOption.Zone = v.Zone
+	}
+
+	// for string-slice
+	zones := []string{}
+	if c.IsSet("zones") {
+		zones = c.StringSlice("zones")
+	} else if len(v.Zones) > 0 {
+		zones = v.Zones
+	} else {
+		if z, ok := os.LookupEnv("USACLOUD_ZONES"); ok {
+			zones = strings.Split(z, ",")
+		}
+	}
+	command.GlobalOption.Zones = zones
+
+	if !c.IsSet("api-root-url") && v.APIRootURL != "" {
+		c.Set("api-root-url", v.APIRootURL)
+		command.GlobalOption.APIRootURL = v.APIRootURL
+	}
+
+	if len(command.GlobalOption.Zones) > 0 {
+		define.AllowZones = command.GlobalOption.Zones
+	}
+	if command.GlobalOption.APIRootURL != "" {
+		api.SakuraCloudAPIRoot = command.GlobalOption.APIRootURL
 	}
 
 	return nil

--- a/command/cli/functions_test.go
+++ b/command/cli/functions_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 type mockFlagHandler struct {
-	val     map[string]string
-	initVal map[string]string
+	val     map[string]interface{}
+	initVal map[string]interface{}
 }
 
 var envKeyValMap = map[string]string{
@@ -19,10 +19,10 @@ var envKeyValMap = map[string]string{
 	"SAKURACLOUD_ZONE":                "zone",
 }
 
-func newMockFlagHandler(val map[string]string) *mockFlagHandler {
+func newMockFlagHandler(val map[string]interface{}) *mockFlagHandler {
 	h := &mockFlagHandler{
 		val:     val,
-		initVal: map[string]string{},
+		initVal: map[string]interface{}{},
 	}
 	for k, v := range val {
 		h.initVal[k] = v
@@ -30,7 +30,7 @@ func newMockFlagHandler(val map[string]string) *mockFlagHandler {
 
 	for key, valKey := range envKeyValMap {
 		if v, ok := os.LookupEnv(key); ok {
-			if h.val[valKey] == "" {
+			if s, ok := h.val[valKey]; !ok || s.(string) == "" {
 				h.val[valKey] = v
 			}
 		}
@@ -48,7 +48,16 @@ func (h *mockFlagHandler) Set(name, value string) error {
 }
 
 func (h *mockFlagHandler) String(name string) string {
-	return h.val[name]
+	if v, ok := h.val[name]; ok {
+		return v.(string)
+	}
+	return ""
+}
+func (h *mockFlagHandler) StringSlice(name string) []string {
+	if v, ok := h.val[name]; ok {
+		return v.([]string)
+	}
+	return []string{}
 }
 
 func TestApplyConfigFromFile(t *testing.T) {
@@ -72,7 +81,7 @@ func TestApplyConfigFromFile(t *testing.T) {
 		defer initFunc()()
 
 		flagHandler := newMockFlagHandler(
-			map[string]string{
+			map[string]interface{}{
 				"token":  "test-token",
 				"secret": "test-secret",
 				"zone":   "tk1v",
@@ -98,7 +107,7 @@ func TestApplyConfigFromFile(t *testing.T) {
 		})
 
 		flagHandler := newMockFlagHandler(
-			map[string]string{
+			map[string]interface{}{
 				"profile": testProfileName,
 			},
 		)
@@ -117,7 +126,7 @@ func TestApplyConfigFromFile(t *testing.T) {
 		os.Setenv("SAKURACLOUD_ACCESS_TOKEN_SECRET", "test-secret")
 		os.Setenv("SAKURACLOUD_ZONE", "tk1v")
 
-		flagHandler := newMockFlagHandler(map[string]string{})
+		flagHandler := newMockFlagHandler(map[string]interface{}{})
 
 		err := applyConfigFromFile(flagHandler)
 		assert.NoError(t, err)
@@ -138,7 +147,7 @@ func TestApplyConfigFromFile(t *testing.T) {
 		})
 
 		flagHandler := newMockFlagHandler(
-			map[string]string{
+			map[string]interface{}{
 				"token":   "test-token",
 				"secret":  "test-secret",
 				"zone":    "tk1v",
@@ -162,7 +171,7 @@ func TestApplyConfigFromFile(t *testing.T) {
 		os.Setenv("SAKURACLOUD_ZONE", "fromEnv")
 
 		flagHandler := newMockFlagHandler(
-			map[string]string{
+			map[string]interface{}{
 				"token":  "test-token",
 				"secret": "test-secret",
 				"zone":   "tk1v",
@@ -190,7 +199,7 @@ func TestApplyConfigFromFile(t *testing.T) {
 		os.Setenv("SAKURACLOUD_ZONE", "fromEnv")
 
 		flagHandler := newMockFlagHandler(
-			map[string]string{
+			map[string]interface{}{
 				"profile": testProfileName,
 			},
 		)
@@ -216,7 +225,7 @@ func TestApplyConfigFromFile(t *testing.T) {
 		})
 
 		flagHandler := newMockFlagHandler(
-			map[string]string{
+			map[string]interface{}{
 				"token":   "test-token",
 				"secret":  "test-secret",
 				"zone":    "tk1v",

--- a/command/funcs/database_backup_lock.go
+++ b/command/funcs/database_backup_lock.go
@@ -28,7 +28,7 @@ func DatabaseBackupLock(ctx command.Context, params *params.BackupLockDatabasePa
 		return fmt.Errorf("index(%d) is out of range", params.Index)
 	}
 
-	backupID := info.DBConf.Backup.History[params.Index-1].Id()
+	backupID := info.DBConf.Backup.History[params.Index-1].ID()
 	_, err := api.HistoryLock(params.Id, backupID)
 	if err != nil {
 		return fmt.Errorf("DatabaseBackupLock is failed: %s", e)

--- a/command/funcs/database_backup_remove.go
+++ b/command/funcs/database_backup_remove.go
@@ -28,7 +28,7 @@ func DatabaseBackupRemove(ctx command.Context, params *params.BackupRemoveDataba
 		return fmt.Errorf("index(%d) is out of range", params.Index)
 	}
 
-	backupID := info.DBConf.Backup.History[params.Index-1].Id()
+	backupID := info.DBConf.Backup.History[params.Index-1].ID()
 	_, err := api.DeleteBackup(params.Id, backupID)
 	if err != nil {
 		return fmt.Errorf("DatabaseBackupRemove is failed: %s", e)

--- a/command/funcs/database_backup_restore.go
+++ b/command/funcs/database_backup_restore.go
@@ -29,7 +29,7 @@ func DatabaseBackupRestore(ctx command.Context, params *params.BackupRestoreData
 		return fmt.Errorf("index(%d) is out of range", params.Index)
 	}
 
-	backupID := info.DBConf.Backup.History[params.Index-1].Id()
+	backupID := info.DBConf.Backup.History[params.Index-1].ID()
 	err := internal.ExecWithProgress(
 		fmt.Sprintf("Still restoring from backup[ID:%d:%s]...", params.Id, backupID),
 		fmt.Sprintf("Restore Database[ID:%d]", params.Id),

--- a/command/funcs/database_backup_unlock.go
+++ b/command/funcs/database_backup_unlock.go
@@ -28,7 +28,7 @@ func DatabaseBackupUnlock(ctx command.Context, params *params.BackupUnlockDataba
 		return fmt.Errorf("index(%d) is out of range", params.Index)
 	}
 
-	backupID := info.DBConf.Backup.History[params.Index-1].Id()
+	backupID := info.DBConf.Backup.History[params.Index-1].ID()
 	_, err := api.HistoryUnlock(params.Id, backupID)
 	if err != nil {
 		return fmt.Errorf("DatabaseBackupUnlock is failed: %s", e)

--- a/command/funcs/gslb_create.go
+++ b/command/funcs/gslb_create.go
@@ -24,12 +24,12 @@ func GSLBCreate(ctx command.Context, params *params.CreateGSLBParam) error {
 		if params.Path == "" || params.ResponseCode == 0 {
 			return fmt.Errorf("path and response-code is required when protocol is http")
 		}
-		p.SetHttpHealthCheck(params.HostHeader, params.Path, params.ResponseCode)
+		p.SetHTTPHealthCheck(params.HostHeader, params.Path, params.ResponseCode)
 	case "https":
 		if params.Path == "" || params.ResponseCode == 0 {
 			return fmt.Errorf("path and response-code is required when protocol is https")
 		}
-		p.SetHttpsHealthCheck(params.HostHeader, params.Path, params.ResponseCode)
+		p.SetHTTPSHealthCheck(params.HostHeader, params.Path, params.ResponseCode)
 	case "ping":
 		p.SetPingHealthCheck()
 	case "tcp":

--- a/command/funcs/gslb_update.go
+++ b/command/funcs/gslb_update.go
@@ -58,7 +58,7 @@ func GSLBUpdate(ctx command.Context, params *params.UpdateGSLBParam) error {
 			if err != nil {
 				return fmt.Errorf("GSLBUpdate is failed: %s", e)
 			}
-			p.SetHttpHealthCheck(hostHeader, path, code)
+			p.SetHTTPHealthCheck(hostHeader, path, code)
 		case "https":
 
 			if p.Settings.GSLB.HealthCheck.Protocol != "https" && (params.Path == "" || params.ResponseCode == 0) {
@@ -83,7 +83,7 @@ func GSLBUpdate(ctx command.Context, params *params.UpdateGSLBParam) error {
 			if err != nil {
 				return fmt.Errorf("GSLBUpdate is failed: %s", e)
 			}
-			p.SetHttpsHealthCheck(hostHeader, path, code)
+			p.SetHTTPSHealthCheck(hostHeader, path, code)
 		case "ping":
 			p.SetPingHealthCheck()
 		case "tcp":

--- a/command/global_option.go
+++ b/command/global_option.go
@@ -15,6 +15,8 @@ type Option struct {
 	AccessTokenSecret string
 	Zone              string
 	ProfileName       string
+	Zones             []string
+	APIRootURL        string
 	TraceMode         bool
 	Format            string
 	In                io.Reader
@@ -70,6 +72,16 @@ var GlobalFlags = []cli.Flag{
 		Usage:       "Config(Profile) name",
 		EnvVars:     []string{"USACLOUD_PROFILE"},
 		Destination: &GlobalOption.ProfileName,
+	},
+	&cli.StringFlag{
+		Name:        "api-root-url",
+		Hidden:      true,
+		EnvVars:     []string{"USACLOUD_API_ROOT_URL"},
+		Destination: &GlobalOption.APIRootURL,
+	},
+	&cli.StringSliceFlag{
+		Name:   "zones",
+		Hidden: true,
 	},
 	&cli.BoolFlag{
 		Name:        "trace",

--- a/command/profile/profile.go
+++ b/command/profile/profile.go
@@ -72,6 +72,8 @@ type ConfigFileValue struct {
 	AccessToken       string
 	AccessTokenSecret string
 	Zone              string
+	Zones             []string `json:",omitempty"`
+	APIRootURL        string   `json:",omitempty"`
 }
 
 func (p *ConfigFileValue) IsEmpty() bool {

--- a/tools/gen-bash-completion/main.go
+++ b/tools/gen-bash-completion/main.go
@@ -93,6 +93,9 @@ func generateResource(resources sortableResources) (string, error) {
 	}
 
 	for _, f := range command.GlobalFlags {
+		if f.Names()[0] == "zones" || f.Names()[0] == "api-root-url" {
+			continue
+		}
 		switch f.(type) {
 		case *cli.BoolFlag:
 			globalFlags = append(globalFlags, toFlagNames(f.Names())...)

--- a/vendor/github.com/sacloud/libsacloud/Makefile
+++ b/vendor/github.com/sacloud/libsacloud/Makefile
@@ -22,7 +22,7 @@ vet: golint
 	go vet ./...
 
 golint: fmt
-	golint $(go list ./... | grep -v "_string.go")
+	test -z "$(golint ./... | tee /dev/stderr | grep -v '_string.go')"
 
 fmt:
 	gofmt -s -l -w $(GOFMT_FILES)

--- a/vendor/github.com/sacloud/libsacloud/api/client.go
+++ b/vendor/github.com/sacloud/libsacloud/api/client.go
@@ -14,8 +14,8 @@ import (
 	"time"
 )
 
-const (
-	sakuraCloudAPIRoot = "https://secure.sakura.ad.jp/cloud/zone"
+var (
+	SakuraCloudAPIRoot = "https://secure.sakura.ad.jp/cloud/zone"
 )
 
 // Client APIクライアント
@@ -68,7 +68,7 @@ func (c *Client) Clone() *Client {
 }
 
 func (c *Client) getEndpoint() string {
-	return fmt.Sprintf("%s/%s", sakuraCloudAPIRoot, c.Zone)
+	return fmt.Sprintf("%s/%s", SakuraCloudAPIRoot, c.Zone)
 }
 
 func (c *Client) isOkStatus(code int) bool {

--- a/vendor/github.com/sacloud/libsacloud/api/newsfeed.go
+++ b/vendor/github.com/sacloud/libsacloud/api/newsfeed.go
@@ -42,7 +42,7 @@ func (api *NewsFeedAPI) GetFeedByURL(url string) (*sacloud.NewsFeed, error) {
 		return nil, err
 	}
 	for _, r := range res {
-		if r.Url == url {
+		if r.URL == url {
 			return &r, nil
 		}
 	}

--- a/vendor/github.com/sacloud/libsacloud/builder/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/disk.go
@@ -858,7 +858,7 @@ func (b *DiskBuilder) createSSHKey(strKey string) (*sacloud.SSHKey, error) {
 	b.callEventHandlerIfExists(DiskBuildOnCreateSSHKeyBefore)
 
 	keyReq := b.client.SSHKey.New()
-	keyReq.Name = fmt.Sprintf("publickey-%s", time.Now())
+	keyReq.Name = fmt.Sprintf("publickey-%s", time.Now().Format(time.RFC3339))
 	keyReq.PublicKey = strKey
 
 	key, err := b.client.SSHKey.Create(keyReq)
@@ -904,7 +904,7 @@ func (b *DiskBuilder) createNote(strNote string) (*sacloud.Note, error) {
 	b.callEventHandlerIfExists(DiskBuildOnCreateNoteBefore)
 
 	noteReq := b.client.Note.New()
-	noteReq.Name = fmt.Sprintf("note-%s", time.Now())
+	noteReq.Name = fmt.Sprintf("note-%s", time.Now().Format(time.RFC3339))
 	noteReq.Content = strNote
 
 	note, err := b.client.Note.Create(noteReq)

--- a/vendor/github.com/sacloud/libsacloud/sacloud/database_status.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/database_status.go
@@ -45,8 +45,8 @@ func (l *DatabaseLog) Logs() []string {
 	return strings.Split(l.Data, "\n")
 }
 
-// Id ログのID取得
-func (l *DatabaseLog) Id() string {
+// ID ログのID取得
+func (l *DatabaseLog) ID() string {
 	return l.Name
 }
 
@@ -63,8 +63,8 @@ type DatabaseBackupHistory struct {
 	Size         int64      `json:"size,omitempty"`
 }
 
-// Id バックアップ履歴のID取得
-func (h *DatabaseBackupHistory) Id() string {
+// ID バックアップ履歴のID取得
+func (h *DatabaseBackupHistory) ID() string {
 	return h.CreatedAt.Format(time.RFC3339)
 }
 

--- a/vendor/github.com/sacloud/libsacloud/sacloud/feed.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/feed.go
@@ -12,7 +12,7 @@ type NewsFeed struct {
 	StrEventStart string `json:"event_start,omitempty"`
 	StrEventEnd   string `json:"event_end,omitempty"`
 	Title         string `json:"title,omitempty"`
-	Url           string `json:"url,omitempty"`
+	URL           string `json:"url,omitempty"`
 }
 
 // Date 対象日時

--- a/vendor/github.com/sacloud/libsacloud/sacloud/gslb.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/gslb.go
@@ -159,8 +159,8 @@ var defaultGSLBHealthCheck = GSLBHealthCheck{
 	Status:   "200",
 }
 
-// SetHttpHealthCheck HTTPヘルスチェック 設定
-func (g *GSLB) SetHttpHealthCheck(hostHeader string, path string, responseCode int) {
+// SetHTTPHealthCheck HTTPヘルスチェック 設定
+func (g *GSLB) SetHTTPHealthCheck(hostHeader string, path string, responseCode int) {
 	g.Settings.GSLB.HealthCheck.Protocol = "http"
 	g.Settings.GSLB.HealthCheck.Host = hostHeader
 	g.Settings.GSLB.HealthCheck.Path = path
@@ -169,8 +169,8 @@ func (g *GSLB) SetHttpHealthCheck(hostHeader string, path string, responseCode i
 
 }
 
-// SetHttpsHealthCheck HTTPSヘルスチェック 設定
-func (g *GSLB) SetHttpsHealthCheck(hostHeader string, path string, responseCode int) {
+// SetHTTPSHealthCheck HTTPSヘルスチェック 設定
+func (g *GSLB) SetHTTPSHealthCheck(hostHeader string, path string, responseCode int) {
 	g.Settings.GSLB.HealthCheck.Protocol = "https"
 	g.Settings.GSLB.HealthCheck.Host = hostHeader
 	g.Settings.GSLB.HealthCheck.Path = path

--- a/vendor/github.com/sacloud/libsacloud/sacloud/nfs.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/nfs.go
@@ -41,6 +41,7 @@ type CreateNFSValue struct {
 	Icon         *Resource // アイコン
 }
 
+// NewCreateNFSValue NFS作成用パラメーター
 func NewCreateNFSValue() *CreateNFSValue {
 	return &CreateNFSValue{
 		Plan: NFSPlan100G,

--- a/vendor/github.com/sacloud/libsacloud/sacloud/note.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/note.go
@@ -11,6 +11,6 @@ type Note struct {
 	propTags                // タグ
 	propCreatedAt           // 作成日時
 	PropModifiedAt          // 変更日時
+	propNoteClass           // クラス
 	Content          string // スクリプト本体
-	Class            string `json:",omitempty"` // クラス
 }

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_note_class.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_note_class.go
@@ -1,0 +1,39 @@
+package sacloud
+
+// ENoteClass スタートアップスクリプトクラス
+type ENoteClass string
+
+var (
+	// NoteClassShell shellクラス
+	NoteClassShell = ENoteClass("shell")
+	// NoteClassYAMLCloudConfig yaml_cloud_configクラス
+	NoteClassYAMLCloudConfig = ENoteClass("yaml_cloud_config")
+)
+
+// ENoteClasses 設定可能なスタートアップスクリプトクラス
+var ENoteClasses = []ENoteClass{NoteClassShell, NoteClassYAMLCloudConfig}
+
+// propNoteClass スタートアップスクリプトクラス情報内包型
+type propNoteClass struct {
+	Class ENoteClass `json:",omitempty"` // クラス
+}
+
+// GetClass クラス 取得
+func (p *propNoteClass) GetClass() ENoteClass {
+	return p.Class
+}
+
+// SetClass クラス 設定
+func (p *propNoteClass) SetClass(c ENoteClass) {
+	p.Class = c
+}
+
+// GetClassStr クラス 取得(文字列)
+func (p *propNoteClass) GetClassStr() string {
+	return string(p.Class)
+}
+
+// SetClassByStr クラス 設定(文字列)
+func (p *propNoteClass) SetClassByStr(c string) {
+	p.Class = ENoteClass(c)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -105,34 +105,34 @@
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
-			"checksumSHA1": "XI7myxuwZnJ3ySMwSCLTXcpBN4Y=",
+			"checksumSHA1": "Ty0DZIzKlQzVhbLRo0DlzTgcOPU=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "bcf90aaa06cac69e1ca43546f72badb17ab1d907",
-			"revisionTime": "2017-09-07T08:24:05Z"
+			"revision": "292a1fd22a5a2e350a9ed19fc7bb66afee7c991e",
+			"revisionTime": "2017-09-25T08:35:25Z"
 		},
 		{
-			"checksumSHA1": "Kk/yNBQXXuNSeJONEfCRFE4y6uM=",
+			"checksumSHA1": "q0BdCaNlOOdRLDGhUrj8Xys8TQk=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "bcf90aaa06cac69e1ca43546f72badb17ab1d907",
-			"revisionTime": "2017-09-07T08:24:05Z"
+			"revision": "292a1fd22a5a2e350a9ed19fc7bb66afee7c991e",
+			"revisionTime": "2017-09-25T08:35:25Z"
 		},
 		{
-			"checksumSHA1": "4F2EQ6GKInQQNsaC1aBu5ZLZ0n4=",
+			"checksumSHA1": "fxsLxYRyjctfpVbYdT6/6F+asJo=",
 			"path": "github.com/sacloud/libsacloud/builder",
-			"revision": "bcf90aaa06cac69e1ca43546f72badb17ab1d907",
-			"revisionTime": "2017-09-07T08:24:05Z"
+			"revision": "292a1fd22a5a2e350a9ed19fc7bb66afee7c991e",
+			"revisionTime": "2017-09-25T08:35:25Z"
 		},
 		{
-			"checksumSHA1": "9t3KUSxPYMH9QA8aMCji+aM9Yv8=",
+			"checksumSHA1": "M/I8zUn8AAC4og3stZn34+JPmrI=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "bcf90aaa06cac69e1ca43546f72badb17ab1d907",
-			"revisionTime": "2017-09-07T08:24:05Z"
+			"revision": "292a1fd22a5a2e350a9ed19fc7bb66afee7c991e",
+			"revisionTime": "2017-09-25T08:35:25Z"
 		},
 		{
 			"checksumSHA1": "CLqmrM7XFbaROU/9IbJyqR9Z1XM=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "bcf90aaa06cac69e1ca43546f72badb17ab1d907",
-			"revisionTime": "2017-09-07T08:24:05Z"
+			"revision": "292a1fd22a5a2e350a9ed19fc7bb66afee7c991e",
+			"revisionTime": "2017-09-25T08:35:25Z"
 		},
 		{
 			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",


### PR DESCRIPTION
## 概要

現在は以下の値が固定で利用されている。
- 対象ゾーン : [`is1a`,`is1b`,`tk1a`,`tk1v`]
- APIルートURL: `https://secure.sakura.ad.jp/cloud/zone/`

これをグローバルオプションを追加することで環境変数/設定ファイル/コマンドラインオプションから設定可能とする。

## 環境変数から設定する場合

#### 対象ゾーン
`USACLOUD_ZONES`環境変数に利用したいゾーン名をカンマ区切りで文字列を指定する。  
例えば`is1b`と`tk1v`だけを利用する場合、以下のように指定する。

```bash
$ export USACLOUD_ZONES="is1b,tk1a"
```

#### APIルートURL
`USACLOUD_API_ROOT_URL`環境変数を設定する。

```bash
$ export USACLOUD_API_ROOT_URL="https://192.168.0.1/sacloud-api-test/zone/"
```

## 設定ファイルで指定する場合

利用したいプロファイルの設定ファイルを直接編集する。
ファイルは`~/.usacloud/[プロファイル名]/config.json`となる(存在しない場合は直接作成する)

ゾーンに`is2a`と`is2b`、APIルートURLに`https://192.168.0.1/sacloud-api-test/zone/`を指定する場合、以下のように記載する。
```js
{
	"AccessToken": "",
	"AccessTokenSecret": "",
	"Zone": "is2a",
        "Zones": ["is2a","is2b"],
        "APIRootURL": "https://192.168.0.1/sacloud-api-test/zone/"
}
```

## コマンドラインオプションで指定する場合

## 設定ファイルで指定する場合

ゾーンに`is2a`と`is2b`、APIルートURLに`https://192.168.0.1/sacloud-api-test/zone/`を指定する場合、以下のように指定する。
```bash
$ usacloud --zones is2a --zones is2b --api-root-url "https://192.168.0.1/sacloud-api-test/zone/" リソース コマンド [オプション] [引数]
```

## 優先順位

通常のオプションと同じく、以下の順となる(後のものが優先)

- 環境変数
- プロファイル(設定ファイル)
- コマンドラインオプション

## 既知の問題

ゾーンの設定を変更してもbash_completionに反映されない。  
この問題は今後bash_completion用のスクリプトをusacloudコマンドから出力できるようにすることで解決する予定。  
(現在の利用可能ゾーン設定を反映したbash_completionスクリプトを出力)