### PR TITLE
Release version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0 (2017-11-09)
+
+* VPCルータへの機能追加(DHCPでのDNSサーバ配布/NICごとのファイアウォール)  #242 (yamamoto-febc)
+
+
 ## 0.3.1 (2017-11-02)
 
 * Fix typo on messages #239 (ariarijp)

--- a/package/deb/debian/changelog
+++ b/package/deb/debian/changelog
@@ -1,3 +1,10 @@
+usacloud (0.4.0-1) stable; urgency=low
+
+  * VPCルータへの機能追加(DHCPでのDNSサーバ配布/NICごとのファイアウォール)  (by yamamoto-febc)
+    <https://github.com/sacloud/usacloud/pull/242>
+
+ -- usacloud <yamamoto.febc@gmail.com>  Thu, 09 Nov 2017 11:02:31 +0000
+
 usacloud (0.3.1-1) stable; urgency=low
 
   * Fix typo on messages (by ariarijp)

--- a/package/rpm/usacloud.spec
+++ b/package/rpm/usacloud.spec
@@ -40,6 +40,9 @@ CLI client of the SakuraCloud
 %{_sysconfdir}/bash_completion.d/usacloud
 
 %changelog
+* Thu Nov 09 2017 <yamamoto.febc@gmail.com> - 0.4.0-1
+- VPCルータへの機能追加(DHCPでのDNSサーバ配布/NICごとのファイアウォール)  (by yamamoto-febc)
+
 * Thu Nov 02 2017 <yamamoto.febc@gmail.com> - 0.3.1-1
 - Fix typo on messages (by ariarijp)
 - VPC APIのレスポンス処理修正 (by yamamoto-febc)


### PR DESCRIPTION
## CHANGELOG

- VPCルータへの機能追加(DHCPでのDNSサーバ配布/NICごとのファイアウォール)  #242

## VPCルータに追加された機能について

VPCルータにDHCPでのDNSサーバ配布機能とプライベートインターフェースに対するファイアウォール設定機能が追加されました。

### DHCPでのDNSサーバ指定の例

```bash
# 1番目のプライベートインターフェースに対しDHCPサーバ機能を設定
$ usacloud vpc-router dhcp-server-add \
                      --interface 1 \
                      --range-start 192.2.0.100 \
                      --range-stop 192.2.0.200 \
                      --dns-servers 8.8.4.4 \
                      --dns-servers 8.8.8.8 \
                      [対象のID or Name]
```

### プライベートインターフェースに対するファイアウォール設定の例

```bash
# 1番目のプライベートインターフェースに対し送信側ファイアウォールルール(ALL-Deny)を追加
$ usacloud vpc-router firewall-add \
                      --interface 1 \
                      --direction send \
                      --protocol ip \
                     [対象のID or Name]
```