### PR TITLE
Fix startup-script to startup-script-ids

### DIFF
--- a/command/funcs/disk_edit.go
+++ b/command/funcs/disk_edit.go
@@ -26,7 +26,7 @@ func DiskEdit(ctx command.Context, params *params.EditDiskParam) error {
 	if ctx.IsSet("disable-password-auth") {
 		p.SetDisablePWAuth(params.DisablePasswordAuth)
 	}
-	if ctx.IsSet("startup-script") {
+	if ctx.IsSet("startup-script-ids") {
 		p.SetNotes(command.StringIDs(params.StartupScriptIds))
 	}
 	if ctx.IsSet("ipaddress") {


### PR DESCRIPTION
define/disk.go の `diskConfigParam` にて `"startup-script-ids"` と定義されていますが、
command/funcs/disk_edit.go にて `"startup-script"` の存在確認をしているため、
ディスク修正時にスタートアップスクリプトのパラメータが渡っていなかった問題を修正しました。