### PR TITLE
Add an asterisk to current config for usacloud config list

### DIFF
--- a/command/funcs/config_list.go
+++ b/command/funcs/config_list.go
@@ -13,8 +13,18 @@ func ConfigList(ctx command.Context, params *params.ListConfigParam) error {
 		return err
 	}
 
+	cp, err := profile.GetCurrentName()
+	if err != nil {
+		return err
+	}
+
 	for _, p := range profiles {
-		fmt.Fprintln(command.GlobalOption.Out, p)
+		mark := " "
+		if p == cp {
+			mark = "*"
+		}
+
+		fmt.Fprintf(command.GlobalOption.Out, "%s %s\n", mark, p)
 	}
 	return nil
 }


### PR DESCRIPTION
`git branch` コマンドにて現在のブランチ名にアスタリスクが付与される挙動と同様に、
`usacloud config list` にて現在の設定にアスタリスクが付与されるようにしました。
複数の設定がある場合には便利ですので、マージを検討していただけるとありがたいです。

```
$ usacloud config list
  default
  account1
* account2
  account3
```

既存の挙動と異なり、各設定の先頭に半角2つ分の文字列が追加される変更になります。
そのため、もし仮に `usacloud config list` の結果を
何かのスクリプト等で利用されているユーザーがいらっしゃる場合には、
そのユーザーに影響のある変更です。

ただ、利便性とユーザーへの影響を比較すると、
デフォルトでアスタリスクが付く挙動に変更した方がメリットが大きいと判断いたしました。