### PR TITLE
VPCルータへの機能追加(DHCPでのDNSサーバ配布/NICごとのファイアウォール) 

### DIFF
--- a/command/cli/cli_vpc_router_gen.go
+++ b/command/cli/cli_vpc_router_gen.go
@@ -3882,7 +3882,7 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "index",
+						Name:  "interface",
 						Usage: "[Required] index of target private-interface",
 					},
 					&cli.StringFlag{
@@ -3970,8 +3970,8 @@ func init() {
 					ctx := command.NewContext(c, realArgs, interfaceConnectParam)
 
 					// Set option values
-					if c.IsSet("index") {
-						interfaceConnectParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						interfaceConnectParam.Interface = c.String("interface")
 					}
 					if c.IsSet("ipaddress") {
 						interfaceConnectParam.Ipaddress = c.String("ipaddress")
@@ -4094,8 +4094,8 @@ func init() {
 					}
 
 					// Set option values
-					if c.IsSet("index") {
-						interfaceConnectParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						interfaceConnectParam.Interface = c.String("interface")
 					}
 					if c.IsSet("ipaddress") {
 						interfaceConnectParam.Ipaddress = c.String("ipaddress")
@@ -4252,7 +4252,7 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "index",
+						Name:  "interface",
 						Usage: "[Required] index of target interface",
 					},
 					&cli.StringFlag{
@@ -4344,8 +4344,8 @@ func init() {
 					ctx := command.NewContext(c, realArgs, interfaceUpdateParam)
 
 					// Set option values
-					if c.IsSet("index") {
-						interfaceUpdateParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						interfaceUpdateParam.Interface = c.String("interface")
 					}
 					if c.IsSet("ipaddress") {
 						interfaceUpdateParam.Ipaddress = c.String("ipaddress")
@@ -4471,8 +4471,8 @@ func init() {
 					}
 
 					// Set option values
-					if c.IsSet("index") {
-						interfaceUpdateParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						interfaceUpdateParam.Interface = c.String("interface")
 					}
 					if c.IsSet("ipaddress") {
 						interfaceUpdateParam.Ipaddress = c.String("ipaddress")
@@ -4632,7 +4632,7 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "index",
+						Name:  "interface",
 						Usage: "[Required] index of target private-interface",
 					},
 					&cli.BoolFlag{
@@ -4695,8 +4695,8 @@ func init() {
 					ctx := command.NewContext(c, realArgs, interfaceDisconnectParam)
 
 					// Set option values
-					if c.IsSet("index") {
-						interfaceDisconnectParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						interfaceDisconnectParam.Interface = c.String("interface")
 					}
 					if c.IsSet("with-reboot") {
 						interfaceDisconnectParam.WithReboot = c.Bool("with-reboot")
@@ -4804,8 +4804,8 @@ func init() {
 					}
 
 					// Set option values
-					if c.IsSet("index") {
-						interfaceDisconnectParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						interfaceDisconnectParam.Interface = c.String("interface")
 					}
 					if c.IsSet("with-reboot") {
 						interfaceDisconnectParam.WithReboot = c.Bool("with-reboot")
@@ -6934,7 +6934,7 @@ func init() {
 				Flags: []cli.Flag{
 					&cli.IntFlag{
 						Name:  "index",
-						Usage: "[Required] index of target static NAT",
+						Usage: "[Required] index of target PortForward",
 					},
 					&cli.StringFlag{
 						Name:  "protocol",
@@ -7291,7 +7291,7 @@ func init() {
 				Flags: []cli.Flag{
 					&cli.IntFlag{
 						Name:  "index",
-						Usage: "[Required] index of target static NAT",
+						Usage: "[Required] index of target PortForward",
 					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
@@ -7595,6 +7595,11 @@ func init() {
 				Usage:     "Show information of firewall rules",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "interface",
+						Usage: "set target NIC index",
+						Value: 0,
+					},
 					&cli.StringFlag{
 						Name:  "direction",
 						Usage: "[Required] set target direction[send/receive]",
@@ -7675,6 +7680,9 @@ func init() {
 					ctx := command.NewContext(c, realArgs, firewallInfoParam)
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallInfoParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallInfoParam.Direction = c.String("direction")
 					}
@@ -7793,6 +7801,9 @@ func init() {
 					}
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallInfoParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallInfoParam.Direction = c.String("direction")
 					}
@@ -7939,6 +7950,11 @@ func init() {
 				Usage:     "Add firewall rule",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "interface",
+						Usage: "set target NIC index",
+						Value: 0,
+					},
 					&cli.StringFlag{
 						Name:  "direction",
 						Usage: "[Required] set target direction[send/receive]",
@@ -8036,6 +8052,9 @@ func init() {
 					ctx := command.NewContext(c, realArgs, firewallAddParam)
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallAddParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallAddParam.Direction = c.String("direction")
 					}
@@ -8166,6 +8185,9 @@ func init() {
 					}
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallAddParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallAddParam.Direction = c.String("direction")
 					}
@@ -8329,6 +8351,11 @@ func init() {
 				Usage:     "Update firewall rule",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "interface",
+						Usage: "set target NIC index",
+						Value: 0,
+					},
 					&cli.StringFlag{
 						Name:  "direction",
 						Usage: "[Required] set target direction[send/receive]",
@@ -8336,7 +8363,7 @@ func init() {
 					},
 					&cli.IntFlag{
 						Name:  "index",
-						Usage: "[Required] index of target static NAT",
+						Usage: "[Required] index of target Firewall rule",
 					},
 					&cli.StringFlag{
 						Name:  "protocol",
@@ -8430,6 +8457,9 @@ func init() {
 					ctx := command.NewContext(c, realArgs, firewallUpdateParam)
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallUpdateParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallUpdateParam.Direction = c.String("direction")
 					}
@@ -8563,6 +8593,9 @@ func init() {
 					}
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallUpdateParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallUpdateParam.Direction = c.String("direction")
 					}
@@ -8729,6 +8762,11 @@ func init() {
 				Usage:     "Delete firewall rule",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "interface",
+						Usage: "set target NIC index",
+						Value: 0,
+					},
 					&cli.StringFlag{
 						Name:  "direction",
 						Usage: "[Required] set target direction[send/receive]",
@@ -8736,7 +8774,7 @@ func init() {
 					},
 					&cli.IntFlag{
 						Name:  "index",
-						Usage: "[Required] index of target static NAT",
+						Usage: "[Required] index of target Firewall rule",
 					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
@@ -8794,6 +8832,9 @@ func init() {
 					ctx := command.NewContext(c, realArgs, firewallDeleteParam)
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallDeleteParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallDeleteParam.Direction = c.String("direction")
 					}
@@ -8903,6 +8944,9 @@ func init() {
 					}
 
 					// Set option values
+					if c.IsSet("interface") {
+						firewallDeleteParam.Interface = c.Int("interface")
+					}
 					if c.IsSet("direction") {
 						firewallDeleteParam.Direction = c.String("direction")
 					}
@@ -9380,7 +9424,7 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.IntFlag{
-						Name:  "index",
+						Name:  "interface",
 						Usage: "[Required] set target NIC(private NIC index)",
 					},
 					&cli.StringFlag{
@@ -9391,6 +9435,10 @@ func init() {
 						Name:    "range-stop",
 						Aliases: []string{"range-end"},
 						Usage:   "[Required] set DHCP IPAddress Range(stop)",
+					},
+					&cli.StringSliceFlag{
+						Name:  "dns-servers",
+						Usage: "set DNS Server IPAddress",
 					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
@@ -9448,14 +9496,17 @@ func init() {
 					ctx := command.NewContext(c, realArgs, dhcpServerAddParam)
 
 					// Set option values
-					if c.IsSet("index") {
-						dhcpServerAddParam.Index = c.Int("index")
+					if c.IsSet("interface") {
+						dhcpServerAddParam.Interface = c.Int("interface")
 					}
 					if c.IsSet("range-start") {
 						dhcpServerAddParam.RangeStart = c.String("range-start")
 					}
 					if c.IsSet("range-stop") {
 						dhcpServerAddParam.RangeStop = c.String("range-stop")
+					}
+					if c.IsSet("dns-servers") {
+						dhcpServerAddParam.DnsServers = c.StringSlice("dns-servers")
 					}
 					if c.IsSet("selector") {
 						dhcpServerAddParam.Selector = c.StringSlice("selector")
@@ -9560,14 +9611,17 @@ func init() {
 					}
 
 					// Set option values
-					if c.IsSet("index") {
-						dhcpServerAddParam.Index = c.Int("index")
+					if c.IsSet("interface") {
+						dhcpServerAddParam.Interface = c.Int("interface")
 					}
 					if c.IsSet("range-start") {
 						dhcpServerAddParam.RangeStart = c.String("range-start")
 					}
 					if c.IsSet("range-stop") {
 						dhcpServerAddParam.RangeStop = c.String("range-stop")
+					}
+					if c.IsSet("dns-servers") {
+						dhcpServerAddParam.DnsServers = c.StringSlice("dns-servers")
 					}
 					if c.IsSet("selector") {
 						dhcpServerAddParam.Selector = c.StringSlice("selector")
@@ -9706,7 +9760,7 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.IntFlag{
-						Name:  "index",
+						Name:  "interface",
 						Usage: "[Required] set target NIC(private NIC index)",
 					},
 					&cli.StringFlag{
@@ -9717,6 +9771,10 @@ func init() {
 						Name:    "range-stop",
 						Aliases: []string{"range-end"},
 						Usage:   "set DHCP IPAddress Range(stop)",
+					},
+					&cli.StringSliceFlag{
+						Name:  "dns-servers",
+						Usage: "set DNS Server IPAddress",
 					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
@@ -9774,14 +9832,17 @@ func init() {
 					ctx := command.NewContext(c, realArgs, dhcpServerUpdateParam)
 
 					// Set option values
-					if c.IsSet("index") {
-						dhcpServerUpdateParam.Index = c.Int("index")
+					if c.IsSet("interface") {
+						dhcpServerUpdateParam.Interface = c.Int("interface")
 					}
 					if c.IsSet("range-start") {
 						dhcpServerUpdateParam.RangeStart = c.String("range-start")
 					}
 					if c.IsSet("range-stop") {
 						dhcpServerUpdateParam.RangeStop = c.String("range-stop")
+					}
+					if c.IsSet("dns-servers") {
+						dhcpServerUpdateParam.DnsServers = c.StringSlice("dns-servers")
 					}
 					if c.IsSet("selector") {
 						dhcpServerUpdateParam.Selector = c.StringSlice("selector")
@@ -9886,14 +9947,17 @@ func init() {
 					}
 
 					// Set option values
-					if c.IsSet("index") {
-						dhcpServerUpdateParam.Index = c.Int("index")
+					if c.IsSet("interface") {
+						dhcpServerUpdateParam.Interface = c.Int("interface")
 					}
 					if c.IsSet("range-start") {
 						dhcpServerUpdateParam.RangeStart = c.String("range-start")
 					}
 					if c.IsSet("range-stop") {
 						dhcpServerUpdateParam.RangeStop = c.String("range-stop")
+					}
+					if c.IsSet("dns-servers") {
+						dhcpServerUpdateParam.DnsServers = c.StringSlice("dns-servers")
 					}
 					if c.IsSet("selector") {
 						dhcpServerUpdateParam.Selector = c.StringSlice("selector")
@@ -10032,7 +10096,7 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.IntFlag{
-						Name:  "index",
+						Name:  "interface",
 						Usage: "[Required] set target NIC(private NIC index)",
 					},
 					&cli.StringSliceFlag{
@@ -10091,8 +10155,8 @@ func init() {
 					ctx := command.NewContext(c, realArgs, dhcpServerDeleteParam)
 
 					// Set option values
-					if c.IsSet("index") {
-						dhcpServerDeleteParam.Index = c.Int("index")
+					if c.IsSet("interface") {
+						dhcpServerDeleteParam.Interface = c.Int("interface")
 					}
 					if c.IsSet("selector") {
 						dhcpServerDeleteParam.Selector = c.StringSlice("selector")
@@ -10197,8 +10261,8 @@ func init() {
 					}
 
 					// Set option values
-					if c.IsSet("index") {
-						dhcpServerDeleteParam.Index = c.Int("index")
+					if c.IsSet("interface") {
+						dhcpServerDeleteParam.Interface = c.Int("interface")
 					}
 					if c.IsSet("selector") {
 						dhcpServerDeleteParam.Selector = c.StringSlice("selector")
@@ -16849,7 +16913,7 @@ func init() {
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "index",
+						Name:  "interface",
 						Usage: "[Required] index of target interface",
 						Value: "0",
 					},
@@ -16941,8 +17005,8 @@ func init() {
 					ctx := command.NewContext(c, realArgs, monitorParam)
 
 					// Set option values
-					if c.IsSet("index") {
-						monitorParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						monitorParam.Interface = c.String("interface")
 					}
 					if c.IsSet("start") {
 						monitorParam.Start = c.String("start")
@@ -17068,8 +17132,8 @@ func init() {
 					}
 
 					// Set option values
-					if c.IsSet("index") {
-						monitorParam.Index = c.String("index")
+					if c.IsSet("interface") {
+						monitorParam.Interface = c.String("interface")
 					}
 					if c.IsSet("start") {
 						monitorParam.Start = c.String("start")
@@ -18016,6 +18080,11 @@ func init() {
 		DisplayName: "Input options",
 		Order:       2147483627,
 	})
+	AppendFlagCategoryMap("vpc-router", "dhcp-server-add", "dns-servers", &schema.Category{
+		Key:         "DHCP-Server",
+		DisplayName: "DHCP-Server options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("vpc-router", "dhcp-server-add", "generate-skeleton", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -18026,7 +18095,7 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
-	AppendFlagCategoryMap("vpc-router", "dhcp-server-add", "index", &schema.Category{
+	AppendFlagCategoryMap("vpc-router", "dhcp-server-add", "interface", &schema.Category{
 		Key:         "DHCP-Server",
 		DisplayName: "DHCP-Server options",
 		Order:       1,
@@ -18071,7 +18140,7 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
-	AppendFlagCategoryMap("vpc-router", "dhcp-server-delete", "index", &schema.Category{
+	AppendFlagCategoryMap("vpc-router", "dhcp-server-delete", "interface", &schema.Category{
 		Key:         "DHCP-Server",
 		DisplayName: "DHCP-Server options",
 		Order:       1,
@@ -18146,6 +18215,11 @@ func init() {
 		DisplayName: "Input options",
 		Order:       2147483627,
 	})
+	AppendFlagCategoryMap("vpc-router", "dhcp-server-update", "dns-servers", &schema.Category{
+		Key:         "DHCP-Server",
+		DisplayName: "DHCP-Server options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("vpc-router", "dhcp-server-update", "generate-skeleton", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -18156,7 +18230,7 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
-	AppendFlagCategoryMap("vpc-router", "dhcp-server-update", "index", &schema.Category{
+	AppendFlagCategoryMap("vpc-router", "dhcp-server-update", "interface", &schema.Category{
 		Key:         "DHCP-Server",
 		DisplayName: "DHCP-Server options",
 		Order:       1,
@@ -18401,6 +18475,11 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
+	AppendFlagCategoryMap("vpc-router", "firewall-add", "interface", &schema.Category{
+		Key:         "Firewall",
+		DisplayName: "Firewall options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("vpc-router", "firewall-add", "param-template", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -18456,6 +18535,11 @@ func init() {
 		DisplayName: "Firewall options",
 		Order:       1,
 	})
+	AppendFlagCategoryMap("vpc-router", "firewall-delete", "interface", &schema.Category{
+		Key:         "Firewall",
+		DisplayName: "Firewall options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("vpc-router", "firewall-delete", "param-template", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -18500,6 +18584,11 @@ func init() {
 		Key:         "default",
 		DisplayName: "Other options",
 		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("vpc-router", "firewall-info", "interface", &schema.Category{
+		Key:         "Firewall",
+		DisplayName: "Firewall options",
+		Order:       1,
 	})
 	AppendFlagCategoryMap("vpc-router", "firewall-info", "output-type", &schema.Category{
 		Key:         "output",
@@ -18576,6 +18665,11 @@ func init() {
 		DisplayName: "Firewall options",
 		Order:       1,
 	})
+	AppendFlagCategoryMap("vpc-router", "firewall-update", "interface", &schema.Category{
+		Key:         "Firewall",
+		DisplayName: "Firewall options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("vpc-router", "firewall-update", "param-template", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -18621,7 +18715,7 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
-	AppendFlagCategoryMap("vpc-router", "interface-connect", "index", &schema.Category{
+	AppendFlagCategoryMap("vpc-router", "interface-connect", "interface", &schema.Category{
 		Key:         "interface",
 		DisplayName: "Interface options",
 		Order:       1,
@@ -18686,7 +18780,7 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
-	AppendFlagCategoryMap("vpc-router", "interface-disconnect", "index", &schema.Category{
+	AppendFlagCategoryMap("vpc-router", "interface-disconnect", "interface", &schema.Category{
 		Key:         "interface",
 		DisplayName: "Interface options",
 		Order:       1,
@@ -18781,7 +18875,7 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
-	AppendFlagCategoryMap("vpc-router", "interface-update", "index", &schema.Category{
+	AppendFlagCategoryMap("vpc-router", "interface-update", "interface", &schema.Category{
 		Key:         "interface",
 		DisplayName: "Interface options",
 		Order:       1,
@@ -19076,7 +19170,7 @@ func init() {
 		DisplayName: "Other options",
 		Order:       2147483647,
 	})
-	AppendFlagCategoryMap("vpc-router", "monitor", "index", &schema.Category{
+	AppendFlagCategoryMap("vpc-router", "monitor", "interface", &schema.Category{
 		Key:         "monitor",
 		DisplayName: "Monitor options",
 		Order:       1,

--- a/command/completion/vpc_router_flags_gen.go
+++ b/command/completion/vpc_router_flags_gen.go
@@ -409,8 +409,8 @@ func VPCRouterInterfaceConnectCompleteFlags(ctx command.Context, params *params.
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "index":
-		param := define.Resources["VPCRouter"].Commands["interface-connect"].BuildedParams().Get("index")
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["interface-connect"].BuildedParams().Get("interface")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -468,8 +468,8 @@ func VPCRouterInterfaceUpdateCompleteFlags(ctx command.Context, params *params.I
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "index":
-		param := define.Resources["VPCRouter"].Commands["interface-update"].BuildedParams().Get("index")
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["interface-update"].BuildedParams().Get("interface")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -532,8 +532,8 @@ func VPCRouterInterfaceDisconnectCompleteFlags(ctx command.Context, params *para
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "index":
-		param := define.Resources["VPCRouter"].Commands["interface-disconnect"].BuildedParams().Get("index")
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["interface-disconnect"].BuildedParams().Get("interface")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -862,6 +862,11 @@ func VPCRouterFirewallInfoCompleteFlags(ctx command.Context, params *params.Fire
 	var comp schema.CompletionFunc
 
 	switch flagName {
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["firewall-info"].BuildedParams().Get("interface")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "direction":
 		param := define.Resources["VPCRouter"].Commands["firewall-info"].BuildedParams().Get("direction")
 		if param != nil {
@@ -893,6 +898,11 @@ func VPCRouterFirewallAddCompleteFlags(ctx command.Context, params *params.Firew
 	var comp schema.CompletionFunc
 
 	switch flagName {
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["firewall-add"].BuildedParams().Get("interface")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "direction":
 		param := define.Resources["VPCRouter"].Commands["firewall-add"].BuildedParams().Get("direction")
 		if param != nil {
@@ -962,6 +972,11 @@ func VPCRouterFirewallUpdateCompleteFlags(ctx command.Context, params *params.Fi
 	var comp schema.CompletionFunc
 
 	switch flagName {
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["firewall-update"].BuildedParams().Get("interface")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "direction":
 		param := define.Resources["VPCRouter"].Commands["firewall-update"].BuildedParams().Get("direction")
 		if param != nil {
@@ -1036,6 +1051,11 @@ func VPCRouterFirewallDeleteCompleteFlags(ctx command.Context, params *params.Fi
 	var comp schema.CompletionFunc
 
 	switch flagName {
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["firewall-delete"].BuildedParams().Get("interface")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "direction":
 		param := define.Resources["VPCRouter"].Commands["firewall-delete"].BuildedParams().Get("direction")
 		if param != nil {
@@ -1096,8 +1116,8 @@ func VPCRouterDhcpServerAddCompleteFlags(ctx command.Context, params *params.Dhc
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "index":
-		param := define.Resources["VPCRouter"].Commands["dhcp-server-add"].BuildedParams().Get("index")
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["dhcp-server-add"].BuildedParams().Get("interface")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -1108,6 +1128,11 @@ func VPCRouterDhcpServerAddCompleteFlags(ctx command.Context, params *params.Dhc
 		}
 	case "range-stop", "range-end":
 		param := define.Resources["VPCRouter"].Commands["dhcp-server-add"].BuildedParams().Get("range-stop")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "dns-servers":
+		param := define.Resources["VPCRouter"].Commands["dhcp-server-add"].BuildedParams().Get("dns-servers")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -1135,8 +1160,8 @@ func VPCRouterDhcpServerUpdateCompleteFlags(ctx command.Context, params *params.
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "index":
-		param := define.Resources["VPCRouter"].Commands["dhcp-server-update"].BuildedParams().Get("index")
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["dhcp-server-update"].BuildedParams().Get("interface")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -1147,6 +1172,11 @@ func VPCRouterDhcpServerUpdateCompleteFlags(ctx command.Context, params *params.
 		}
 	case "range-stop", "range-end":
 		param := define.Resources["VPCRouter"].Commands["dhcp-server-update"].BuildedParams().Get("range-stop")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "dns-servers":
+		param := define.Resources["VPCRouter"].Commands["dhcp-server-update"].BuildedParams().Get("dns-servers")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -1174,8 +1204,8 @@ func VPCRouterDhcpServerDeleteCompleteFlags(ctx command.Context, params *params.
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "index":
-		param := define.Resources["VPCRouter"].Commands["dhcp-server-delete"].BuildedParams().Get("index")
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["dhcp-server-delete"].BuildedParams().Get("interface")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -1880,8 +1910,8 @@ func VPCRouterMonitorCompleteFlags(ctx command.Context, params *params.MonitorVP
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "index":
-		param := define.Resources["VPCRouter"].Commands["monitor"].BuildedParams().Get("index")
+	case "interface":
+		param := define.Resources["VPCRouter"].Commands["monitor"].BuildedParams().Get("interface")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}

--- a/command/funcs/vpc_router_dhcp_server_add.go
+++ b/command/funcs/vpc_router_dhcp_server_add.go
@@ -20,9 +20,10 @@ func VPCRouterDhcpServerAdd(ctx command.Context, params *params.DhcpServerAddVPC
 	}
 
 	p.Settings.Router.AddDHCPServer(
-		params.Index,
+		params.Interface,
 		params.RangeStart,
 		params.RangeStop,
+		params.DnsServers...,
 	)
 
 	_, err := api.UpdateSetting(params.Id, p)

--- a/command/funcs/vpc_router_dhcp_server_delete.go
+++ b/command/funcs/vpc_router_dhcp_server_delete.go
@@ -19,12 +19,12 @@ func VPCRouterDhcpServerDelete(ctx command.Context, params *params.DhcpServerDel
 		return fmt.Errorf("VPCRouter[%d] don't have any DHCP servers", params.Id)
 	}
 
-	cnf := p.Settings.Router.FindDHCPServerAt(params.Index)
+	cnf := p.Settings.Router.FindDHCPServerAt(params.Interface)
 	if cnf == nil {
-		return fmt.Errorf("DHCP server is not found on eth%d", params.Index)
+		return fmt.Errorf("DHCP server is not found on eth%d", params.Interface)
 	}
 
-	p.Settings.Router.RemoveDHCPServerAt(params.Index)
+	p.Settings.Router.RemoveDHCPServerAt(params.Interface)
 
 	_, err := api.UpdateSetting(params.Id, p)
 	if err != nil {

--- a/command/funcs/vpc_router_dhcp_server_info.go
+++ b/command/funcs/vpc_router_dhcp_server_info.go
@@ -2,8 +2,10 @@ package funcs
 
 import (
 	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
+	"strings"
 )
 
 func VPCRouterDhcpServerInfo(ctx command.Context, params *params.DhcpServerInfoVPCRouterParam) error {
@@ -24,7 +26,13 @@ func VPCRouterDhcpServerInfo(ctx command.Context, params *params.DhcpServerInfoV
 	// build parameters to display table
 	list := []interface{}{}
 	for i := range confList {
-		list = append(list, &confList[i])
+		list = append(list, &struct {
+			*sacloud.VPCRouterDHCPServerConfig
+			DNSServerList string
+		}{
+			VPCRouterDHCPServerConfig: confList[i],
+			DNSServerList:             strings.Join(confList[i].DNSServers, ","),
+		})
 	}
 
 	return ctx.GetOutput().Print(list...)

--- a/command/funcs/vpc_router_dhcp_server_update.go
+++ b/command/funcs/vpc_router_dhcp_server_update.go
@@ -19,9 +19,9 @@ func VPCRouterDhcpServerUpdate(ctx command.Context, params *params.DhcpServerUpd
 		return fmt.Errorf("VPCRouter[%d] don't have any DHCP servers", params.Id)
 	}
 
-	cnf := p.Settings.Router.FindDHCPServerAt(params.Index)
+	cnf := p.Settings.Router.FindDHCPServerAt(params.Interface)
 	if cnf == nil {
-		return fmt.Errorf("DHCP server is not found on eth%d", params.Index)
+		return fmt.Errorf("DHCP server is not found on eth%d", params.Interface)
 	}
 
 	if ctx.IsSet("range-start") {
@@ -29,6 +29,9 @@ func VPCRouterDhcpServerUpdate(ctx command.Context, params *params.DhcpServerUpd
 	}
 	if ctx.IsSet("range-stop") {
 		cnf.RangeStop = params.RangeStop
+	}
+	if ctx.IsSet("dns_servers") {
+		cnf.DNSServers = params.DnsServers
 	}
 
 	_, err := api.UpdateSetting(params.Id, p)

--- a/command/funcs/vpc_router_firewall_add.go
+++ b/command/funcs/vpc_router_firewall_add.go
@@ -45,7 +45,7 @@ func VPCRouterFirewallAdd(ctx command.Context, params *params.FirewallAddVPCRout
 		}
 	}
 
-	var f func(isAllow bool, protocol string, sourceNetwork string, sourcePort string, destNetwork string, destPort string, logging bool, description string)
+	var f func(ifIndex int, isAllow bool, protocol string, sourceNetwork string, sourcePort string, destNetwork string, destPort string, logging bool, description string)
 	switch params.Direction {
 	case "send":
 		f = p.Settings.Router.AddFirewallRuleSend
@@ -54,6 +54,7 @@ func VPCRouterFirewallAdd(ctx command.Context, params *params.FirewallAddVPCRout
 	}
 	// add
 	f(
+		params.Interface,
 		isAllow,
 		params.Protocol,
 		params.SourceNetwork,

--- a/command/funcs/vpc_router_firewall_delete.go
+++ b/command/funcs/vpc_router_firewall_delete.go
@@ -20,22 +20,20 @@ func VPCRouterFirewallDelete(ctx command.Context, params *params.FirewallDeleteV
 	}
 
 	// validate
-	if params.Index <= 0 {
-		cnt := len(p.Settings.Router.Firewall.Config[0].Receive)
-		if params.Direction == "send" {
-			cnt = len(p.Settings.Router.Firewall.Config[0].Send)
-		}
+	cnt := len(p.Settings.Router.Firewall.Config[params.Interface].Receive)
+	if params.Direction == "send" {
+		cnt = len(p.Settings.Router.Firewall.Config[params.Interface].Send)
+	}
 
-		if params.Index-1 >= cnt {
-			return fmt.Errorf("index(%d) is out of range", params.Index)
-		}
+	if params.Index <= 0 || params.Index-1 >= cnt {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
 	}
 
 	switch params.Direction {
 	case "send":
-		p.Settings.Router.RemoveFirewallRuleSendAt(params.Index - 1)
+		p.Settings.Router.RemoveFirewallRuleSendAt(params.Interface, params.Index-1)
 	case "receive":
-		p.Settings.Router.RemoveFirewallRuleReceiveAt(params.Index - 1)
+		p.Settings.Router.RemoveFirewallRuleReceiveAt(params.Interface, params.Index-1)
 	}
 
 	_, err := api.UpdateSetting(params.Id, p)

--- a/command/funcs/vpc_router_firewall_info.go
+++ b/command/funcs/vpc_router_firewall_info.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
 )
@@ -20,12 +21,12 @@ func VPCRouterFirewallInfo(ctx command.Context, params *params.FirewallInfoVPCRo
 		return nil
 	}
 
-	ruleList := p.Settings.Router.Firewall.Config[0].Receive
+	ruleList := p.Settings.Router.Firewall.Config[params.Interface].Receive
 	switch params.Direction {
 	case "send":
-		ruleList = p.Settings.Router.Firewall.Config[0].Send
+		ruleList = p.Settings.Router.Firewall.Config[params.Interface].Send
 	case "receive":
-		ruleList = p.Settings.Router.Firewall.Config[0].Receive
+		ruleList = p.Settings.Router.Firewall.Config[params.Interface].Receive
 	}
 
 	if len(ruleList) == 0 {
@@ -36,7 +37,13 @@ func VPCRouterFirewallInfo(ctx command.Context, params *params.FirewallInfoVPCRo
 	// build parameters to display table
 	list := []interface{}{}
 	for i := range ruleList {
-		list = append(list, &ruleList[i])
+		list = append(list, &struct {
+			*sacloud.VPCRouterFirewallRule
+			Interface int
+		}{
+			VPCRouterFirewallRule: ruleList[i],
+			Interface:             params.Interface,
+		})
 	}
 
 	return ctx.GetOutput().Print(list...)

--- a/command/funcs/vpc_router_firewall_update.go
+++ b/command/funcs/vpc_router_firewall_update.go
@@ -31,23 +31,21 @@ func VPCRouterFirewallUpdate(ctx command.Context, params *params.FirewallUpdateV
 	}
 
 	// validate
-	if params.Index <= 0 {
-		cnt := len(p.Settings.Router.Firewall.Config[0].Receive)
-		if params.Direction == "send" {
-			cnt = len(p.Settings.Router.Firewall.Config[0].Send)
-		}
+	cnt := len(p.Settings.Router.Firewall.Config[params.Interface].Receive)
+	if params.Direction == "send" {
+		cnt = len(p.Settings.Router.Firewall.Config[params.Interface].Send)
+	}
 
-		if params.Index-1 >= cnt {
-			return fmt.Errorf("index(%d) is out of range", params.Index)
-		}
+	if params.Index <= 0 || params.Index-1 >= cnt {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
 	}
 
 	var rule *sacloud.VPCRouterFirewallRule
 	switch params.Direction {
 	case "send":
-		rule = p.Settings.Router.Firewall.Config[0].Send[params.Index-1]
+		rule = p.Settings.Router.Firewall.Config[params.Interface].Send[params.Index-1]
 	case "receive":
-		rule = p.Settings.Router.Firewall.Config[0].Receive[params.Index-1]
+		rule = p.Settings.Router.Firewall.Config[params.Interface].Receive[params.Index-1]
 	}
 
 	if ctx.IsSet("protocol") {

--- a/command/funcs/vpc_router_interface_connect.go
+++ b/command/funcs/vpc_router_interface_connect.go
@@ -16,7 +16,7 @@ func VPCRouterInterfaceConnect(ctx command.Context, params *params.InterfaceConn
 	if e != nil {
 		return fmt.Errorf("VPCRouterInterfaceConnect is failed: %s", e)
 	}
-	index, _ := strconv.Atoi(params.Index)
+	index, _ := strconv.Atoi(params.Interface)
 
 	// validation
 	if !p.IsStandardPlan() {

--- a/command/funcs/vpc_router_interface_disconnect.go
+++ b/command/funcs/vpc_router_interface_disconnect.go
@@ -16,7 +16,7 @@ func VPCRouterInterfaceDisconnect(ctx command.Context, params *params.InterfaceD
 	if e != nil {
 		return fmt.Errorf("VPCRouterInterfaceDisconnect is failed: %s", e)
 	}
-	index, _ := strconv.Atoi(params.Index)
+	index, _ := strconv.Atoi(params.Interface)
 
 	// validation
 	if p.Interfaces[index].GetSwitch() == nil {

--- a/command/funcs/vpc_router_interface_update.go
+++ b/command/funcs/vpc_router_interface_update.go
@@ -16,7 +16,7 @@ func VPCRouterInterfaceUpdate(ctx command.Context, params *params.InterfaceUpdat
 	if e != nil {
 		return fmt.Errorf("VPCRouterInterfaceUpdate is failed: %s", e)
 	}
-	index, _ := strconv.Atoi(params.Index)
+	index, _ := strconv.Atoi(params.Interface)
 
 	// validation
 	if p.Interfaces[index].GetSwitch() == nil {

--- a/command/funcs/vpc_router_monitor.go
+++ b/command/funcs/vpc_router_monitor.go
@@ -29,7 +29,7 @@ func VPCRouterMonitor(ctx command.Context, params *params.MonitorVPCRouterParam)
 	}
 
 	req := sacloud.NewResourceMonitorRequest(&start, &end)
-	nicIndex, _ := strconv.Atoi(params.Index)
+	nicIndex, _ := strconv.Atoi(params.Interface)
 	var nicType string
 	if nicIndex == 0 {
 		nicType = "Global"
@@ -70,7 +70,7 @@ func VPCRouterMonitor(ctx command.Context, params *params.MonitorVPCRouterParam)
 	list := MonitorValues{}
 	for i := range receiveValues {
 		list = append(list, MonitorValue{
-			"Index":     params.Index,
+			"Index":     params.Interface,
 			"Type":      nicType,
 			"Key":       key,
 			"TimeStamp": fmt.Sprintf("%s", receiveValues[i].Time),

--- a/command/params/params_vpc_router_gen.go
+++ b/command/params/params_vpc_router_gen.go
@@ -2231,7 +2231,7 @@ func (p *InterfaceInfoVPCRouterParam) GetId() int64 {
 
 // InterfaceConnectVPCRouterParam is input parameters for the sacloud API
 type InterfaceConnectVPCRouterParam struct {
-	Index             string   `json:"index"`
+	Interface         string   `json:"interface"`
 	Ipaddress         string   `json:"ipaddress"`
 	WithReboot        bool     `json:"with-reboot"`
 	Ipaddress1        string   `json:"ipaddress1"`
@@ -2256,8 +2256,8 @@ func NewInterfaceConnectVPCRouterParam() *InterfaceConnectVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *InterfaceConnectVPCRouterParam) FillValueToSkeleton() {
-	if isEmpty(p.Index) {
-		p.Index = ""
+	if isEmpty(p.Interface) {
+		p.Interface = ""
 	}
 	if isEmpty(p.Ipaddress) {
 		p.Ipaddress = ""
@@ -2303,14 +2303,14 @@ func (p *InterfaceConnectVPCRouterParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--index", p.Index)
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["VPCRouter"].Commands["interface-connect"].Params["index"].ValidateFunc
-		errs := validator("--index", p.Index)
+		validator := define.Resources["VPCRouter"].Commands["interface-connect"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2403,12 +2403,12 @@ func (p *InterfaceConnectVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
-func (p *InterfaceConnectVPCRouterParam) SetIndex(v string) {
-	p.Index = v
+func (p *InterfaceConnectVPCRouterParam) SetInterface(v string) {
+	p.Interface = v
 }
 
-func (p *InterfaceConnectVPCRouterParam) GetIndex() string {
-	return p.Index
+func (p *InterfaceConnectVPCRouterParam) GetInterface() string {
+	return p.Interface
 }
 func (p *InterfaceConnectVPCRouterParam) SetIpaddress(v string) {
 	p.Ipaddress = v
@@ -2497,7 +2497,7 @@ func (p *InterfaceConnectVPCRouterParam) GetId() int64 {
 
 // InterfaceUpdateVPCRouterParam is input parameters for the sacloud API
 type InterfaceUpdateVPCRouterParam struct {
-	Index             string   `json:"index"`
+	Interface         string   `json:"interface"`
 	Ipaddress         string   `json:"ipaddress"`
 	WithReboot        bool     `json:"with-reboot"`
 	Ipaddress1        string   `json:"ipaddress1"`
@@ -2523,8 +2523,8 @@ func NewInterfaceUpdateVPCRouterParam() *InterfaceUpdateVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *InterfaceUpdateVPCRouterParam) FillValueToSkeleton() {
-	if isEmpty(p.Index) {
-		p.Index = ""
+	if isEmpty(p.Interface) {
+		p.Interface = ""
 	}
 	if isEmpty(p.Ipaddress) {
 		p.Ipaddress = ""
@@ -2573,14 +2573,14 @@ func (p *InterfaceUpdateVPCRouterParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--index", p.Index)
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["VPCRouter"].Commands["interface-update"].Params["index"].ValidateFunc
-		errs := validator("--index", p.Index)
+		validator := define.Resources["VPCRouter"].Commands["interface-update"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2666,12 +2666,12 @@ func (p *InterfaceUpdateVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
-func (p *InterfaceUpdateVPCRouterParam) SetIndex(v string) {
-	p.Index = v
+func (p *InterfaceUpdateVPCRouterParam) SetInterface(v string) {
+	p.Interface = v
 }
 
-func (p *InterfaceUpdateVPCRouterParam) GetIndex() string {
-	return p.Index
+func (p *InterfaceUpdateVPCRouterParam) GetInterface() string {
+	return p.Interface
 }
 func (p *InterfaceUpdateVPCRouterParam) SetIpaddress(v string) {
 	p.Ipaddress = v
@@ -2767,7 +2767,7 @@ func (p *InterfaceUpdateVPCRouterParam) GetId() int64 {
 
 // InterfaceDisconnectVPCRouterParam is input parameters for the sacloud API
 type InterfaceDisconnectVPCRouterParam struct {
-	Index             string   `json:"index"`
+	Interface         string   `json:"interface"`
 	WithReboot        bool     `json:"with-reboot"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
@@ -2784,8 +2784,8 @@ func NewInterfaceDisconnectVPCRouterParam() *InterfaceDisconnectVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *InterfaceDisconnectVPCRouterParam) FillValueToSkeleton() {
-	if isEmpty(p.Index) {
-		p.Index = ""
+	if isEmpty(p.Interface) {
+		p.Interface = ""
 	}
 	if isEmpty(p.WithReboot) {
 		p.WithReboot = false
@@ -2816,14 +2816,14 @@ func (p *InterfaceDisconnectVPCRouterParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--index", p.Index)
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["VPCRouter"].Commands["interface-disconnect"].Params["index"].ValidateFunc
-		errs := validator("--index", p.Index)
+		validator := define.Resources["VPCRouter"].Commands["interface-disconnect"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2867,12 +2867,12 @@ func (p *InterfaceDisconnectVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
-func (p *InterfaceDisconnectVPCRouterParam) SetIndex(v string) {
-	p.Index = v
+func (p *InterfaceDisconnectVPCRouterParam) SetInterface(v string) {
+	p.Interface = v
 }
 
-func (p *InterfaceDisconnectVPCRouterParam) GetIndex() string {
-	return p.Index
+func (p *InterfaceDisconnectVPCRouterParam) GetInterface() string {
+	return p.Interface
 }
 func (p *InterfaceDisconnectVPCRouterParam) SetWithReboot(v bool) {
 	p.WithReboot = v
@@ -4440,6 +4440,7 @@ func (p *PortForwardingDeleteVPCRouterParam) GetId() int64 {
 
 // FirewallInfoVPCRouterParam is input parameters for the sacloud API
 type FirewallInfoVPCRouterParam struct {
+	Interface         int      `json:"interface"`
 	Direction         string   `json:"direction"`
 	Selector          []string `json:"selector"`
 	ParamTemplate     string   `json:"param-template"`
@@ -4463,6 +4464,9 @@ func NewFirewallInfoVPCRouterParam() *FirewallInfoVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *FirewallInfoVPCRouterParam) FillValueToSkeleton() {
+	if isEmpty(p.Interface) {
+		p.Interface = 0
+	}
 	if isEmpty(p.Direction) {
 		p.Direction = ""
 	}
@@ -4502,6 +4506,13 @@ func (p *FirewallInfoVPCRouterParam) FillValueToSkeleton() {
 // Validate checks current values in model
 func (p *FirewallInfoVPCRouterParam) Validate() []error {
 	errors := []error{}
+	{
+		validator := define.Resources["VPCRouter"].Commands["firewall-info"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
 	{
 		validator := validateRequired
 		errs := validator("--direction", p.Direction)
@@ -4575,6 +4586,13 @@ func (p *FirewallInfoVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *FirewallInfoVPCRouterParam) SetInterface(v int) {
+	p.Interface = v
+}
+
+func (p *FirewallInfoVPCRouterParam) GetInterface() int {
+	return p.Interface
+}
 func (p *FirewallInfoVPCRouterParam) SetDirection(v string) {
 	p.Direction = v
 }
@@ -4655,6 +4673,7 @@ func (p *FirewallInfoVPCRouterParam) GetId() int64 {
 
 // FirewallAddVPCRouterParam is input parameters for the sacloud API
 type FirewallAddVPCRouterParam struct {
+	Interface          int      `json:"interface"`
 	Direction          string   `json:"direction"`
 	Protocol           string   `json:"protocol"`
 	SourceNetwork      string   `json:"source-network"`
@@ -4683,6 +4702,9 @@ func NewFirewallAddVPCRouterParam() *FirewallAddVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *FirewallAddVPCRouterParam) FillValueToSkeleton() {
+	if isEmpty(p.Interface) {
+		p.Interface = 0
+	}
 	if isEmpty(p.Direction) {
 		p.Direction = ""
 	}
@@ -4734,6 +4756,13 @@ func (p *FirewallAddVPCRouterParam) FillValueToSkeleton() {
 // Validate checks current values in model
 func (p *FirewallAddVPCRouterParam) Validate() []error {
 	errors := []error{}
+	{
+		validator := define.Resources["VPCRouter"].Commands["firewall-add"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
 	{
 		validator := validateRequired
 		errs := validator("--direction", p.Direction)
@@ -4850,6 +4879,13 @@ func (p *FirewallAddVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *FirewallAddVPCRouterParam) SetInterface(v int) {
+	p.Interface = v
+}
+
+func (p *FirewallAddVPCRouterParam) GetInterface() int {
+	return p.Interface
+}
 func (p *FirewallAddVPCRouterParam) SetDirection(v string) {
 	p.Direction = v
 }
@@ -4958,6 +4994,7 @@ func (p *FirewallAddVPCRouterParam) GetId() int64 {
 
 // FirewallUpdateVPCRouterParam is input parameters for the sacloud API
 type FirewallUpdateVPCRouterParam struct {
+	Interface          int      `json:"interface"`
 	Direction          string   `json:"direction"`
 	Index              int      `json:"index"`
 	Protocol           string   `json:"protocol"`
@@ -4987,6 +5024,9 @@ func NewFirewallUpdateVPCRouterParam() *FirewallUpdateVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *FirewallUpdateVPCRouterParam) FillValueToSkeleton() {
+	if isEmpty(p.Interface) {
+		p.Interface = 0
+	}
 	if isEmpty(p.Direction) {
 		p.Direction = ""
 	}
@@ -5041,6 +5081,13 @@ func (p *FirewallUpdateVPCRouterParam) FillValueToSkeleton() {
 // Validate checks current values in model
 func (p *FirewallUpdateVPCRouterParam) Validate() []error {
 	errors := []error{}
+	{
+		validator := define.Resources["VPCRouter"].Commands["firewall-update"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
 	{
 		validator := validateRequired
 		errs := validator("--direction", p.Direction)
@@ -5150,6 +5197,13 @@ func (p *FirewallUpdateVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *FirewallUpdateVPCRouterParam) SetInterface(v int) {
+	p.Interface = v
+}
+
+func (p *FirewallUpdateVPCRouterParam) GetInterface() int {
+	return p.Interface
+}
 func (p *FirewallUpdateVPCRouterParam) SetDirection(v string) {
 	p.Direction = v
 }
@@ -5265,6 +5319,7 @@ func (p *FirewallUpdateVPCRouterParam) GetId() int64 {
 
 // FirewallDeleteVPCRouterParam is input parameters for the sacloud API
 type FirewallDeleteVPCRouterParam struct {
+	Interface         int      `json:"interface"`
 	Direction         string   `json:"direction"`
 	Index             int      `json:"index"`
 	Selector          []string `json:"selector"`
@@ -5285,6 +5340,9 @@ func NewFirewallDeleteVPCRouterParam() *FirewallDeleteVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *FirewallDeleteVPCRouterParam) FillValueToSkeleton() {
+	if isEmpty(p.Interface) {
+		p.Interface = 0
+	}
 	if isEmpty(p.Direction) {
 		p.Direction = ""
 	}
@@ -5315,6 +5373,13 @@ func (p *FirewallDeleteVPCRouterParam) FillValueToSkeleton() {
 // Validate checks current values in model
 func (p *FirewallDeleteVPCRouterParam) Validate() []error {
 	errors := []error{}
+	{
+		validator := define.Resources["VPCRouter"].Commands["firewall-delete"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
 	{
 		validator := validateRequired
 		errs := validator("--direction", p.Direction)
@@ -5375,6 +5440,13 @@ func (p *FirewallDeleteVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
+func (p *FirewallDeleteVPCRouterParam) SetInterface(v int) {
+	p.Interface = v
+}
+
+func (p *FirewallDeleteVPCRouterParam) GetInterface() int {
+	return p.Interface
+}
 func (p *FirewallDeleteVPCRouterParam) SetDirection(v string) {
 	p.Direction = v
 }
@@ -5621,9 +5693,10 @@ func (p *DhcpServerInfoVPCRouterParam) GetId() int64 {
 
 // DhcpServerAddVPCRouterParam is input parameters for the sacloud API
 type DhcpServerAddVPCRouterParam struct {
-	Index             int      `json:"index"`
+	Interface         int      `json:"interface"`
 	RangeStart        string   `json:"range-start"`
 	RangeStop         string   `json:"range-stop"`
+	DnsServers        []string `json:"dns-servers"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
 	ParamTemplate     string   `json:"param-template"`
@@ -5639,14 +5712,17 @@ func NewDhcpServerAddVPCRouterParam() *DhcpServerAddVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *DhcpServerAddVPCRouterParam) FillValueToSkeleton() {
-	if isEmpty(p.Index) {
-		p.Index = 0
+	if isEmpty(p.Interface) {
+		p.Interface = 0
 	}
 	if isEmpty(p.RangeStart) {
 		p.RangeStart = ""
 	}
 	if isEmpty(p.RangeStop) {
 		p.RangeStop = ""
+	}
+	if isEmpty(p.DnsServers) {
+		p.DnsServers = []string{""}
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -5674,14 +5750,14 @@ func (p *DhcpServerAddVPCRouterParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--index", p.Index)
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["index"].ValidateFunc
-		errs := validator("--index", p.Index)
+		validator := define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5710,6 +5786,13 @@ func (p *DhcpServerAddVPCRouterParam) Validate() []error {
 	{
 		validator := define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["range-stop"].ValidateFunc
 		errs := validator("--range-stop", p.RangeStop)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["VPCRouter"].Commands["dhcp-server-add"].Params["dns-servers"].ValidateFunc
+		errs := validator("--dns-servers", p.DnsServers)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5753,12 +5836,12 @@ func (p *DhcpServerAddVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
-func (p *DhcpServerAddVPCRouterParam) SetIndex(v int) {
-	p.Index = v
+func (p *DhcpServerAddVPCRouterParam) SetInterface(v int) {
+	p.Interface = v
 }
 
-func (p *DhcpServerAddVPCRouterParam) GetIndex() int {
-	return p.Index
+func (p *DhcpServerAddVPCRouterParam) GetInterface() int {
+	return p.Interface
 }
 func (p *DhcpServerAddVPCRouterParam) SetRangeStart(v string) {
 	p.RangeStart = v
@@ -5773,6 +5856,13 @@ func (p *DhcpServerAddVPCRouterParam) SetRangeStop(v string) {
 
 func (p *DhcpServerAddVPCRouterParam) GetRangeStop() string {
 	return p.RangeStop
+}
+func (p *DhcpServerAddVPCRouterParam) SetDnsServers(v []string) {
+	p.DnsServers = v
+}
+
+func (p *DhcpServerAddVPCRouterParam) GetDnsServers() []string {
+	return p.DnsServers
 }
 func (p *DhcpServerAddVPCRouterParam) SetSelector(v []string) {
 	p.Selector = v
@@ -5819,9 +5909,10 @@ func (p *DhcpServerAddVPCRouterParam) GetId() int64 {
 
 // DhcpServerUpdateVPCRouterParam is input parameters for the sacloud API
 type DhcpServerUpdateVPCRouterParam struct {
-	Index             int      `json:"index"`
+	Interface         int      `json:"interface"`
 	RangeStart        string   `json:"range-start"`
 	RangeStop         string   `json:"range-stop"`
+	DnsServers        []string `json:"dns-servers"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
 	ParamTemplate     string   `json:"param-template"`
@@ -5837,14 +5928,17 @@ func NewDhcpServerUpdateVPCRouterParam() *DhcpServerUpdateVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *DhcpServerUpdateVPCRouterParam) FillValueToSkeleton() {
-	if isEmpty(p.Index) {
-		p.Index = 0
+	if isEmpty(p.Interface) {
+		p.Interface = 0
 	}
 	if isEmpty(p.RangeStart) {
 		p.RangeStart = ""
 	}
 	if isEmpty(p.RangeStop) {
 		p.RangeStop = ""
+	}
+	if isEmpty(p.DnsServers) {
+		p.DnsServers = []string{""}
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -5872,14 +5966,14 @@ func (p *DhcpServerUpdateVPCRouterParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--index", p.Index)
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["index"].ValidateFunc
-		errs := validator("--index", p.Index)
+		validator := define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5894,6 +5988,13 @@ func (p *DhcpServerUpdateVPCRouterParam) Validate() []error {
 	{
 		validator := define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["range-stop"].ValidateFunc
 		errs := validator("--range-stop", p.RangeStop)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["VPCRouter"].Commands["dhcp-server-update"].Params["dns-servers"].ValidateFunc
+		errs := validator("--dns-servers", p.DnsServers)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5937,12 +6038,12 @@ func (p *DhcpServerUpdateVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
-func (p *DhcpServerUpdateVPCRouterParam) SetIndex(v int) {
-	p.Index = v
+func (p *DhcpServerUpdateVPCRouterParam) SetInterface(v int) {
+	p.Interface = v
 }
 
-func (p *DhcpServerUpdateVPCRouterParam) GetIndex() int {
-	return p.Index
+func (p *DhcpServerUpdateVPCRouterParam) GetInterface() int {
+	return p.Interface
 }
 func (p *DhcpServerUpdateVPCRouterParam) SetRangeStart(v string) {
 	p.RangeStart = v
@@ -5957,6 +6058,13 @@ func (p *DhcpServerUpdateVPCRouterParam) SetRangeStop(v string) {
 
 func (p *DhcpServerUpdateVPCRouterParam) GetRangeStop() string {
 	return p.RangeStop
+}
+func (p *DhcpServerUpdateVPCRouterParam) SetDnsServers(v []string) {
+	p.DnsServers = v
+}
+
+func (p *DhcpServerUpdateVPCRouterParam) GetDnsServers() []string {
+	return p.DnsServers
 }
 func (p *DhcpServerUpdateVPCRouterParam) SetSelector(v []string) {
 	p.Selector = v
@@ -6003,7 +6111,7 @@ func (p *DhcpServerUpdateVPCRouterParam) GetId() int64 {
 
 // DhcpServerDeleteVPCRouterParam is input parameters for the sacloud API
 type DhcpServerDeleteVPCRouterParam struct {
-	Index             int      `json:"index"`
+	Interface         int      `json:"interface"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
 	ParamTemplate     string   `json:"param-template"`
@@ -6019,8 +6127,8 @@ func NewDhcpServerDeleteVPCRouterParam() *DhcpServerDeleteVPCRouterParam {
 
 // FillValueToSkeleton fill values to empty fields
 func (p *DhcpServerDeleteVPCRouterParam) FillValueToSkeleton() {
-	if isEmpty(p.Index) {
-		p.Index = 0
+	if isEmpty(p.Interface) {
+		p.Interface = 0
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -6048,14 +6156,14 @@ func (p *DhcpServerDeleteVPCRouterParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--index", p.Index)
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["VPCRouter"].Commands["dhcp-server-delete"].Params["index"].ValidateFunc
-		errs := validator("--index", p.Index)
+		validator := define.Resources["VPCRouter"].Commands["dhcp-server-delete"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6099,12 +6207,12 @@ func (p *DhcpServerDeleteVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
-func (p *DhcpServerDeleteVPCRouterParam) SetIndex(v int) {
-	p.Index = v
+func (p *DhcpServerDeleteVPCRouterParam) SetInterface(v int) {
+	p.Interface = v
 }
 
-func (p *DhcpServerDeleteVPCRouterParam) GetIndex() int {
-	return p.Index
+func (p *DhcpServerDeleteVPCRouterParam) GetInterface() int {
+	return p.Interface
 }
 func (p *DhcpServerDeleteVPCRouterParam) SetSelector(v []string) {
 	p.Selector = v
@@ -9710,7 +9818,7 @@ func (p *StaticRouteDeleteVPCRouterParam) GetId() int64 {
 
 // MonitorVPCRouterParam is input parameters for the sacloud API
 type MonitorVPCRouterParam struct {
-	Index             string   `json:"index"`
+	Interface         string   `json:"interface"`
 	Start             string   `json:"start"`
 	End               string   `json:"end"`
 	KeyFormat         string   `json:"key-format"`
@@ -9730,15 +9838,15 @@ type MonitorVPCRouterParam struct {
 func NewMonitorVPCRouterParam() *MonitorVPCRouterParam {
 	return &MonitorVPCRouterParam{
 
-		Index:     "0",
+		Interface: "0",
 		KeyFormat: "sakuracloud.vpcrouter.{{.ID}}.nic.{{.Index}}",
 	}
 }
 
 // FillValueToSkeleton fill values to empty fields
 func (p *MonitorVPCRouterParam) FillValueToSkeleton() {
-	if isEmpty(p.Index) {
-		p.Index = ""
+	if isEmpty(p.Interface) {
+		p.Interface = ""
 	}
 	if isEmpty(p.Start) {
 		p.Start = ""
@@ -9787,14 +9895,14 @@ func (p *MonitorVPCRouterParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--index", p.Index)
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["VPCRouter"].Commands["monitor"].Params["index"].ValidateFunc
-		errs := validator("--index", p.Index)
+		validator := define.Resources["VPCRouter"].Commands["monitor"].Params["interface"].ValidateFunc
+		errs := validator("--interface", p.Interface)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -9879,12 +9987,12 @@ func (p *MonitorVPCRouterParam) GetOutputFormat() string {
 	return "table"
 }
 
-func (p *MonitorVPCRouterParam) SetIndex(v string) {
-	p.Index = v
+func (p *MonitorVPCRouterParam) SetInterface(v string) {
+	p.Interface = v
 }
 
-func (p *MonitorVPCRouterParam) GetIndex() string {
-	return p.Index
+func (p *MonitorVPCRouterParam) GetInterface() string {
+	return p.Interface
 }
 func (p *MonitorVPCRouterParam) SetStart(v string) {
 	p.Start = v

--- a/define/vpc_router.go
+++ b/define/vpc_router.go
@@ -748,6 +748,11 @@ func vpcRouterPortForwardingListColumns() []output.ColumnDef {
 
 func vpcRouterFirewallListColumns() []output.ColumnDef {
 	return []output.ColumnDef{
+		{
+			Name:    "NIC",
+			Sources: []string{"Interface"},
+			Format:  "eth%s",
+		},
 		{Name: "__ORDER__"}, // magic column name(generated on demand)
 		{Name: "Protocol"},
 		{Name: "SourceNetwork"},
@@ -774,6 +779,7 @@ func vpcRouterDHCPServerListColumns() []output.ColumnDef {
 		{Name: "Interface"},
 		{Name: "RangeStart"},
 		{Name: "RangeStop"},
+		{Name: "DNSServerList"},
 	}
 }
 
@@ -1016,7 +1022,7 @@ func vpcRouterInterfaceInfoParam() map[string]*schema.Schema {
 
 func vpcRouterInterfaceConnectParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"index": {
+		"interface": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
 			Description:  "index of target private-interface",
@@ -1085,7 +1091,7 @@ func vpcRouterInterfaceConnectParam() map[string]*schema.Schema {
 
 func vpcRouterInterfaceUpdateParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"index": {
+		"interface": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
 			Description:  "index of target interface",
@@ -1160,7 +1166,7 @@ func vpcRouterInterfaceUpdateParam() map[string]*schema.Schema {
 
 func vpcRouterInterfaceDisconnectParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"index": {
+		"interface": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
 			Description:  "index of target private-interface",
@@ -1331,7 +1337,7 @@ func vpcRouterPortForwardingUpdateParam() map[string]*schema.Schema {
 		"index": {
 			Type:        schema.TypeInt,
 			HandlerType: schema.HandlerNoop,
-			Description: "index of target static NAT",
+			Description: "index of target PortForward",
 			Required:    true,
 			Category:    "Port-Forwarding",
 			Order:       1,
@@ -1387,7 +1393,7 @@ func vpcRouterPortForwardingDeleteParam() map[string]*schema.Schema {
 		"index": {
 			Type:        schema.TypeInt,
 			HandlerType: schema.HandlerNoop,
-			Description: "index of target static NAT",
+			Description: "index of target PortForward",
 			Required:    true,
 			Category:    "Port-Forwarding",
 			Order:       1,
@@ -1397,6 +1403,15 @@ func vpcRouterPortForwardingDeleteParam() map[string]*schema.Schema {
 
 func vpcRouterFirewallInfoParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"interface": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set target NIC index",
+			ValidateFunc: validateIntRange(0, 7),
+			DefaultValue: 0,
+			Category:     "Firewall",
+			Order:        1,
+		},
 		"direction": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
@@ -1406,13 +1421,22 @@ func vpcRouterFirewallInfoParam() map[string]*schema.Schema {
 			Required:     true,
 			DefaultValue: "receive",
 			Category:     "Firewall",
-			Order:        1,
+			Order:        2,
 		},
 	}
 }
 
 func vpcRouterFirewallAddParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"interface": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set target NIC index",
+			ValidateFunc: validateIntRange(0, 7),
+			DefaultValue: 0,
+			Category:     "Firewall",
+			Order:        1,
+		},
 		"direction": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
@@ -1422,7 +1446,7 @@ func vpcRouterFirewallAddParam() map[string]*schema.Schema {
 			Required:     true,
 			DefaultValue: "receive",
 			Category:     "Firewall",
-			Order:        1,
+			Order:        2,
 		},
 		"protocol": {
 			Type:         schema.TypeString,
@@ -1500,6 +1524,15 @@ func vpcRouterFirewallAddParam() map[string]*schema.Schema {
 
 func vpcRouterFirewallUpdateParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"interface": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set target NIC index",
+			ValidateFunc: validateIntRange(0, 7),
+			DefaultValue: 0,
+			Category:     "Firewall",
+			Order:        1,
+		},
 		"direction": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
@@ -1509,15 +1542,15 @@ func vpcRouterFirewallUpdateParam() map[string]*schema.Schema {
 			Required:     true,
 			DefaultValue: "receive",
 			Category:     "Firewall",
-			Order:        1,
+			Order:        2,
 		},
 		"index": {
 			Type:        schema.TypeInt,
 			HandlerType: schema.HandlerNoop,
-			Description: "index of target static NAT",
+			Description: "index of target Firewall rule",
 			Required:    true,
 			Category:    "Firewall",
-			Order:       2,
+			Order:       3,
 		},
 		"protocol": {
 			Type:         schema.TypeString,
@@ -1593,6 +1626,15 @@ func vpcRouterFirewallUpdateParam() map[string]*schema.Schema {
 
 func vpcRouterFirewallDeleteParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"interface": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set target NIC index",
+			ValidateFunc: validateIntRange(0, 7),
+			DefaultValue: 0,
+			Category:     "Firewall",
+			Order:        1,
+		},
 		"direction": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
@@ -1602,15 +1644,15 @@ func vpcRouterFirewallDeleteParam() map[string]*schema.Schema {
 			Required:     true,
 			DefaultValue: "receive",
 			Category:     "Firewall",
-			Order:        1,
+			Order:        2,
 		},
 		"index": {
 			Type:        schema.TypeInt,
 			HandlerType: schema.HandlerNoop,
-			Description: "index of target static NAT",
+			Description: "index of target Firewall rule",
 			Required:    true,
 			Category:    "Firewall",
-			Order:       2,
+			Order:       3,
 		},
 	}
 }
@@ -1621,7 +1663,7 @@ func vpcRouterDHCPServerInfoParam() map[string]*schema.Schema {
 
 func vpcRouterDHCPServerAddParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"index": {
+		"interface": {
 			Type:         schema.TypeInt,
 			HandlerType:  schema.HandlerNoop,
 			Description:  "set target NIC(private NIC index)",
@@ -1648,13 +1690,21 @@ func vpcRouterDHCPServerAddParam() map[string]*schema.Schema {
 			Required:     true,
 			Category:     "DHCP-Server",
 			Order:        20,
+		},
+		"dns-servers": {
+			Type:         schema.TypeStringList,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set DNS Server IPAddress",
+			ValidateFunc: validateStringSlice(validateIPv4Address()),
+			Category:     "DHCP-Server",
+			Order:        30,
 		},
 	}
 }
 
 func vpcRouterDHCPServerUpdateParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"index": {
+		"interface": {
 			Type:         schema.TypeInt,
 			HandlerType:  schema.HandlerNoop,
 			Description:  "set target NIC(private NIC index)",
@@ -1680,12 +1730,20 @@ func vpcRouterDHCPServerUpdateParam() map[string]*schema.Schema {
 			Category:     "DHCP-Server",
 			Order:        20,
 		},
+		"dns-servers": {
+			Type:         schema.TypeStringList,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set DNS Server IPAddress",
+			ValidateFunc: validateStringSlice(validateIPv4Address()),
+			Category:     "DHCP-Server",
+			Order:        30,
+		},
 	}
 }
 
 func vpcRouterDHCPServerDeleteParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"index": {
+		"interface": {
 			Type:         schema.TypeInt,
 			HandlerType:  schema.HandlerNoop,
 			Description:  "set target NIC(private NIC index)",
@@ -2106,7 +2164,7 @@ func vpcRouterStaticRouteDeleteParam() map[string]*schema.Schema {
 
 func vpcRouterMonitorParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"index": {
+		"interface": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
 			Description:  "index of target interface",

--- a/vendor/github.com/sacloud/libsacloud/api/client.go
+++ b/vendor/github.com/sacloud/libsacloud/api/client.go
@@ -171,7 +171,7 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 		if err != nil {
 			return nil, fmt.Errorf("Error in response: %s", string(data))
 		}
-		return nil, fmt.Errorf("Error in response: %#v", errResponse)
+		return nil, NewError(resp.StatusCode, errResponse)
 
 	}
 	if err != nil {

--- a/vendor/github.com/sacloud/libsacloud/api/error.go
+++ b/vendor/github.com/sacloud/libsacloud/api/error.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
+)
+
+// Error APIコール時のエラー情報
+type Error interface {
+	// errorインターフェースを内包
+	error
+
+	// エラー発生時のレスポンスコード
+	ResponseCode() int
+
+	// エラーコード
+	Code() string
+
+	// エラー発生時のメッセージ
+	Message() string
+
+	// エラー追跡用シリアルコード
+	Serial() string
+
+	// エラー(オリジナル)
+	OrigErr() *sacloud.ResultErrorValue
+}
+
+// NewError APIコール時のエラー情報
+func NewError(responseCode int, err *sacloud.ResultErrorValue) Error {
+	return &apiError{
+		responseCode: responseCode,
+		origErr:      err,
+	}
+}
+
+type apiError struct {
+	responseCode int
+	origErr      *sacloud.ResultErrorValue
+}
+
+// Error errorインターフェース
+func (e *apiError) Error() string {
+	return fmt.Sprintf("Error in response: %#v", e.origErr)
+}
+
+// ResponseCode エラー発生時のレスポンスコード
+func (e *apiError) ResponseCode() int {
+	return e.responseCode
+}
+
+// Code エラーコード
+func (e *apiError) Code() string {
+	if e.origErr != nil {
+		return e.origErr.ErrorCode
+	}
+	return ""
+}
+
+// Message エラー発生時のメッセージ(
+func (e *apiError) Message() string {
+	if e.origErr != nil {
+		return e.origErr.ErrorMessage
+	}
+	return ""
+}
+
+// Serial エラー追跡用シリアルコード
+func (e *apiError) Serial() string {
+	if e.origErr != nil {
+		return e.origErr.Serial
+	}
+	return ""
+}
+
+// OrigErr エラー(オリジナル)
+func (e *apiError) OrigErr() *sacloud.ResultErrorValue {
+	return e.origErr
+}

--- a/vendor/github.com/sacloud/libsacloud/builder/server.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server.go
@@ -70,6 +70,9 @@ type serverBuilder struct {
 	// CDROM
 	isoImageID int64
 
+	// privateHost
+	privateHostID int64
+
 	// for nic
 	nicConnections []string
 
@@ -349,6 +352,10 @@ func (b *serverBuilder) buildServerParams() error {
 	}
 	if b.iconID > 0 {
 		s.SetIconByID(b.iconID)
+	}
+
+	if b.privateHostID > 0 {
+		s.SetPrivateHostByID(b.privateHostID)
 	}
 
 	// NIC

--- a/vendor/github.com/sacloud/libsacloud/builder/server_blank.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server_blank.go
@@ -111,6 +111,22 @@ func (b *BlankDiskServerBuilder) WithIconID(iconID int64) *BlankDiskServerBuilde
 	return b
 }
 
+// GetPrivateHostID アイコンID 取得
+func (b *BlankDiskServerBuilder) GetPrivateHostID() int64 {
+	return b.privateHostID
+}
+
+// SetPrivateHostID アイコンID 設定
+func (b *BlankDiskServerBuilder) SetPrivateHostID(privateHostID int64) {
+	b.privateHostID = privateHostID
+}
+
+// WithPrivateHostID アイコンID 設定
+func (b *BlankDiskServerBuilder) WithPrivateHostID(privateHostID int64) *BlankDiskServerBuilder {
+	b.privateHostID = privateHostID
+	return b
+}
+
 // IsBootAfterCreate サーバー作成後すぐに起動フラグ 取得
 func (b *BlankDiskServerBuilder) IsBootAfterCreate() bool {
 	return b.bootAfterCreate

--- a/vendor/github.com/sacloud/libsacloud/builder/server_common.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server_common.go
@@ -111,6 +111,22 @@ func (b *CommonServerBuilder) WithIconID(iconID int64) *CommonServerBuilder {
 	return b
 }
 
+// GetPrivateHostID 専有ホストID 取得
+func (b *CommonServerBuilder) GetPrivateHostID() int64 {
+	return b.privateHostID
+}
+
+// SetPrivateHostID 専有ホストID 設定
+func (b *CommonServerBuilder) SetPrivateHostID(privateHostID int64) {
+	b.privateHostID = privateHostID
+}
+
+// WithPrivateHostID 専有ホストID 設定
+func (b *CommonServerBuilder) WithPrivateHostID(privateHostID int64) *CommonServerBuilder {
+	b.privateHostID = privateHostID
+	return b
+}
+
 // IsBootAfterCreate サーバー作成後すぐに起動フラグ 取得
 func (b *CommonServerBuilder) IsBootAfterCreate() bool {
 	return b.bootAfterCreate

--- a/vendor/github.com/sacloud/libsacloud/builder/server_connect.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server_connect.go
@@ -109,6 +109,22 @@ func (b *ConnectDiskServerBuilder) WithIconID(iconID int64) *ConnectDiskServerBu
 	return b
 }
 
+// GetPrivateHostID 専有ホストID 取得
+func (b *ConnectDiskServerBuilder) GetPrivateHostID() int64 {
+	return b.privateHostID
+}
+
+// SetPrivateHostID 専有ホストID 設定
+func (b *ConnectDiskServerBuilder) SetPrivateHostID(privateHostID int64) {
+	b.privateHostID = privateHostID
+}
+
+// WithPrivateHostID 専有ホストID 設定
+func (b *ConnectDiskServerBuilder) WithPrivateHostID(privateHostID int64) *ConnectDiskServerBuilder {
+	b.privateHostID = privateHostID
+	return b
+}
+
 // IsBootAfterCreate サーバー作成後すぐに起動フラグ 取得
 func (b *ConnectDiskServerBuilder) IsBootAfterCreate() bool {
 	return b.bootAfterCreate

--- a/vendor/github.com/sacloud/libsacloud/builder/server_diskless.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server_diskless.go
@@ -109,6 +109,22 @@ func (b *DisklessServerBuilder) WithIconID(iconID int64) *DisklessServerBuilder 
 	return b
 }
 
+// GetPrivateHostID 専有ホストID 取得
+func (b *DisklessServerBuilder) GetPrivateHostID() int64 {
+	return b.privateHostID
+}
+
+// SetPrivateHostID 専有ホストID 設定
+func (b *DisklessServerBuilder) SetPrivateHostID(privateHostID int64) {
+	b.privateHostID = privateHostID
+}
+
+// WithPrivateHostID 専有ホストID 設定
+func (b *DisklessServerBuilder) WithPrivateHostID(privateHostID int64) *DisklessServerBuilder {
+	b.privateHostID = privateHostID
+	return b
+}
+
 // IsBootAfterCreate サーバー作成後すぐに起動フラグ 取得
 func (b *DisklessServerBuilder) IsBootAfterCreate() bool {
 	return b.bootAfterCreate

--- a/vendor/github.com/sacloud/libsacloud/builder/server_unix_archive.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server_unix_archive.go
@@ -109,6 +109,22 @@ func (b *PublicArchiveUnixServerBuilder) WithIconID(iconID int64) *PublicArchive
 	return b
 }
 
+// GetPrivateHostID 専有ホストID 取得
+func (b *PublicArchiveUnixServerBuilder) GetPrivateHostID() int64 {
+	return b.privateHostID
+}
+
+// SetPrivateHostID 専有ホストID 設定
+func (b *PublicArchiveUnixServerBuilder) SetPrivateHostID(privateHostID int64) {
+	b.privateHostID = privateHostID
+}
+
+// WithPrivateHostID 専有ホストID 設定
+func (b *PublicArchiveUnixServerBuilder) WithPrivateHostID(privateHostID int64) *PublicArchiveUnixServerBuilder {
+	b.privateHostID = privateHostID
+	return b
+}
+
 // IsBootAfterCreate サーバー作成後すぐに起動フラグ 取得
 func (b *PublicArchiveUnixServerBuilder) IsBootAfterCreate() bool {
 	return b.bootAfterCreate

--- a/vendor/github.com/sacloud/libsacloud/builder/server_windows_archive.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server_windows_archive.go
@@ -109,6 +109,22 @@ func (b *PublicArchiveWindowsServerBuilder) WithIconID(iconID int64) *PublicArch
 	return b
 }
 
+// GetPrivateHostID 専有ID 取得
+func (b *PublicArchiveWindowsServerBuilder) GetPrivateHostID() int64 {
+	return b.privateHostID
+}
+
+// SetPrivateHostID 専有ホストID 設定
+func (b *PublicArchiveWindowsServerBuilder) SetPrivateHostID(privateHostID int64) {
+	b.privateHostID = privateHostID
+}
+
+// WithPrivateHostID 専有ホストID 設定
+func (b *PublicArchiveWindowsServerBuilder) WithPrivateHostID(privateHostID int64) *PublicArchiveWindowsServerBuilder {
+	b.privateHostID = privateHostID
+	return b
+}
+
 // IsBootAfterCreate サーバー作成後すぐに起動フラグ 取得
 func (b *PublicArchiveWindowsServerBuilder) IsBootAfterCreate() bool {
 	return b.bootAfterCreate

--- a/vendor/github.com/sacloud/libsacloud/sacloud/account.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/account.go
@@ -8,5 +8,4 @@ type Account struct {
 	ID       string `json:",omitempty"` // リソースID
 	Class    string `json:",omitempty"` // リソースクラス
 	Code     string `json:",omitempty"` // アカウントコード
-
 }

--- a/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
@@ -140,61 +140,65 @@ type EDiskConnection string
 
 // SakuraCloudResources さくらのクラウド上のリソース種別一覧
 type SakuraCloudResources struct {
-	Server       *Server          `json:",omitempty"` // サーバー
-	Disk         *Disk            `json:",omitempty"` // ディスク
-	Note         *Note            `json:",omitempty"` // スタートアップスクリプト
-	Archive      *Archive         `json:",omitempty"` // アーカイブ
-	PacketFilter *PacketFilter    `json:",omitempty"` // パケットフィルタ
-	Bridge       *Bridge          `json:",omitempty"` // ブリッジ
-	Icon         *Icon            `json:",omitempty"` // アイコン
-	Image        *Image           `json:",omitempty"` // 画像
-	Interface    *Interface       `json:",omitempty"` // インターフェース
-	Internet     *Internet        `json:",omitempty"` // ルーター
-	IPAddress    *IPAddress       `json:",omitempty"` // IPv4アドレス
-	IPv6Addr     *IPv6Addr        `json:",omitempty"` // IPv6アドレス
-	IPv6Net      *IPv6Net         `json:",omitempty"` // IPv6ネットワーク
-	License      *License         `json:",omitempty"` // ライセンス
-	Switch       *Switch          `json:",omitempty"` // スイッチ
-	CDROM        *CDROM           `json:",omitempty"` // ISOイメージ
-	SSHKey       *SSHKey          `json:",omitempty"` // 公開鍵
-	Subnet       *Subnet          `json:",omitempty"` // IPv4ネットワーク
-	DiskPlan     *ProductDisk     `json:",omitempty"` // ディスクプラン
-	InternetPlan *ProductInternet `json:",omitempty"` // ルータープラン
-	LicenseInfo  *ProductLicense  `json:",omitempty"` // ライセンス情報
-	ServerPlan   *ProductServer   `json:",omitempty"` // サーバープラン
-	Region       *Region          `json:",omitempty"` // リージョン
-	Zone         *Zone            `json:",omitempty"` // ゾーン
-	FTPServer    *FTPServer       `json:",omitempty"` // FTPサーバー情報
+	Server          *Server             `json:",omitempty"` // サーバー
+	Disk            *Disk               `json:",omitempty"` // ディスク
+	Note            *Note               `json:",omitempty"` // スタートアップスクリプト
+	Archive         *Archive            `json:",omitempty"` // アーカイブ
+	PacketFilter    *PacketFilter       `json:",omitempty"` // パケットフィルタ
+	PrivateHost     *PrivateHost        `json:",omitempty"` // 専有ホスト
+	Bridge          *Bridge             `json:",omitempty"` // ブリッジ
+	Icon            *Icon               `json:",omitempty"` // アイコン
+	Image           *Image              `json:",omitempty"` // 画像
+	Interface       *Interface          `json:",omitempty"` // インターフェース
+	Internet        *Internet           `json:",omitempty"` // ルーター
+	IPAddress       *IPAddress          `json:",omitempty"` // IPv4アドレス
+	IPv6Addr        *IPv6Addr           `json:",omitempty"` // IPv6アドレス
+	IPv6Net         *IPv6Net            `json:",omitempty"` // IPv6ネットワーク
+	License         *License            `json:",omitempty"` // ライセンス
+	Switch          *Switch             `json:",omitempty"` // スイッチ
+	CDROM           *CDROM              `json:",omitempty"` // ISOイメージ
+	SSHKey          *SSHKey             `json:",omitempty"` // 公開鍵
+	Subnet          *Subnet             `json:",omitempty"` // IPv4ネットワーク
+	DiskPlan        *ProductDisk        `json:",omitempty"` // ディスクプラン
+	InternetPlan    *ProductInternet    `json:",omitempty"` // ルータープラン
+	LicenseInfo     *ProductLicense     `json:",omitempty"` // ライセンス情報
+	ServerPlan      *ProductServer      `json:",omitempty"` // サーバープラン
+	PrivateHostPlan *ProductPrivateHost `json:",omitempty"` // 専有ホストプラン
+	Region          *Region             `json:",omitempty"` // リージョン
+	Zone            *Zone               `json:",omitempty"` // ゾーン
+	FTPServer       *FTPServer          `json:",omitempty"` // FTPサーバー情報
 
 	//REMARK: CommonServiceItemとApplianceはapiパッケージにて別途定義
 }
 
 // SakuraCloudResourceList さくらのクラウド上のリソース種別一覧(複数形)
 type SakuraCloudResourceList struct {
-	Servers        []Server          `json:",omitempty"` // サーバー
-	Disks          []Disk            `json:",omitempty"` // ディスク
-	Notes          []Note            `json:",omitempty"` // スタートアップスクリプト
-	Archives       []Archive         `json:",omitempty"` // アーカイブ
-	PacketFilters  []PacketFilter    `json:",omitempty"` // パケットフィルタ
-	Bridges        []Bridge          `json:",omitempty"` // ブリッジ
-	Icons          []Icon            `json:",omitempty"` // アイコン
-	Interfaces     []Interface       `json:",omitempty"` // インターフェース
-	Internet       []Internet        `json:",omitempty"` // ルーター
-	IPAddress      []IPAddress       `json:",omitempty"` // IPv4アドレス
-	IPv6Addrs      []IPv6Addr        `json:",omitempty"` // IPv6アドレス
-	IPv6Nets       []IPv6Net         `json:",omitempty"` // IPv6ネットワーク
-	Licenses       []License         `json:",omitempty"` // ライセンス
-	Switches       []Switch          `json:",omitempty"` // スイッチ
-	CDROMs         []CDROM           `json:",omitempty"` // ISOイメージ
-	SSHKeys        []SSHKey          `json:",omitempty"` // 公開鍵
-	Subnets        []Subnet          `json:",omitempty"` // IPv4ネットワーク
-	DiskPlans      []ProductDisk     `json:",omitempty"` // ディスクプラン
-	InternetPlans  []ProductInternet `json:",omitempty"` // ルータープラン
-	LicenseInfo    []ProductLicense  `json:",omitempty"` // ライセンス情報
-	ServerPlans    []ProductServer   `json:",omitempty"` // サーバープラン
-	Regions        []Region          `json:",omitempty"` // リージョン
-	Zones          []Zone            `json:",omitempty"` // ゾーン
-	ServiceClasses []PublicPrice     `json:",omitempty"` // サービスクラス(価格情報)
+	Servers          []Server             `json:",omitempty"` // サーバー
+	Disks            []Disk               `json:",omitempty"` // ディスク
+	Notes            []Note               `json:",omitempty"` // スタートアップスクリプト
+	Archives         []Archive            `json:",omitempty"` // アーカイブ
+	PacketFilters    []PacketFilter       `json:",omitempty"` // パケットフィルタ
+	PrivateHosts     []PrivateHost        `json:",omitempty"` // 専有ホスト
+	Bridges          []Bridge             `json:",omitempty"` // ブリッジ
+	Icons            []Icon               `json:",omitempty"` // アイコン
+	Interfaces       []Interface          `json:",omitempty"` // インターフェース
+	Internet         []Internet           `json:",omitempty"` // ルーター
+	IPAddress        []IPAddress          `json:",omitempty"` // IPv4アドレス
+	IPv6Addrs        []IPv6Addr           `json:",omitempty"` // IPv6アドレス
+	IPv6Nets         []IPv6Net            `json:",omitempty"` // IPv6ネットワーク
+	Licenses         []License            `json:",omitempty"` // ライセンス
+	Switches         []Switch             `json:",omitempty"` // スイッチ
+	CDROMs           []CDROM              `json:",omitempty"` // ISOイメージ
+	SSHKeys          []SSHKey             `json:",omitempty"` // 公開鍵
+	Subnets          []Subnet             `json:",omitempty"` // IPv4ネットワーク
+	DiskPlans        []ProductDisk        `json:",omitempty"` // ディスクプラン
+	InternetPlans    []ProductInternet    `json:",omitempty"` // ルータープラン
+	LicenseInfo      []ProductLicense     `json:",omitempty"` // ライセンス情報
+	ServerPlans      []ProductServer      `json:",omitempty"` // サーバープラン
+	PrivateHostPlans []ProductPrivateHost `json:",omitempty"` // 専有ホストプラン
+	Regions          []Region             `json:",omitempty"` // リージョン
+	Zones            []Zone               `json:",omitempty"` // ゾーン
+	ServiceClasses   []PublicPrice        `json:",omitempty"` // サービスクラス(価格情報)
 
 	//REMARK:CommonServiceItemとApplianceはapiパッケージにて別途定義
 }

--- a/vendor/github.com/sacloud/libsacloud/sacloud/host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/host.go
@@ -1,0 +1,6 @@
+package sacloud
+
+// Host さくらのクラウド ホスト(物理)
+type Host struct {
+	propName // 名称
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/private_host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/private_host.go
@@ -1,0 +1,18 @@
+package sacloud
+
+// PrivateHost 専有ホスト
+type PrivateHost struct {
+	*Resource       // ID
+	propName        // 名称
+	propDescription // 説明
+
+	propPrivateHostPlan  // 専有ホストプラン
+	propHost             // ホスト(物理)
+	propAssignedCPU      // 割当済みCPUコア数
+	propAssignedMemoryMB // 割当済みメモリ(MB)
+
+	propIcon      // アイコン
+	propTags      // タグ
+	propCreatedAt // 作成日時
+
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/product_privatehost.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/product_privatehost.go
@@ -1,0 +1,13 @@
+package sacloud
+
+// ProductPrivateHost 専有ホストプラン
+type ProductPrivateHost struct {
+	*Resource        // ID
+	propName         // 名称
+	propDescription  // 説明
+	propAvailability // 有功状態
+	propCPU          // CPUコア数
+	propMemoryMB     // メモリサイズ(MB単位)
+	propClass        // クラス
+	propServiceClass // サービスクラス
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_cpu.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_cpu.go
@@ -1,0 +1,11 @@
+package sacloud
+
+// propAssignedCPU CPUコア数内包型
+type propAssignedCPU struct {
+	AssignedCPU int `json:",omitempty"` // CPUコア数
+}
+
+// GetAssignedCPU CPUコア数 取得
+func (p *propAssignedCPU) GetAssignedCPU() int {
+	return p.AssignedCPU
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_memory.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_assigned_memory.go
@@ -1,0 +1,19 @@
+package sacloud
+
+// propAssignedMemoryMB サイズ(MB)内包型
+type propAssignedMemoryMB struct {
+	AssignedMemoryMB int `json:",omitempty"` // サイズ(MB単位)
+}
+
+// GetAssignedMemoryMB サイズ(MB単位) 取得
+func (p *propAssignedMemoryMB) GetAssignedMemoryMB() int {
+	return p.AssignedMemoryMB
+}
+
+// GetAssignedMemoryGB サイズ(GB単位) 取得
+func (p *propAssignedMemoryMB) GetAssignedMemoryGB() int {
+	if p.AssignedMemoryMB <= 0 {
+		return 0
+	}
+	return p.AssignedMemoryMB / 1024
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_class.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_class.go
@@ -1,0 +1,11 @@
+package sacloud
+
+// propClass クラス内包型
+type propClass struct {
+	Class string `json:",omitempty"` // サービスクラス
+}
+
+// GetClass クラス 取得
+func (p *propClass) GetClass() string {
+	return p.Class
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_host.go
@@ -1,0 +1,19 @@
+package sacloud
+
+// propHost ホスト(物理)内包型
+type propHost struct {
+	Host *Host `json:",omitempty"` // サービスクラス
+}
+
+// GetHost ホスト(物理) 取得
+func (p *propHost) GetHost() *Host {
+	return p.Host
+}
+
+// GetHostName ホスト(物理)名称取得
+func (p *propHost) GetHostName() string {
+	if p.Host == nil {
+		return ""
+	}
+	return p.Host.GetName()
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host.go
@@ -1,0 +1,21 @@
+package sacloud
+
+// propPrivateHost 専有ホスト内包型
+type propPrivateHost struct {
+	PrivateHost *PrivateHost // 専有ホスト
+}
+
+// SetPrivateHostByID 指定のアイコンIDを設定
+func (p *propPrivateHost) SetPrivateHostByID(id int64) {
+	p.PrivateHost = &PrivateHost{Resource: NewResource(id)}
+}
+
+// SetPrivateHost 指定のアイコンオブジェクトを設定
+func (p *propPrivateHost) SetPrivateHost(icon *PrivateHost) {
+	p.PrivateHost = icon
+}
+
+// ClearPrivateHost アイコンをクリア(空IDを持つアイコンオブジェクトをセット)
+func (p *propPrivateHost) ClearPrivateHost() {
+	p.PrivateHost = &PrivateHost{Resource: NewResource(EmptyID)}
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host_plan.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_private_host_plan.go
@@ -1,0 +1,51 @@
+package sacloud
+
+// propPrivateHostPlan 専有ホストプラン内包型
+type propPrivateHostPlan struct {
+	Plan *ProductPrivateHost `json:",omitempty"` // 専有ホストプラン
+}
+
+// GetPrivateHostPlan 専有ホストプラン取得
+func (p *propPrivateHostPlan) GetPrivateHostPlan() *ProductPrivateHost {
+	return p.Plan
+}
+
+// SetPrivateHostPlan 専有ホストプラン設定
+func (p *propPrivateHostPlan) SetPrivateHostPlan(plan *ProductPrivateHost) {
+	p.Plan = plan
+}
+
+// SetPrivateHostPlanByID 専有ホストプラン設定
+func (p *propPrivateHostPlan) SetPrivateHostPlanByID(planID int64) {
+	if p.Plan == nil {
+		p.Plan = &ProductPrivateHost{}
+	}
+	p.Plan.Resource = NewResource(planID)
+}
+
+// GetCPU CPUコア数 取得
+func (p *propPrivateHostPlan) GetCPU() int {
+	if p.Plan == nil {
+		return -1
+	}
+
+	return p.Plan.GetCPU()
+}
+
+// GetMemoryMB メモリ(MB) 取得
+func (p *propPrivateHostPlan) GetMemoryMB() int {
+	if p.Plan == nil {
+		return -1
+	}
+
+	return p.Plan.GetMemoryMB()
+}
+
+// GetMemoryGB メモリ(GB) 取得
+func (p *propPrivateHostPlan) GetMemoryGB() int {
+	if p.Plan == nil {
+		return -1
+	}
+
+	return p.Plan.GetMemoryGB()
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/server.go
@@ -15,6 +15,7 @@ type Server struct {
 	propDisks             // ディスク配列
 	propInstance          // インスタンス
 	propInterfaces        // インターフェース配列
+	propPrivateHost       // 専有ホスト
 	propIcon              // アイコン
 	propTags              // タグ
 	propCreatedAt         // 作成日時

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -113,32 +113,32 @@
 		{
 			"checksumSHA1": "6SUOCG4pJYli/d6+mjpIomTUCms=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "f48cb99ebacfa388be626166de0eb04faae2c62a",
-			"revisionTime": "2017-11-02T05:18:55Z"
+			"revision": "f2f5b8538d26965bb9ae73d6b9c8d348f5fd9314",
+			"revisionTime": "2017-11-09T06:02:57Z"
 		},
 		{
-			"checksumSHA1": "epLP7uubK0ArQ06hl6LUBWc5WPE=",
+			"checksumSHA1": "qw9FPxFmQ3EDOSs1QVOBJPYLMUk=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "f48cb99ebacfa388be626166de0eb04faae2c62a",
-			"revisionTime": "2017-11-02T05:18:55Z"
+			"revision": "f2f5b8538d26965bb9ae73d6b9c8d348f5fd9314",
+			"revisionTime": "2017-11-09T06:02:57Z"
 		},
 		{
-			"checksumSHA1": "BVVaejtugZ0tYORdUG0aClElvRc=",
+			"checksumSHA1": "EW8lYp5KetlqaGuoCeiqAFBmJfs=",
 			"path": "github.com/sacloud/libsacloud/builder",
-			"revision": "f48cb99ebacfa388be626166de0eb04faae2c62a",
-			"revisionTime": "2017-11-02T05:18:55Z"
+			"revision": "f2f5b8538d26965bb9ae73d6b9c8d348f5fd9314",
+			"revisionTime": "2017-11-09T06:02:57Z"
 		},
 		{
-			"checksumSHA1": "5oy78bwjMgvCc+LkdQTGlvYr3g4=",
+			"checksumSHA1": "CQAqz7qD9OWG09dzcIAZdDoYosQ=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "f48cb99ebacfa388be626166de0eb04faae2c62a",
-			"revisionTime": "2017-11-02T05:18:55Z"
+			"revision": "f2f5b8538d26965bb9ae73d6b9c8d348f5fd9314",
+			"revisionTime": "2017-11-09T06:02:57Z"
 		},
 		{
 			"checksumSHA1": "TPskly51IHKVf2DAjV3Xs/Fiyx8=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "f48cb99ebacfa388be626166de0eb04faae2c62a",
-			"revisionTime": "2017-11-02T05:18:55Z"
+			"revision": "f2f5b8538d26965bb9ae73d6b9c8d348f5fd9314",
+			"revisionTime": "2017-11-09T06:02:57Z"
 		},
 		{
 			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",


### PR DESCRIPTION
DHCPでのDNSサーバ指定機能とプライベートインターフェースに対するファイアウォール設定機能を追加する。

### DHCPでのDNSサーバ指定の例

```bash
# 1番目のプライベートインターフェースに対しDHCPサーバ機能を設定
$ usacloud vpc-router dhcp-server-add \
                      --interface 1 \
                      --range-start 192.2.0.100 \
                      --range-stop 192.2.0.200 \
                      --dns-servers 8.8.4.4 \
                      --dns-servers 8.8.8.8 \
                      [対象のID or Name]
```

### プライベートインターフェースに対するファイアウォール設定の例

```bash
# 1番目のプライベートインターフェースに対し送信側ファイアウォールルール(ALL-Deny)を追加
$ usacloud vpc-router firewall-add \
                      --interface 1 \
                      --direction send \
                      --protocol ip \
                     [対象のID or Name]
```