### PR TITLE
タイムアウトオプションの追加

### DIFF
--- a/command/functions.go
+++ b/command/functions.go
@@ -97,6 +97,10 @@ func createAPIClient() *api.Client {
 	c.UserAgent = fmt.Sprintf("usacloud-%s", version.Version)
 	c.TraceMode = GlobalOption.TraceMode
 
+	if GlobalOption.Timeout > 0 {
+		c.DefaultTimeoutDuration = time.Duration(GlobalOption.Timeout) * time.Minute
+	}
+
 	if GlobalOption.AcceptLanguage != "" {
 		c.AcceptLanguage = GlobalOption.AcceptLanguage
 	}

--- a/command/global_option.go
+++ b/command/global_option.go
@@ -15,6 +15,7 @@ type Option struct {
 	AccessTokenSecret string
 	Zone              string
 	ProfileName       string
+	Timeout           int
 	AcceptLanguage    string
 	RetryMax          int
 	RetryIntervalSec  int64
@@ -80,6 +81,13 @@ var GlobalFlags = []cli.Flag{
 		Usage:       "Config(Profile) name",
 		EnvVars:     []string{"USACLOUD_PROFILE"},
 		Destination: &GlobalOption.ProfileName,
+	},
+	&cli.IntFlag{
+		Name:        "timeout",
+		Usage:       "Number of timeout minutes for polling functions",
+		EnvVars:     []string{"SAKURACLOUD_TIMEOUT"},
+		Value:       20,
+		Destination: &GlobalOption.Timeout,
 	},
 	&cli.StringFlag{
 		Name:        "accept-language",

--- a/command/internal/progress.go
+++ b/command/internal/progress.go
@@ -31,7 +31,7 @@ func NewProgress(msgProgress, msgPrefix string, out io.Writer) *ProgressWriter {
 		msgStart:    fmt.Sprintf("%s is started...", msgPrefix),
 		msgComplete: fmt.Sprintf("%s is finished", msgPrefix),
 		msgFail:     fmt.Sprintf("%s is failed", msgPrefix),
-		timeout:     1 * time.Hour,
+		timeout:     12 * time.Hour,
 		duration:    10 * time.Second,
 		wg:          sync.WaitGroup{},
 	}

--- a/command/profile/profile.go
+++ b/command/profile/profile.go
@@ -72,6 +72,7 @@ type ConfigFileValue struct {
 	AccessToken       string
 	AccessTokenSecret string
 	Zone              string
+	Timeout           int      `json:",omitempty"`
 	AcceptLanguage    string   `json:",omitempty"`
 	RetryMax          int      `json:",omitempty"`
 	RetryIntervalSec  int64    `json:",omitempty"`

--- a/contrib/completion/bash/usacloud
+++ b/contrib/completion/bash/usacloud
@@ -4,7 +4,7 @@ _usacloud() {
     local commands=(archive auth-status auto-backup bill bridge config profile dns database disk gslb ipv4 ipv6 iso-image icon interface internet license load-balancer nfs object-storage ojs packet-filter price public-price private-host product-disk disk-plan product-internet internet-plan product-license license-info product-server server-plan region ssh-key self server simple-monitor startup-script note summary switch vpc-router web-accel zone )
 
     local flags=(--no-color --trace --help --version)
-    local wants_value=(--token --secret --zone --config --profile --accept-language --retry-max --retry-interval --default-output-type )
+    local wants_value=(--token --secret --zone --config --profile --timeout --accept-language --retry-max --retry-interval --default-output-type )
     local configflags=(--help --token --secret --zone --config --profile --show)
     local zones=(is1a is1b tk1a tk1v)
 


### PR DESCRIPTION
To fix #310 

ディスク/アーカイブの作成やサーバの起動待ちなど、ポーリング処理を行う際のタイムアウト時間を設定可能にする。

#### 利用例

```bash
# コマンドラインオプションで指定(分単位)
$ usacloud --timeout 10 ...

# 環境変数で指定(分単位)
$ export SAKURACLOUD_TIMEOUT=10
$ usacloud ...
```