### PR TITLE
Release version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.0 (2017-10-26)
+
+* アーカイブアップロード時のout of memory対応 #225, #227 (higebu)
+* VNCスナップショット機能の追加 #226 (misodengaku)
+* Pleskパブリックアーカイブを除去 #230 (yamamoto-febc)
+* ostypeパラメータによるCentOS6パブリックアーカイブの指定 #231 (yamamoto-febc)
+* シンプル監視でのSSLサーバ証明書 有効期限監視 #232 (yamamoto-febc)
+* configディレクトリが存在しない場合のconfig listコマンドエラー修正 #233 (yamamoto-febc)
+* 統合テスト(初期実装) #235 (yamamoto-febc)
+* FTPSアップロードでレスポンス226が応答されない問題の修正 #236 (yamamoto-febc)
+* IPv4/IPv6関連コマンドの追加 #237 (yamamoto-febc)
+
+
 ## 0.2.2 (2017-10-01)
 
 * NFSアプライアンス プラン追加 #220 (yamamoto-febc)

--- a/package/deb/debian/changelog
+++ b/package/deb/debian/changelog
@@ -1,3 +1,27 @@
+usacloud (0.3.0-1) stable; urgency=low
+
+  * アーカイブアップロード時のout of memory対応 (by higebu)
+    <https://github.com/sacloud/usacloud/pull/225>
+    <https://github.com/sacloud/usacloud/pull/227>
+  * VNCスナップショット機能の追加 (by misodengaku)
+    <https://github.com/sacloud/usacloud/pull/226>
+  * Pleskパブリックアーカイブを除去 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/230>
+  * ostypeパラメータによるCentOS6パブリックアーカイブの指定 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/231>
+  * シンプル監視でのSSLサーバ証明書 有効期限監視 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/232>
+  * configディレクトリが存在しない場合のconfig listコマンドエラー修正 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/233>
+  * 統合テスト(初期実装) (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/235>
+  * FTPSアップロードでレスポンス226が応答されない問題の修正 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/236>
+  * IPv4/IPv6関連コマンドの追加 (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/237>
+
+ -- usacloud <yamamoto.febc@gmail.com>  Thu, 26 Oct 2017 13:21:18 +0000
+
 usacloud (0.2.2-1) stable; urgency=low
 
   * NFSアプライアンス プラン追加 (by yamamoto-febc)

--- a/package/rpm/usacloud.spec
+++ b/package/rpm/usacloud.spec
@@ -40,6 +40,17 @@ CLI client of the SakuraCloud
 %{_sysconfdir}/bash_completion.d/usacloud
 
 %changelog
+* Thu Oct 26 2017 <yamamoto.febc@gmail.com> - 0.3.0-1
+- アーカイブアップロード時のout of memory対応 (by higebu)
+- VNCスナップショット機能の追加 (by misodengaku)
+- Pleskパブリックアーカイブを除去 (by yamamoto-febc)
+- ostypeパラメータによるCentOS6パブリックアーカイブの指定 (by yamamoto-febc)
+- シンプル監視でのSSLサーバ証明書 有効期限監視 (by yamamoto-febc)
+- configディレクトリが存在しない場合のconfig listコマンドエラー修正 (by yamamoto-febc)
+- 統合テスト(初期実装) (by yamamoto-febc)
+- FTPSアップロードでレスポンス226が応答されない問題の修正 (by yamamoto-febc)
+- IPv4/IPv6関連コマンドの追加 (by yamamoto-febc)
+
 * Sun Oct 01 2017 <yamamoto.febc@gmail.com> - 0.2.2-1
 - NFSアプライアンス プラン追加 (by yamamoto-febc)
 - ドキュメント更新 (by yamamoto-febc)


### PR DESCRIPTION
# CHANGELOG

- アーカイブアップロード時のout of memory対応 #225, #227
- VNCスナップショット機能の追加 #226
- Pleskパブリックアーカイブを除去 #230
- ostypeパラメータによるCentOS6パブリックアーカイブの指定 #231
- シンプル監視でのSSLサーバ証明書 有効期限監視 #232
- configディレクトリが存在しない場合のconfig listコマンドエラー修正 #233
- 統合テスト(初期実装) #235
- FTPSアップロードでレスポンス226が応答されない問題の修正 #236
- IPv4/IPv6関連コマンドの追加 #237

# 主な機能追加/変更点

## VNCスナップショット機能の追加 #226

VNC接続にてスナップショット(スクリーンショット)を取得する機能が追加されました。

#### 利用例

```bash
# VNCスナップショット取得(カレントディレクトリに[ID_yyyyMMdd_HHmmdd.gif]ファイルが作成される)
$ usacloud server vnc-snapshot [対象のID or 名称]

# 出力先を指定することも可能
$ usacloud server vnc-snapshot --output-path /your/file/path [対象のID or 名称]
```

## Pleskパブリックアーカイブを除去 #230

Pleskパブリックアーカイブの公開終了にともない`server build`時の`os-type`パラメータにて`plesk`を除去しました。

## ostypeパラメータによるCentOS6パブリックアーカイブの指定 #231

`server build`時の`os-type`パラメータに`centos6`が指定可能になりました。

#### 利用例

```bash
# CentOS6パブリックアーカイブを元にサーバ作成
$ usacloud server build --os-type centos6 --password "your-password" --name "your-name" --hostname "your-host-name"
```

## シンプル監視でのSSLサーバ証明書 有効期限監視 #232

シンプル監視にてSSLサーバ証明書の有効期限監視に対応しました。

#### 利用例

```bash
$ usacloud simple-monitor create --target example.com --protocol ssl-certificate --remaining-days 30
```

## IPv4/IPv6関連コマンドの追加 #237

以下のネットワーク関連コマンドを追加しました。

- スイッチ+ルータでのサブネット(スタティックルート)管理機能
- スイッチ+ルータでのIPv6機能
- IPv4 逆引きレコード管理機能
- IPv6 逆引きレコード管理機能

#### 利用例

#### スイッチ+ルータへのコマンド追加

```bash
# === サブネット(スタティックルート)関連 ===
# 一覧表示
$ usacloud internet subnet-info [対象スイッチ+ルータのID or Name]
# 追加
$ usacloud internet subnet-add --next-hop "your-global-ip" --nw-mask-len 28 [対象スイッチ+ルータのID or Name]
# 更新
$ usacloud internet subnet-update --next-hop "your-global-ip" [対象スイッチ+ルータのID or Name]
# 削除
$ usacloud internet subnet-delete --subnet-id 9999 [対象スイッチ+ルータのID or Name]

# === IPv6関連 ===
# 情報表示
$ usacloud internet ipv6-info [対象スイッチ+ルータのID or Name]
# IPv6有効化
$ usacloud internet ipv6-enable [対象スイッチ+ルータのID or Name]
# IPv6無効化(逆引きレコードが登録されている場合はエラーとなる)
$ usacloud internet ipv6-disable [対象スイッチ+ルータのID or Name]
```

#### ipv4リソース追加

```bash
# IPv4アドレス一覧表示
$ usacloud ipv4 list
# 逆引きレコード追加
$ usacloud ipv4 ptr-add --hostname "your-host-name" 192.0.2.1
# 逆引きレコード参照
$ usacloud ipv4 ptr-read 192.0.2.1
# 逆引きレコード更新
$ usacloud ipv4 ptr-update --hostname "your-host-name" 192.0.2.1
# 逆引きレコード削除
$ usacloud ipv4 ptr-delete 192.0.2.1
```


#### ipv6リソース追加

```bash
# IPv6アドレス一覧表示
$ usacloud ipv6 list
# IPv6アドレス一覧表示(スイッチ+ルータのIDでフィルタ)
$ usacloud ipv6 list --internet-id 123456789012
# IPv6アドレス一覧表示(IPv6NetのIDでフィルタ)
$ usacloud ipv6 list --ipv6net-id 999

# 逆引きレコード追加
$ usacloud ipv6 ptr-add --hostname "your-host-name" 2001:db8::1
# 逆引きレコード参照
$ usacloud ipv6 ptr-read 2001:db8::1
# 逆引きレコード更新
$ usacloud ipv6 ptr-update --hostname "your-host-name" 2001:db8::1
# 逆引きレコード削除
$ usacloud ipv6 ptr-delete 2001:db8::1
```

# バグ修正/改善

## アーカイブアップロード時のout of memory対応 #225, #227

アーカイブアップロード時に大きいサイズのファイルをアップロードしようとした場合に`Out of memory`エラーが発生していた問題を修正しました。

## configディレクトリが存在しない場合のconfig listコマンドエラー修正 #233

`config list`実行時のエラー修正を行いました。

## 統合テスト(初期実装) #235

`bats`での統合テストの仕組みを追加しました。
詳細は[test/integration/README.md](https://github.com/sacloud/usacloud/blob/master/test/integration/README.md)を参照ください。

## FTPSアップロードでレスポンス226が応答されない問題の修正 #236

FTPSでのアップロード処理が終了しないことがある問題を修正しました。

# Contributors

- @higebu (#225, #227)
- @misodengaku (#226)
- @yamamoto-febc (#230, #231, #232, #233, #235, #236, #237)
