### PR TITLE
グローバルオプションの追加

### DIFF
--- a/command/cli/functions.go
+++ b/command/cli/functions.go
@@ -58,6 +58,19 @@ func applyConfigFromFile(c FlagHandler) error {
 		command.GlobalOption.DefaultOutputType = v.DefaultOutputType
 	}
 
+	if !c.IsSet("accept-language") && v.AcceptLanguage != "" {
+		c.Set("accept-language", v.AcceptLanguage)
+		command.GlobalOption.AcceptLanguage = v.AcceptLanguage
+	}
+	if !c.IsSet("retry-max") && v.RetryMax > 0 {
+		c.Set("retry-max", fmt.Sprintf("%d", v.RetryMax))
+		command.GlobalOption.RetryMax = v.RetryMax
+	}
+	if !c.IsSet("retry-interval") && v.RetryIntervalSec > 0 {
+		c.Set("retry-interval", fmt.Sprintf("%d", v.RetryIntervalSec))
+		command.GlobalOption.RetryIntervalSec = v.RetryIntervalSec
+	}
+
 	// for string-slice
 	zones := []string{}
 	if c.IsSet("zones") {

--- a/command/functions.go
+++ b/command/functions.go
@@ -96,6 +96,17 @@ func createAPIClient() *api.Client {
 	c := api.NewClient(GlobalOption.AccessToken, GlobalOption.AccessTokenSecret, GlobalOption.Zone)
 	c.UserAgent = fmt.Sprintf("usacloud-%s", version.Version)
 	c.TraceMode = GlobalOption.TraceMode
+
+	if GlobalOption.AcceptLanguage != "" {
+		c.AcceptLanguage = GlobalOption.AcceptLanguage
+	}
+	if GlobalOption.RetryMax >= 0 {
+		c.RetryMax = GlobalOption.RetryMax
+	}
+	if GlobalOption.RetryIntervalSec >= 0 {
+		c.RetryInterval = time.Duration(GlobalOption.RetryIntervalSec) * time.Second
+	}
+
 	return c
 }
 

--- a/command/global_option.go
+++ b/command/global_option.go
@@ -15,6 +15,9 @@ type Option struct {
 	AccessTokenSecret string
 	Zone              string
 	ProfileName       string
+	AcceptLanguage    string
+	RetryMax          int
+	RetryIntervalSec  int64
 	Zones             []string
 	APIRootURL        string
 	TraceMode         bool
@@ -78,10 +81,28 @@ var GlobalFlags = []cli.Flag{
 		Destination: &GlobalOption.ProfileName,
 	},
 	&cli.StringFlag{
+		Name:        "accept-language",
+		Usage:       "Accept-Language Header",
+		EnvVars:     []string{"SAKURACLOUD_ACCEPT_LANGUAGE"},
+		Destination: &GlobalOption.AcceptLanguage,
+	},
+	&cli.IntFlag{
+		Name:        "retry-max",
+		Usage:       "Number of API-Client retries",
+		EnvVars:     []string{"SAKURACLOUD_RETRY_MAX"},
+		Destination: &GlobalOption.RetryMax,
+	},
+	&cli.Int64Flag{
+		Name:        "retry-interval",
+		Usage:       "API client retry interval seconds",
+		EnvVars:     []string{"SAKURACLOUD_RETRY_INTERVAL"},
+		Destination: &GlobalOption.RetryIntervalSec,
+	},
+	&cli.StringFlag{
 		Name:        "api-root-url",
-		Hidden:      true,
 		EnvVars:     []string{"USACLOUD_API_ROOT_URL"},
 		Destination: &GlobalOption.APIRootURL,
+		Hidden:      true,
 	},
 	&cli.StringFlag{
 		Name:        "default-output-type",

--- a/command/profile/profile.go
+++ b/command/profile/profile.go
@@ -72,6 +72,9 @@ type ConfigFileValue struct {
 	AccessToken       string
 	AccessTokenSecret string
 	Zone              string
+	AcceptLanguage    string   `json:",omitempty"`
+	RetryMax          int      `json:",omitempty"`
+	RetryIntervalSec  int64    `json:",omitempty"`
 	DefaultOutputType string   `json:",omitempty"`
 	Zones             []string `json:",omitempty"`
 	APIRootURL        string   `json:",omitempty"`

--- a/contrib/completion/bash/usacloud
+++ b/contrib/completion/bash/usacloud
@@ -4,7 +4,7 @@ _usacloud() {
     local commands=(archive auth-status auto-backup bill bridge config profile dns database disk gslb ipv4 ipv6 iso-image icon interface internet license load-balancer nfs object-storage ojs packet-filter price public-price private-host product-disk disk-plan product-internet internet-plan product-license license-info product-server server-plan region ssh-key self server simple-monitor startup-script note summary switch vpc-router web-accel zone )
 
     local flags=(--trace --help --version)
-    local wants_value=(--token --secret --zone --config --profile --default-output-type )
+    local wants_value=(--token --secret --zone --config --profile --accept-language --retry-max --retry-interval --default-output-type )
     local configflags=(--help --token --secret --zone --config --profile --show)
     local zones=(is1a is1b tk1a tk1v)
 


### PR DESCRIPTION
To fix #282 

以下グローバルオプションを追加

- `--accept-language`: さくらのクラウドAPI呼び出し時の`Accept-Language`ヘッダの指定
- `--retry-max`: API呼び出し時に503エラーとなった場合のリトライ最大数
- `--retry-max`: API呼び出し時に503エラーとなった場合のリトライ間隔秒数