### PR TITLE
シンプル監視でのSSLサーバ証明書 有効期限監視

### DIFF
--- a/command/cli/cli_simple_monitor_gen.go
+++ b/command/cli/cli_simple_monitor_gen.go
@@ -335,7 +335,7 @@ func init() {
 					},
 					&cli.StringFlag{
 						Name:  "protocol",
-						Usage: "[Required] set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3]",
+						Usage: "[Required] set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3/ssl-certificate]",
 						Value: "ping",
 					},
 					&cli.IntFlag{
@@ -371,6 +371,11 @@ func init() {
 						Name:  "dns-excepted",
 						Usage: "set DNS query excepted value",
 					},
+					&cli.IntFlag{
+						Name:  "remaining-days",
+						Usage: "set SSL-Certificate remaining days",
+						Value: 30,
+					},
 					&cli.BoolFlag{
 						Name:  "notify-email",
 						Usage: "enable e-mail notification",
@@ -379,6 +384,7 @@ func init() {
 					&cli.StringFlag{
 						Name:  "email-type",
 						Usage: "set e-mail type",
+						Value: "text",
 					},
 					&cli.StringFlag{
 						Name:  "slack-webhook",
@@ -497,6 +503,9 @@ func init() {
 					}
 					if c.IsSet("dns-excepted") {
 						createParam.DnsExcepted = c.String("dns-excepted")
+					}
+					if c.IsSet("remaining-days") {
+						createParam.RemainingDays = c.Int("remaining-days")
 					}
 					if c.IsSet("notify-email") {
 						createParam.NotifyEmail = c.Bool("notify-email")
@@ -657,6 +666,9 @@ func init() {
 					}
 					if c.IsSet("dns-excepted") {
 						createParam.DnsExcepted = c.String("dns-excepted")
+					}
+					if c.IsSet("remaining-days") {
+						createParam.RemainingDays = c.Int("remaining-days")
 					}
 					if c.IsSet("notify-email") {
 						createParam.NotifyEmail = c.Bool("notify-email")
@@ -1079,7 +1091,7 @@ func init() {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:  "protocol",
-						Usage: "set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3]",
+						Usage: "set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3/ssl-certificate]",
 					},
 					&cli.IntFlag{
 						Name:  "port",
@@ -1112,6 +1124,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "dns-excepted",
 						Usage: "set DNS query excepted value",
+					},
+					&cli.IntFlag{
+						Name:  "remaining-days",
+						Usage: "set SSL-Certificate remaining days",
 					},
 					&cli.BoolFlag{
 						Name:  "notify-email",
@@ -1244,6 +1260,9 @@ func init() {
 					}
 					if c.IsSet("dns-excepted") {
 						updateParam.DnsExcepted = c.String("dns-excepted")
+					}
+					if c.IsSet("remaining-days") {
+						updateParam.RemainingDays = c.Int("remaining-days")
 					}
 					if c.IsSet("notify-email") {
 						updateParam.NotifyEmail = c.Bool("notify-email")
@@ -1407,6 +1426,9 @@ func init() {
 					}
 					if c.IsSet("dns-excepted") {
 						updateParam.DnsExcepted = c.String("dns-excepted")
+					}
+					if c.IsSet("remaining-days") {
+						updateParam.RemainingDays = c.Int("remaining-days")
 					}
 					if c.IsSet("notify-email") {
 						updateParam.NotifyEmail = c.Bool("notify-email")
@@ -2059,6 +2081,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("simple-monitor", "create", "remaining-days", &schema.Category{
+		Key:         "ssl-check",
+		DisplayName: "Health-Check(SSL Certificate) options",
+		Order:       26,
+	})
 	AppendFlagCategoryMap("simple-monitor", "create", "response-code", &schema.Category{
 		Key:         "http-check",
 		DisplayName: "Health-Check(HTTP/HTTPS) options",
@@ -2363,6 +2390,11 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("simple-monitor", "update", "remaining-days", &schema.Category{
+		Key:         "ssl-check",
+		DisplayName: "Health-Check(SSL Certificate) options",
+		Order:       26,
 	})
 	AppendFlagCategoryMap("simple-monitor", "update", "response-code", &schema.Category{
 		Key:         "http-check",

--- a/command/completion/simple_monitor_flags_gen.go
+++ b/command/completion/simple_monitor_flags_gen.go
@@ -110,6 +110,11 @@ func SimpleMonitorCreateCompleteFlags(ctx command.Context, params *params.Create
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
+	case "remaining-days":
+		param := define.Resources["SimpleMonitor"].Commands["create"].BuildedParams().Get("remaining-days")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "notify-email":
 		param := define.Resources["SimpleMonitor"].Commands["create"].BuildedParams().Get("notify-email")
 		if param != nil {
@@ -224,6 +229,11 @@ func SimpleMonitorUpdateCompleteFlags(ctx command.Context, params *params.Update
 		}
 	case "dns_excepted":
 		param := define.Resources["SimpleMonitor"].Commands["update"].BuildedParams().Get("dns_excepted")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "remaining-days":
+		param := define.Resources["SimpleMonitor"].Commands["update"].BuildedParams().Get("remaining-days")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}

--- a/command/funcs/simple_monitor_create.go
+++ b/command/funcs/simple_monitor_create.go
@@ -66,6 +66,8 @@ func SimpleMonitorCreate(ctx command.Context, params *params.CreateSimpleMonitor
 			return fmt.Errorf("dns-qname is required when protocol is dns")
 		}
 		p.SetHealthCheckDNS(params.DnsQname, params.DnsExcepted)
+	case "ssl-certificate":
+		p.SetHealthCheckSSLCertificate(params.RemainingDays)
 	}
 
 	p.SetDelayLoop(params.DelayLoop * 60)

--- a/command/funcs/simple_monitor_update.go
+++ b/command/funcs/simple_monitor_update.go
@@ -101,6 +101,10 @@ func SimpleMonitorUpdate(ctx command.Context, params *params.UpdateSimpleMonitor
 			return fmt.Errorf("dns-qname is required when protocol is dns")
 		}
 		p.SetHealthCheckDNS(qname, excepted)
+	case "ssl-certificate":
+		if ctx.IsSet("remaining-days") {
+			p.SetHealthCheckSSLCertificate(params.RemainingDays)
+		}
 	}
 
 	if ctx.IsSet("delay-loop") {

--- a/command/params/params_simple_monitor_gen.go
+++ b/command/params/params_simple_monitor_gen.go
@@ -276,6 +276,7 @@ type CreateSimpleMonitorParam struct {
 	ResponseCode      int      `json:"response-code"`
 	DnsQname          string   `json:"dns-qname"`
 	DnsExcepted       string   `json:"dns-excepted"`
+	RemainingDays     int      `json:"remaining-days"`
 	NotifyEmail       bool     `json:"notify-email"`
 	EmailType         string   `json:"email-type"`
 	SlackWebhook      string   `json:"slack-webhook"`
@@ -297,9 +298,11 @@ type CreateSimpleMonitorParam struct {
 func NewCreateSimpleMonitorParam() *CreateSimpleMonitorParam {
 	return &CreateSimpleMonitorParam{
 
-		Protocol:    "ping",
-		DelayLoop:   1,
-		NotifyEmail: true,
+		Protocol:      "ping",
+		DelayLoop:     1,
+		RemainingDays: 30,
+		NotifyEmail:   true,
+		EmailType:     "text",
 	}
 }
 
@@ -334,6 +337,9 @@ func (p *CreateSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.DnsExcepted) {
 		p.DnsExcepted = ""
+	}
+	if isEmpty(p.RemainingDays) {
+		p.RemainingDays = 0
 	}
 	if isEmpty(p.NotifyEmail) {
 		p.NotifyEmail = false
@@ -424,6 +430,13 @@ func (p *CreateSimpleMonitorParam) Validate() []error {
 	{
 		validator := define.Resources["SimpleMonitor"].Commands["create"].Params["delay-loop"].ValidateFunc
 		errs := validator("--delay-loop", p.DelayLoop)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["SimpleMonitor"].Commands["create"].Params["remaining-days"].ValidateFunc
+		errs := validator("--remaining-days", p.RemainingDays)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -577,6 +590,13 @@ func (p *CreateSimpleMonitorParam) SetDnsExcepted(v string) {
 
 func (p *CreateSimpleMonitorParam) GetDnsExcepted() string {
 	return p.DnsExcepted
+}
+func (p *CreateSimpleMonitorParam) SetRemainingDays(v int) {
+	p.RemainingDays = v
+}
+
+func (p *CreateSimpleMonitorParam) GetRemainingDays() int {
+	return p.RemainingDays
 }
 func (p *CreateSimpleMonitorParam) SetNotifyEmail(v bool) {
 	p.NotifyEmail = v
@@ -882,6 +902,7 @@ type UpdateSimpleMonitorParam struct {
 	ResponseCode      int      `json:"response-code"`
 	DnsQname          string   `json:"dns-qname"`
 	DnsExcepted       string   `json:"dns-excepted"`
+	RemainingDays     int      `json:"remaining-days"`
 	NotifyEmail       bool     `json:"notify-email"`
 	EmailType         string   `json:"email-type"`
 	SlackWebhook      string   `json:"slack-webhook"`
@@ -934,6 +955,9 @@ func (p *UpdateSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.DnsExcepted) {
 		p.DnsExcepted = ""
+	}
+	if isEmpty(p.RemainingDays) {
+		p.RemainingDays = 0
 	}
 	if isEmpty(p.NotifyEmail) {
 		p.NotifyEmail = false
@@ -1009,6 +1033,13 @@ func (p *UpdateSimpleMonitorParam) Validate() []error {
 	{
 		validator := define.Resources["SimpleMonitor"].Commands["update"].Params["delay-loop"].ValidateFunc
 		errs := validator("--delay-loop", p.DelayLoop)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["SimpleMonitor"].Commands["update"].Params["remaining-days"].ValidateFunc
+		errs := validator("--remaining-days", p.RemainingDays)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1162,6 +1193,13 @@ func (p *UpdateSimpleMonitorParam) SetDnsExcepted(v string) {
 
 func (p *UpdateSimpleMonitorParam) GetDnsExcepted() string {
 	return p.DnsExcepted
+}
+func (p *UpdateSimpleMonitorParam) SetRemainingDays(v int) {
+	p.RemainingDays = v
+}
+
+func (p *UpdateSimpleMonitorParam) GetRemainingDays() int {
+	return p.RemainingDays
 }
 func (p *UpdateSimpleMonitorParam) SetNotifyEmail(v bool) {
 	p.NotifyEmail = v

--- a/define/simple_monitor.go
+++ b/define/simple_monitor.go
@@ -84,6 +84,11 @@ var simpleMonitorCreateParamCategories = []schema.Category{
 		Order:       24,
 	},
 	{
+		Key:         "ssl-check",
+		DisplayName: "Health-Check(SSL Certificate) options",
+		Order:       26,
+	},
+	{
 		Key:         "notify",
 		DisplayName: "Notify options",
 		Order:       30,
@@ -110,6 +115,11 @@ var simpleMonitorUpdateParamCategories = []schema.Category{
 		Key:         "dns-check",
 		DisplayName: "Health-Check(DNS) options",
 		Order:       24,
+	},
+	{
+		Key:         "ssl-check",
+		DisplayName: "Health-Check(SSL Certificate) options",
+		Order:       26,
 	},
 	{
 		Key:         "notify",
@@ -157,7 +167,7 @@ func simpleMonitorDetailExcludes() []string {
 	return []string{}
 }
 
-var allowSimpleMonitorProtocol = []string{"http", "https", "ping", "tcp", "dns", "ssh", "smtp", "pop3"}
+var allowSimpleMonitorProtocol = []string{"http", "https", "ping", "tcp", "dns", "ssh", "smtp", "pop3", "ssl-certificate"}
 
 func simpleMonitorCreateParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -172,7 +182,7 @@ func simpleMonitorCreateParam() map[string]*schema.Schema {
 		"protocol": {
 			Type:        schema.TypeString,
 			HandlerType: schema.HandlerNoop,
-			Description: "set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3]",
+			Description: "set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3/ssl-certificate]",
 			// TODO SNMP is not supported on current version.
 			ValidateFunc: validateInStrValues(allowSimpleMonitorProtocol...),
 			CompleteFunc: completeInStrValues(allowSimpleMonitorProtocol...),
@@ -242,6 +252,15 @@ func simpleMonitorCreateParam() map[string]*schema.Schema {
 			Category:    "dns-check",
 			Order:       20,
 		},
+		"remaining-days": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set SSL-Certificate remaining days",
+			ValidateFunc: validateIntRange(1, 9999),
+			DefaultValue: 30,
+			Category:     "ssl-check",
+			Order:        10,
+		},
 		"notify-email": {
 			Type:         schema.TypeBool,
 			HandlerType:  schema.HandlerNoop,
@@ -256,6 +275,7 @@ func simpleMonitorCreateParam() map[string]*schema.Schema {
 			Description:  "set e-mail type",
 			ValidateFunc: validateInStrValues("text", "html"),
 			CompleteFunc: completeInStrValues("text", "html"),
+			DefaultValue: "text",
 			Category:     "notify",
 			Order:        20,
 		},
@@ -281,7 +301,7 @@ func simpleMonitorUpdateParam() map[string]*schema.Schema {
 		"protocol": {
 			Type:        schema.TypeString,
 			HandlerType: schema.HandlerNoop,
-			Description: "set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3]",
+			Description: "set monitoring protocol[http/https/ping/tcp/dns/ssh/smtp/pop3/ssl-certificate]",
 			// TODO SNMP is not supported on current version.
 			ValidateFunc: validateInStrValues(allowSimpleMonitorProtocol...),
 			CompleteFunc: completeInStrValues(allowSimpleMonitorProtocol...),
@@ -345,6 +365,14 @@ func simpleMonitorUpdateParam() map[string]*schema.Schema {
 			Description: "set DNS query excepted value",
 			Category:    "dns-check",
 			Order:       20,
+		},
+		"remaining-days": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set SSL-Certificate remaining days",
+			ValidateFunc: validateIntRange(1, 9999),
+			Category:     "ssl-check",
+			Order:        10,
 		},
 		"notify-email": {
 			Type:        schema.TypeBool,


### PR DESCRIPTION
To fix #228 

以下のようにシンプル監視でのSSLサーバ証明書作成を行えるようにする。

```bash
$ usacloud simple-monitor create --target example.com --protocol ssl-certificate
```