### PR TITLE
ストレージ情報の追加

### DIFF
--- a/command/cli/cli_disk_gen.go
+++ b/command/cli/cli_disk_gen.go
@@ -65,6 +65,10 @@ func init() {
 						Name:  "source-disk-id",
 						Usage: "set filter by source-disk-id",
 					},
+					&cli.StringFlag{
+						Name:  "storage",
+						Usage: "set filter by storage-name",
+					},
 					&cli.IntFlag{
 						Name:    "from",
 						Aliases: []string{"offset"},
@@ -171,6 +175,9 @@ func init() {
 					}
 					if c.IsSet("source-disk-id") {
 						listParam.SourceDiskId = c.Int64("source-disk-id")
+					}
+					if c.IsSet("storage") {
+						listParam.Storage = c.String("storage")
 					}
 					if c.IsSet("from") {
 						listParam.From = c.Int("from")
@@ -307,6 +314,9 @@ func init() {
 					}
 					if c.IsSet("source-disk-id") {
 						listParam.SourceDiskId = c.Int64("source-disk-id")
+					}
+					if c.IsSet("storage") {
+						listParam.Storage = c.String("storage")
 					}
 					if c.IsSet("from") {
 						listParam.From = c.Int("from")
@@ -5033,6 +5043,11 @@ func init() {
 		Order:       2147483587,
 	})
 	AppendFlagCategoryMap("disk", "list", "source-disk-id", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("disk", "list", "storage", &schema.Category{
 		Key:         "filter",
 		DisplayName: "Filter options",
 		Order:       2147483587,

--- a/command/completion/disk_flags_gen.go
+++ b/command/completion/disk_flags_gen.go
@@ -44,6 +44,11 @@ func DiskListCompleteFlags(ctx command.Context, params *params.ListDiskParam, fl
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
+	case "storage":
+		param := define.Resources["Disk"].Commands["list"].BuildedParams().Get("storage")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "from", "offset":
 		param := define.Resources["Disk"].Commands["list"].BuildedParams().Get("from")
 		if param != nil {

--- a/command/funcs/disk_list_gen.go
+++ b/command/funcs/disk_list_gen.go
@@ -61,6 +61,10 @@ func DiskList(ctx command.Context, params *params.ListDiskParam) error {
 			continue
 		}
 
+		if !params.GetCommandDef().Params["storage"].FilterFunc(list, &res.Disks[i], params.Storage) {
+			continue
+		}
+
 		list = append(list, &res.Disks[i])
 	}
 	return ctx.GetOutput().Print(list...)

--- a/command/params/params_disk_gen.go
+++ b/command/params/params_disk_gen.go
@@ -16,6 +16,7 @@ type ListDiskParam struct {
 	Tags              []string `json:"tags"`
 	SourceArchiveId   int64    `json:"source-archive-id"`
 	SourceDiskId      int64    `json:"source-disk-id"`
+	Storage           string   `json:"storage"`
 	From              int      `json:"from"`
 	Max               int      `json:"max"`
 	Sort              []string `json:"sort"`
@@ -53,6 +54,9 @@ func (p *ListDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.SourceDiskId) {
 		p.SourceDiskId = 0
+	}
+	if isEmpty(p.Storage) {
+		p.Storage = ""
 	}
 	if isEmpty(p.From) {
 		p.From = 0
@@ -235,6 +239,13 @@ func (p *ListDiskParam) SetSourceDiskId(v int64) {
 
 func (p *ListDiskParam) GetSourceDiskId() int64 {
 	return p.SourceDiskId
+}
+func (p *ListDiskParam) SetStorage(v string) {
+	p.Storage = v
+}
+
+func (p *ListDiskParam) GetStorage() string {
+	return p.Storage
 }
 func (p *ListDiskParam) SetFrom(v int) {
 	p.From = v

--- a/define/completions.go
+++ b/define/completions.go
@@ -353,3 +353,21 @@ func completeBackupTime() schema.CompletionFunc {
 
 	return schema.CompleteInStrValues(timeStrings...)
 }
+
+func completeStorageName() schema.CompletionFunc {
+	return func(ctx schema.CompletionContext, currentValue string) []string {
+
+		api := ctx.GetAPIClient().GetDiskAPI()
+		res := []string{}
+
+		result, err := api.Find()
+		if err != nil {
+			return res
+		}
+
+		for _, v := range result.Disks {
+			res = append(res, v.Storage.Name)
+		}
+		return res
+	}
+}

--- a/define/disk.go
+++ b/define/disk.go
@@ -1,8 +1,10 @@
 package define
 
 import (
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/output"
 	"github.com/sacloud/usacloud/schema"
+	"strings"
 )
 
 func DiskResource() *schema.Resource {
@@ -184,6 +186,29 @@ func diskListParam() map[string]*schema.Schema {
 		paramTagsCond,
 		paramSourceArchiveIDCond,
 		paramSourceDiskCond,
+		map[string]*schema.Schema{
+			"storage": {
+				Type:        schema.TypeString,
+				HandlerType: schema.HandlerFilterFunc,
+				FilterFunc: func(_ []interface{}, item interface{}, param interface{}) bool {
+					if param == nil {
+						return true
+					}
+					storageName := param.(string)
+					if storageName == "" {
+						return true
+					}
+					if disk, ok := item.(*sacloud.Disk); ok {
+						return strings.Contains(disk.Storage.Name, storageName)
+					}
+					return true
+				},
+				Description:  "set filter by storage-name",
+				Category:     "filter",
+				CompleteFunc: completeStorageName(),
+				Order:        10,
+			},
+		},
 	)
 }
 
@@ -212,6 +237,10 @@ func diskListColumns() []output.ColumnDef {
 			Format:  "%sMB",
 		},
 		{Name: "Connection"},
+		{
+			Name:    "Storage",
+			Sources: []string{"Storage.Name"},
+		},
 	}
 }
 

--- a/vendor/github.com/sacloud/libsacloud/LICENSE.txt
+++ b/vendor/github.com/sacloud/libsacloud/LICENSE.txt
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C) 2015-2017 Kazumichi Yamamoto.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,4 +200,8 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+================================================================================
+
+   Copyright 2015-2017 Kazumichi Yamamoto.
 

--- a/vendor/github.com/sacloud/libsacloud/api/client.go
+++ b/vendor/github.com/sacloud/libsacloud/api/client.go
@@ -38,6 +38,10 @@ type Client struct {
 	RequestTracer io.Writer
 	// レスポンス トレーサー
 	ResponseTracer io.Writer
+	// 503エラー時のリトライ回数
+	RetryMax int
+	// 503エラー時のリトライ待ち時間
+	RetryInterval time.Duration
 }
 
 // NewClient APIクライアント作成
@@ -49,6 +53,8 @@ func NewClient(token, tokenSecret, zone string) *Client {
 		TraceMode:              false,
 		DefaultTimeoutDuration: 20 * time.Minute,
 		UserAgent:              fmt.Sprintf("libsacloud/%s", libsacloud.Version),
+		RetryMax:               0,
+		RetryInterval:          5 * time.Second,
 	}
 	c.API = newAPI(c)
 	return c
@@ -63,6 +69,8 @@ func (c *Client) Clone() *Client {
 		TraceMode:              c.TraceMode,
 		DefaultTimeoutDuration: c.DefaultTimeoutDuration,
 		UserAgent:              c.UserAgent,
+		RetryMax:               c.RetryMax,
+		RetryInterval:          c.RetryInterval,
 	}
 	n.API = newAPI(n)
 	return n
@@ -98,9 +106,12 @@ func (c *Client) isOkStatus(code int) bool {
 
 func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error) {
 	var (
-		client = &http.Client{}
-		err    error
-		req    *http.Request
+		client = &retryableHTTPClient{
+			retryMax:      c.RetryMax,
+			retryInterval: c.RetryInterval,
+		}
+		err error
+		req *request
 	)
 	var url = uri
 	if !strings.HasPrefix(url, "https://") {
@@ -115,9 +126,9 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 		}
 		if method == "GET" {
 			url = fmt.Sprintf("%s?%s", url, bytes.NewBuffer(bodyJSON))
-			req, err = http.NewRequest(method, url, nil)
+			req, err = newRequest(method, url, nil)
 		} else {
-			req, err = http.NewRequest(method, url, bytes.NewBuffer(bodyJSON))
+			req, err = newRequest(method, url, bytes.NewReader(bodyJSON))
 		}
 		b, _ := json.MarshalIndent(body, "", "\t")
 		if c.TraceMode {
@@ -127,7 +138,7 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 			c.RequestTracer.Write(b)
 		}
 	} else {
-		req, err = http.NewRequest(method, url, nil)
+		req, err = newRequest(method, url, nil)
 		if c.TraceMode {
 			log.Printf("[libsacloud:Client#request] method : %#v , url : %s ", method, url)
 		}
@@ -179,6 +190,72 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 	}
 
 	return data, nil
+}
+
+type lenReader interface {
+	Len() int
+}
+
+type request struct {
+	// body is a seekable reader over the request body payload. This is
+	// used to rewind the request data in between retries.
+	body io.ReadSeeker
+
+	// Embed an HTTP request directly. This makes a *Request act exactly
+	// like an *http.Request so that all meta methods are supported.
+	*http.Request
+}
+
+func newRequest(method, url string, body io.ReadSeeker) (*request, error) {
+	var rcBody io.ReadCloser
+	if body != nil {
+		rcBody = ioutil.NopCloser(body)
+	}
+
+	httpReq, err := http.NewRequest(method, url, rcBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if lr, ok := body.(lenReader); ok {
+		httpReq.ContentLength = int64(lr.Len())
+	}
+
+	return &request{body, httpReq}, nil
+}
+
+type retryableHTTPClient struct {
+	http.Client
+	retryInterval time.Duration
+	retryMax      int
+}
+
+func (c *retryableHTTPClient) Do(req *request) (*http.Response, error) {
+	for i := 0; ; i++ {
+
+		if req.body != nil {
+			if _, err := req.body.Seek(0, 0); err != nil {
+				return nil, fmt.Errorf("failed to seek body: %v", err)
+			}
+		}
+
+		res, err := c.Client.Do(req.Request)
+		if res.StatusCode != 503 {
+			return res, err
+		}
+		if res != nil && res.Body != nil {
+			res.Body.Close()
+		}
+
+		remain := c.retryMax - i
+		if remain == 0 {
+			break
+		}
+		time.Sleep(c.retryInterval)
+	}
+
+	return nil, fmt.Errorf("%s %s giving up after %d attempts",
+		req.Method, req.URL, c.retryMax+1)
 }
 
 // API libsacloudでサポートしているAPI群

--- a/vendor/github.com/sacloud/libsacloud/api/database.go
+++ b/vendor/github.com/sacloud/libsacloud/api/database.go
@@ -485,19 +485,18 @@ func (api *DatabaseAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, 
 						err <- e
 						return
 					}
-				}
+				} else {
+					progress <- db
 
-				progress <- db
-
-				if db.IsAvailable() {
-					complete <- db
-					return
+					if db.IsAvailable() {
+						complete <- db
+						return
+					}
+					if db.IsFailed() {
+						err <- fmt.Errorf("Failed: Create Database is failed: %#v", db)
+						return
+					}
 				}
-				if db.IsFailed() {
-					err <- fmt.Errorf("Failed: Create Database is failed: %#v", db)
-					return
-				}
-
 			case <-time.After(timeout):
 				err <- fmt.Errorf("Timeout: AsyncSleepWhileCopying[ID:%d]", id)
 				return

--- a/vendor/github.com/sacloud/libsacloud/api/load_balancer.go
+++ b/vendor/github.com/sacloud/libsacloud/api/load_balancer.go
@@ -285,17 +285,17 @@ func (api *LoadBalancerAPI) AsyncSleepWhileCopying(id int64, timeout time.Durati
 						err <- e
 						return
 					}
-				}
+				} else {
+					progress <- lb
 
-				progress <- lb
-
-				if lb.IsAvailable() {
-					complete <- lb
-					return
-				}
-				if lb.IsFailed() {
-					err <- fmt.Errorf("Failed: Create LoadBalancer is failed: %#v", lb)
-					return
+					if lb.IsAvailable() {
+						complete <- lb
+						return
+					}
+					if lb.IsFailed() {
+						err <- fmt.Errorf("Failed: Create LoadBalancer is failed: %#v", lb)
+						return
+					}
 				}
 
 			case <-time.After(timeout):

--- a/vendor/github.com/sacloud/libsacloud/api/vpc_router.go
+++ b/vendor/github.com/sacloud/libsacloud/api/vpc_router.go
@@ -319,19 +319,19 @@ func (api *VPCRouterAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration,
 						err <- e
 						return
 					}
-				}
+				} else {
 
-				progress <- router
+					progress <- router
 
-				if router.IsAvailable() {
-					complete <- router
-					return
+					if router.IsAvailable() {
+						complete <- router
+						return
+					}
+					if router.IsFailed() {
+						err <- fmt.Errorf("Failed: Create VPCRouter is failed: %#v", router)
+						return
+					}
 				}
-				if router.IsFailed() {
-					err <- fmt.Errorf("Failed: Create VPCRouter is failed: %#v", router)
-					return
-				}
-
 			case <-time.After(timeout):
 				err <- fmt.Errorf("Timeout: AsyncSleepWhileCopying[ID:%d]", id)
 				return

--- a/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
@@ -24,9 +24,11 @@ type Disk struct {
 	ReinstallCount int `json:",omitempty"` // 再インストール回数
 
 	Storage struct { // ストレージ
-		*Resource         // ID
-		MountIndex int64  `json:",omitempty"` // マウント順
-		Class      string `json:",omitempty"` // クラス
+		*Resource              // ID
+		Name       string      `json:",omitempty"`  // 名称
+		DiskPlan   ProductDisk `json:",ommitempty"` // ディスクプラン
+		MountIndex int64       `json:",omitempty"`  // マウント順
+		Class      string      `json:",omitempty"`  // クラス
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -111,34 +111,34 @@
 			"revisionTime": "2017-12-05T06:26:25Z"
 		},
 		{
-			"checksumSHA1": "6SUOCG4pJYli/d6+mjpIomTUCms=",
+			"checksumSHA1": "W39zBUUG2o0JH6jL69krg272PwA=",
 			"path": "github.com/sacloud/libsacloud",
-			"revision": "4a06c4d6ff20ccae5492ee83304a24b5d8ecefd9",
-			"revisionTime": "2017-11-15T03:53:57Z"
+			"revision": "bcd96f7bff6a1f41f4d2fefb9175c2db3cbe0edb",
+			"revisionTime": "2017-12-15T12:53:14Z"
 		},
 		{
-			"checksumSHA1": "dCGFTYmhl3bC3Jf6EoU6Kqti3Tk=",
+			"checksumSHA1": "jq0xnilfFF6jeZoNxE7ZddnupsI=",
 			"path": "github.com/sacloud/libsacloud/api",
-			"revision": "4a06c4d6ff20ccae5492ee83304a24b5d8ecefd9",
-			"revisionTime": "2017-11-15T03:53:57Z"
+			"revision": "bcd96f7bff6a1f41f4d2fefb9175c2db3cbe0edb",
+			"revisionTime": "2017-12-15T12:53:14Z"
 		},
 		{
 			"checksumSHA1": "EW8lYp5KetlqaGuoCeiqAFBmJfs=",
 			"path": "github.com/sacloud/libsacloud/builder",
-			"revision": "4a06c4d6ff20ccae5492ee83304a24b5d8ecefd9",
-			"revisionTime": "2017-11-15T03:53:57Z"
+			"revision": "bcd96f7bff6a1f41f4d2fefb9175c2db3cbe0edb",
+			"revisionTime": "2017-12-15T12:53:14Z"
 		},
 		{
-			"checksumSHA1": "CQAqz7qD9OWG09dzcIAZdDoYosQ=",
+			"checksumSHA1": "8O0r9414cswGbiOHpmD4h5N7o8E=",
 			"path": "github.com/sacloud/libsacloud/sacloud",
-			"revision": "4a06c4d6ff20ccae5492ee83304a24b5d8ecefd9",
-			"revisionTime": "2017-11-15T03:53:57Z"
+			"revision": "bcd96f7bff6a1f41f4d2fefb9175c2db3cbe0edb",
+			"revisionTime": "2017-12-15T12:53:14Z"
 		},
 		{
 			"checksumSHA1": "TPskly51IHKVf2DAjV3Xs/Fiyx8=",
 			"path": "github.com/sacloud/libsacloud/sacloud/ostype",
-			"revision": "4a06c4d6ff20ccae5492ee83304a24b5d8ecefd9",
-			"revisionTime": "2017-11-15T03:53:57Z"
+			"revision": "bcd96f7bff6a1f41f4d2fefb9175c2db3cbe0edb",
+			"revisionTime": "2017-12-15T12:53:14Z"
 		},
 		{
 			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",


### PR DESCRIPTION
To fix #273 

ディスク情報に含まれるストレージの名称などの情報を追加する。
また、ストレージの名称でのフィルタも可能とする。

### 列の追加

```console
#disk lsやreadでストレージの名称列を追加
$ usacloud disk ls
+--------------+----------------+------------------------------+------+----------+------------+-----------------------+
|      ID      |      Name      |            Server            | Plan |   Size   | Connection |        Storage        |
+--------------+----------------+------------------------------+------+----------+------------+-----------------------+
| 999999999999 | Example        | 777777777777(Example)        | ssd  | 102400MB | virtio     | sac-is1b-iscsi4-st111 |
| 888888888888 | sakura-dev     | 666666666666(sakura-dev)     | ssd  | 20480MB  | virtio     | sac-is1b-ssd20g-st218 |
+--------------+----------------+------------------------------+------+----------+------------+-----------------------+

#--out=jsonにもストレージの情報を含む
$ usacloud disk ls --out json
[
  {
    "ID": 999999999999,
    "Name": "Example",
    [略]
    "Storage": {
      "Class": "iscsi1204",
      "DiskPlan": {
        "Description": "",
        "ID": 4,
        "Name": "SSDプラン",
        "StorageClass": "iscsi1204"
      },
      "ID": 3100296016,
      "Name": "sac-is1b-iscsi4-st216"
    }
  }
```

### ストレージ名での検索

```console
#disk ls時にストレージの名称を条件にフィルタ(中間一致、bash_completion対応あり)
$ usacloud disk ls --storage sac-is1b-iscsi4-st111
+--------------+----------------+------------------------------+------+----------+------------+-----------------------+
|      ID      |      Name      |            Server            | Plan |   Size   | Connection |        Storage        |
+--------------+----------------+------------------------------+------+----------+------------+-----------------------+
| 999999999999 | Example        | 777777777777(Example)        | ssd  | 102400MB | virtio     | sac-is1b-iscsi4-st111 |
+--------------+----------------+------------------------------+------+----------+------------+-----------------------+

```