### PR TITLE
リリース時のドキュメント生成を自動化

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,16 +414,15 @@ $ make docker-integration-test
 
 ドキュメントはGithub Pagesを利用しています。(masterブランチの`docs`ディレクトリ配下)  
 静的ファイルの生成は`mkdocs`コマンドで行なっています。  
-ドキュメントの追加や修正は`build_docs`ディレクトリ以下のファイルの追加/修正を行なった上で`mkdocs`コマンドでファイル生成してコミットしてください。
+
+**ドキュメントのPRの際は`build_docs`ディレクトリ配下のみ修正を行い、`docs`ディレクトリ配下は変更しないでください。  
+`docs`ディレクトリはリリース時に一括更新されます。**
 
     # ドキュメントのプレビュー用サーバー起動(http://localhost/でプレビュー可能)
     make serve-docs
     
     # ドキュメントの検証(textlint)
     make lint-docs
-    
-    # build_docs配下のファイルからドキュメント生成(docsディレクトリ再生成)
-    make build-docs
 
 ## License
 

--- a/scripts/usacloud-release.pl
+++ b/scripts/usacloud-release.pl
@@ -477,6 +477,9 @@ sub create_pull_request {
         infof "skip to update changelogs because no merged pull request is found after the last release.\n"
     }
 
+    infof "Build GitHub Pages.\n";
+    system "make", "build-docs";
+
     infof "Update AUTHORS.\n";
     system "scripts/generate-authors.sh";
 


### PR DESCRIPTION
To fix #123 

GitHub Pages用の静的ファイルのビルドをリリース用PR作成時に一括で行う。