### PR TITLE
ロードバランサVIPの重複確認にIPアドレスとポート番号の組み合わせを利用

### DIFF
--- a/command/funcs/load_balancer_vip_add.go
+++ b/command/funcs/load_balancer_vip_add.go
@@ -24,8 +24,8 @@ func LoadBalancerVipAdd(ctx command.Context, params *params.VipAddLoadBalancerPa
 	}
 
 	for _, v := range p.Settings.LoadBalancer {
-		if v.VirtualIPAddress == params.Vip {
-			return fmt.Errorf("VIP(%q) is already used", params.Vip)
+		if v.VirtualIPAddress == params.Vip && v.Port == fmt.Sprintf("%d", params.Port) {
+			return fmt.Errorf("VIP(%s:%d) is already used", params.Vip, params.Port)
 		}
 	}
 

--- a/command/funcs/load_balancer_vip_update.go
+++ b/command/funcs/load_balancer_vip_update.go
@@ -28,8 +28,8 @@ func LoadBalancerVipUpdate(ctx command.Context, params *params.VipUpdateLoadBala
 			continue
 		}
 
-		if v.VirtualIPAddress == params.Vip {
-			return fmt.Errorf("VIP(%q) is already used", params.Vip)
+		if v.VirtualIPAddress == params.Vip && v.Port == fmt.Sprintf("%d", params.Port) {
+			return fmt.Errorf("VIP(%s:%d) is already used", params.Vip, params.Port)
 		}
 	}
 

--- a/test/integration/bats/load-balancer/core-commands.bats
+++ b/test/integration/bats/load-balancer/core-commands.bats
@@ -24,7 +24,7 @@ resource_name=${TEST_TARGET_NAME}01
 
 }
 
-@test "Usacloud: should can add VIP" {
+@test "Usacloud: should can CRUD VIP" {
 
   lb_id=$(usacloud_run load-balancer read -q "$resource_name")
 
@@ -32,7 +32,14 @@ resource_name=${TEST_TARGET_NAME}01
   run usacloud_run load-balancer vip-add --vip 192.168.100.1 --port 80 -y "$resource_name"
   [ "${status}" -eq 0 ]
 
+  run usacloud_run load-balancer vip-add --vip 192.168.100.1 --port 443 -y "$resource_name"
+  [ "${status}" -eq 0 ]
+
   # run vip-update
+  # should error(duplicate ip:port)
+  run usacloud_run load-balancer vip-update --index 2 --port 80 -y "$resource_name"
+  [ "${status}" -eq 1 ]
+
   run usacloud_run load-balancer vip-update --index 1 --vip 192.168.100.2 -y "$resource_name"
   [ "${status}" -eq 0 ]
 


### PR DESCRIPTION
To fix #260 