### PR TITLE
モバイルゲートウェイでのルーティング設定

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,7 @@
     "sacloud/ostype",
     "utils/server"
   ]
-  revision = "160b81c6238019afcfca496d65c63acb7b809ccd"
+  revision = "2fd1b17a85c8ed7bf58ecdc103368a0c0cb3e631"
 
 [[projects]]
   branch = "master"

--- a/command/cli/cli_mobile_gateway_gen.go
+++ b/command/cli/cli_mobile_gateway_gen.go
@@ -33,11 +33,15 @@ func init() {
 	interfaceConnectParam := params.NewInterfaceConnectMobileGatewayParam()
 	interfaceUpdateParam := params.NewInterfaceUpdateMobileGatewayParam()
 	interfaceDisconnectParam := params.NewInterfaceDisconnectMobileGatewayParam()
-	dnsUpdateParam := params.NewDnsUpdateMobileGatewayParam()
+	staticRouteInfoParam := params.NewStaticRouteInfoMobileGatewayParam()
+	staticRouteAddParam := params.NewStaticRouteAddMobileGatewayParam()
+	staticRouteUpdateParam := params.NewStaticRouteUpdateMobileGatewayParam()
+	staticRouteDeleteParam := params.NewStaticRouteDeleteMobileGatewayParam()
 	simInfoParam := params.NewSimInfoMobileGatewayParam()
 	simAddParam := params.NewSimAddMobileGatewayParam()
 	simUpdateParam := params.NewSimUpdateMobileGatewayParam()
 	simDeleteParam := params.NewSimDeleteMobileGatewayParam()
+	dnsUpdateParam := params.NewDnsUpdateMobileGatewayParam()
 	logsParam := params.NewLogsMobileGatewayParam()
 
 	cliCommand := &cli.Command{
@@ -5073,17 +5077,377 @@ func init() {
 				},
 			},
 			{
-				Name:      "dns-update",
-				Usage:     "Update interface",
+				Name:      "static-route-info",
+				Aliases:   []string{"static-route-list"},
+				Usage:     "Show information of static-routes",
+				ArgsUsage: "<ID or Name(only single target)>",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [table/json/csv/tsv]",
+					},
+					&cli.StringSliceFlag{
+						Name:    "column",
+						Aliases: []string{"col"},
+						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
+					},
+					&cli.BoolFlag{
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
+					},
+					&cli.StringFlag{
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
+					},
+					&cli.StringFlag{
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
+					},
+					&cli.StringFlag{
+						Name:  "query",
+						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = staticRouteInfoParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, staticRouteInfoParam)
+
+					// Set option values
+					if c.IsSet("selector") {
+						staticRouteInfoParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("param-template") {
+						staticRouteInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						staticRouteInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						staticRouteInfoParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("output-type") {
+						staticRouteInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						staticRouteInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						staticRouteInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						staticRouteInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						staticRouteInfoParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("query") {
+						staticRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("id") {
+						staticRouteInfoParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayStaticRouteInfoCompleteArgs(ctx, staticRouteInfoParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayStaticRouteInfoCompleteArgs(ctx, staticRouteInfoParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayStaticRouteInfoCompleteFlags(ctx, staticRouteInfoParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayStaticRouteInfoCompleteArgs(ctx, staticRouteInfoParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					staticRouteInfoParam.ParamTemplate = c.String("param-template")
+					staticRouteInfoParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(staticRouteInfoParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewStaticRouteInfoMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(staticRouteInfoParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("selector") {
+						staticRouteInfoParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("param-template") {
+						staticRouteInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						staticRouteInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						staticRouteInfoParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("output-type") {
+						staticRouteInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						staticRouteInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						staticRouteInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						staticRouteInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						staticRouteInfoParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("query") {
+						staticRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("id") {
+						staticRouteInfoParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = staticRouteInfoParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if staticRouteInfoParam.GenerateSkeleton {
+						staticRouteInfoParam.GenerateSkeleton = false
+						staticRouteInfoParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(staticRouteInfoParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := staticRouteInfoParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), staticRouteInfoParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(staticRouteInfoParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, staticRouteInfoParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", staticRouteInfoParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(staticRouteInfoParam.Selector) == 0 || hasTags(&v, staticRouteInfoParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					if len(ids) != 1 {
+						return fmt.Errorf("Can't run with multiple targets: %v", ids)
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						staticRouteInfoParam.SetId(id)
+						p := *staticRouteInfoParam // copy struct value
+						staticRouteInfoParam := &p
+						go func() {
+							err := funcs.MobileGatewayStaticRouteInfo(ctx, staticRouteInfoParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "static-route-add",
+				Usage:     "Add static-route",
 				ArgsUsage: "<ID or Name(only single target)>",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "dns1",
-						Usage: "[Required] set DNS server address",
+						Name:  "prefix",
+						Usage: "[Required] set prefix",
 					},
 					&cli.StringFlag{
-						Name:  "dns2",
-						Usage: "[Required] set DNS server address",
+						Name:  "next-hop",
+						Usage: "[Required] set next-hop",
 					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
@@ -5139,7 +5503,7 @@ func init() {
 
 					// set default output-type
 					// when params have output-type option and have empty value
-					var outputTypeHolder interface{} = dnsUpdateParam
+					var outputTypeHolder interface{} = staticRouteAddParam
 					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
 						if v.GetOutputType() == "" {
 							v.SetOutputType(command.GlobalOption.DefaultOutputType)
@@ -5147,32 +5511,32 @@ func init() {
 					}
 
 					// build command context
-					ctx := command.NewContext(c, realArgs, dnsUpdateParam)
+					ctx := command.NewContext(c, realArgs, staticRouteAddParam)
 
 					// Set option values
-					if c.IsSet("dns1") {
-						dnsUpdateParam.Dns1 = c.String("dns1")
+					if c.IsSet("prefix") {
+						staticRouteAddParam.Prefix = c.String("prefix")
 					}
-					if c.IsSet("dns2") {
-						dnsUpdateParam.Dns2 = c.String("dns2")
+					if c.IsSet("next-hop") {
+						staticRouteAddParam.NextHop = c.String("next-hop")
 					}
 					if c.IsSet("selector") {
-						dnsUpdateParam.Selector = c.StringSlice("selector")
+						staticRouteAddParam.Selector = c.StringSlice("selector")
 					}
 					if c.IsSet("assumeyes") {
-						dnsUpdateParam.Assumeyes = c.Bool("assumeyes")
+						staticRouteAddParam.Assumeyes = c.Bool("assumeyes")
 					}
 					if c.IsSet("param-template") {
-						dnsUpdateParam.ParamTemplate = c.String("param-template")
+						staticRouteAddParam.ParamTemplate = c.String("param-template")
 					}
 					if c.IsSet("param-template-file") {
-						dnsUpdateParam.ParamTemplateFile = c.String("param-template-file")
+						staticRouteAddParam.ParamTemplateFile = c.String("param-template-file")
 					}
 					if c.IsSet("generate-skeleton") {
-						dnsUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+						staticRouteAddParam.GenerateSkeleton = c.Bool("generate-skeleton")
 					}
 					if c.IsSet("id") {
-						dnsUpdateParam.Id = c.Int64("id")
+						staticRouteAddParam.Id = c.Int64("id")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -5182,7 +5546,7 @@ func init() {
 								completion.FlagNames(c, commandName)
 								return
 							} else {
-								completion.MobileGatewayDnsUpdateCompleteArgs(ctx, dnsUpdateParam, cur, prev, commandName)
+								completion.MobileGatewayStaticRouteAddCompleteArgs(ctx, staticRouteAddParam, cur, prev, commandName)
 								return
 							}
 						}
@@ -5213,12 +5577,12 @@ func init() {
 										completion.FlagNames(c, commandName)
 										return
 									} else {
-										completion.MobileGatewayDnsUpdateCompleteArgs(ctx, dnsUpdateParam, cur, prev, commandName)
+										completion.MobileGatewayStaticRouteAddCompleteArgs(ctx, staticRouteAddParam, cur, prev, commandName)
 										return
 									}
 								} else {
 									// prev is flag , call completion func of each flags
-									completion.MobileGatewayDnsUpdateCompleteFlags(ctx, dnsUpdateParam, name, cur)
+									completion.MobileGatewayStaticRouteAddCompleteFlags(ctx, staticRouteAddParam, name, cur)
 									return
 								}
 							}
@@ -5229,7 +5593,7 @@ func init() {
 							completion.FlagNames(c, commandName)
 							return
 						} else {
-							completion.MobileGatewayDnsUpdateCompleteArgs(ctx, dnsUpdateParam, cur, prev, commandName)
+							completion.MobileGatewayStaticRouteAddCompleteArgs(ctx, staticRouteAddParam, cur, prev, commandName)
 							return
 						}
 					}
@@ -5243,45 +5607,45 @@ func init() {
 						return err
 					}
 
-					dnsUpdateParam.ParamTemplate = c.String("param-template")
-					dnsUpdateParam.ParamTemplateFile = c.String("param-template-file")
-					strInput, err := command.GetParamTemplateValue(dnsUpdateParam)
+					staticRouteAddParam.ParamTemplate = c.String("param-template")
+					staticRouteAddParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(staticRouteAddParam)
 					if err != nil {
 						return err
 					}
 					if strInput != "" {
-						p := params.NewDnsUpdateMobileGatewayParam()
+						p := params.NewStaticRouteAddMobileGatewayParam()
 						err := json.Unmarshal([]byte(strInput), p)
 						if err != nil {
 							return fmt.Errorf("Failed to parse JSON: %s", err)
 						}
-						mergo.Merge(dnsUpdateParam, p, mergo.WithOverride)
+						mergo.Merge(staticRouteAddParam, p, mergo.WithOverride)
 					}
 
 					// Set option values
-					if c.IsSet("dns1") {
-						dnsUpdateParam.Dns1 = c.String("dns1")
+					if c.IsSet("prefix") {
+						staticRouteAddParam.Prefix = c.String("prefix")
 					}
-					if c.IsSet("dns2") {
-						dnsUpdateParam.Dns2 = c.String("dns2")
+					if c.IsSet("next-hop") {
+						staticRouteAddParam.NextHop = c.String("next-hop")
 					}
 					if c.IsSet("selector") {
-						dnsUpdateParam.Selector = c.StringSlice("selector")
+						staticRouteAddParam.Selector = c.StringSlice("selector")
 					}
 					if c.IsSet("assumeyes") {
-						dnsUpdateParam.Assumeyes = c.Bool("assumeyes")
+						staticRouteAddParam.Assumeyes = c.Bool("assumeyes")
 					}
 					if c.IsSet("param-template") {
-						dnsUpdateParam.ParamTemplate = c.String("param-template")
+						staticRouteAddParam.ParamTemplate = c.String("param-template")
 					}
 					if c.IsSet("param-template-file") {
-						dnsUpdateParam.ParamTemplateFile = c.String("param-template-file")
+						staticRouteAddParam.ParamTemplateFile = c.String("param-template-file")
 					}
 					if c.IsSet("generate-skeleton") {
-						dnsUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+						staticRouteAddParam.GenerateSkeleton = c.Bool("generate-skeleton")
 					}
 					if c.IsSet("id") {
-						dnsUpdateParam.Id = c.Int64("id")
+						staticRouteAddParam.Id = c.Int64("id")
 					}
 
 					// Validate global params
@@ -5289,7 +5653,7 @@ func init() {
 						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
 					}
 
-					var outputTypeHolder interface{} = dnsUpdateParam
+					var outputTypeHolder interface{} = staticRouteAddParam
 					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
 						if v.GetOutputType() == "" {
 							v.SetOutputType(command.GlobalOption.DefaultOutputType)
@@ -5297,10 +5661,10 @@ func init() {
 					}
 
 					// Generate skeleton
-					if dnsUpdateParam.GenerateSkeleton {
-						dnsUpdateParam.GenerateSkeleton = false
-						dnsUpdateParam.FillValueToSkeleton()
-						d, err := json.MarshalIndent(dnsUpdateParam, "", "\t")
+					if staticRouteAddParam.GenerateSkeleton {
+						staticRouteAddParam.GenerateSkeleton = false
+						staticRouteAddParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(staticRouteAddParam, "", "\t")
 						if err != nil {
 							return fmt.Errorf("Failed to Marshal JSON: %s", err)
 						}
@@ -5309,19 +5673,19 @@ func init() {
 					}
 
 					// Validate specific for each command params
-					if errors := dnsUpdateParam.Validate(); len(errors) > 0 {
+					if errors := staticRouteAddParam.Validate(); len(errors) > 0 {
 						return command.FlattenErrorsWithPrefix(errors, "Options")
 					}
 
 					// create command context
-					ctx := command.NewContext(c, c.Args().Slice(), dnsUpdateParam)
+					ctx := command.NewContext(c, c.Args().Slice(), staticRouteAddParam)
 
 					apiClient := ctx.GetAPIClient().MobileGateway
 					ids := []int64{}
 
 					if c.NArg() == 0 {
 
-						if len(dnsUpdateParam.Selector) == 0 {
+						if len(staticRouteAddParam.Selector) == 0 {
 							return fmt.Errorf("ID or Name argument or --selector option is required")
 						}
 						apiClient.Reset()
@@ -5330,12 +5694,12 @@ func init() {
 							return fmt.Errorf("Find ID is failed: %s", err)
 						}
 						for _, v := range res.MobileGateways {
-							if hasTags(&v, dnsUpdateParam.Selector) {
+							if hasTags(&v, staticRouteAddParam.Selector) {
 								ids = append(ids, v.GetID())
 							}
 						}
 						if len(ids) == 0 {
-							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", dnsUpdateParam.Selector)
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", staticRouteAddParam.Selector)
 						}
 
 					} else {
@@ -5357,7 +5721,7 @@ func init() {
 										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
 									}
 									for _, v := range res.MobileGateways {
-										if len(dnsUpdateParam.Selector) == 0 || hasTags(&v, dnsUpdateParam.Selector) {
+										if len(staticRouteAddParam.Selector) == 0 || hasTags(&v, staticRouteAddParam.Selector) {
 											ids = append(ids, v.GetID())
 										}
 									}
@@ -5378,11 +5742,11 @@ func init() {
 					}
 
 					// confirm
-					if !dnsUpdateParam.Assumeyes {
+					if !staticRouteAddParam.Assumeyes {
 						if !isTerminal() {
 							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
 						}
-						if !command.ConfirmContinue("dns-update", ids...) {
+						if !command.ConfirmContinue("static-route-add", ids...) {
 							return nil
 						}
 					}
@@ -5392,11 +5756,683 @@ func init() {
 
 					for _, id := range ids {
 						wg.Add(1)
-						dnsUpdateParam.SetId(id)
-						p := *dnsUpdateParam // copy struct value
-						dnsUpdateParam := &p
+						staticRouteAddParam.SetId(id)
+						p := *staticRouteAddParam // copy struct value
+						staticRouteAddParam := &p
 						go func() {
-							err := funcs.MobileGatewayDnsUpdate(ctx, dnsUpdateParam)
+							err := funcs.MobileGatewayStaticRouteAdd(ctx, staticRouteAddParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "static-route-update",
+				Usage:     "Update static-route",
+				ArgsUsage: "<ID or Name(only single target)>",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "index",
+						Usage: "[Required] index of target static-route",
+					},
+					&cli.StringFlag{
+						Name:  "prefix",
+						Usage: "set prefix",
+					},
+					&cli.StringFlag{
+						Name:  "next-hop",
+						Usage: "set next-hop",
+					},
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = staticRouteUpdateParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, staticRouteUpdateParam)
+
+					// Set option values
+					if c.IsSet("index") {
+						staticRouteUpdateParam.Index = c.Int("index")
+					}
+					if c.IsSet("prefix") {
+						staticRouteUpdateParam.Prefix = c.String("prefix")
+					}
+					if c.IsSet("next-hop") {
+						staticRouteUpdateParam.NextHop = c.String("next-hop")
+					}
+					if c.IsSet("selector") {
+						staticRouteUpdateParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						staticRouteUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						staticRouteUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						staticRouteUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						staticRouteUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						staticRouteUpdateParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayStaticRouteUpdateCompleteArgs(ctx, staticRouteUpdateParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayStaticRouteUpdateCompleteArgs(ctx, staticRouteUpdateParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayStaticRouteUpdateCompleteFlags(ctx, staticRouteUpdateParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayStaticRouteUpdateCompleteArgs(ctx, staticRouteUpdateParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					staticRouteUpdateParam.ParamTemplate = c.String("param-template")
+					staticRouteUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(staticRouteUpdateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewStaticRouteUpdateMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(staticRouteUpdateParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("index") {
+						staticRouteUpdateParam.Index = c.Int("index")
+					}
+					if c.IsSet("prefix") {
+						staticRouteUpdateParam.Prefix = c.String("prefix")
+					}
+					if c.IsSet("next-hop") {
+						staticRouteUpdateParam.NextHop = c.String("next-hop")
+					}
+					if c.IsSet("selector") {
+						staticRouteUpdateParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						staticRouteUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						staticRouteUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						staticRouteUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						staticRouteUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						staticRouteUpdateParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = staticRouteUpdateParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if staticRouteUpdateParam.GenerateSkeleton {
+						staticRouteUpdateParam.GenerateSkeleton = false
+						staticRouteUpdateParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(staticRouteUpdateParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := staticRouteUpdateParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), staticRouteUpdateParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(staticRouteUpdateParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, staticRouteUpdateParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", staticRouteUpdateParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(staticRouteUpdateParam.Selector) == 0 || hasTags(&v, staticRouteUpdateParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					if len(ids) != 1 {
+						return fmt.Errorf("Can't run with multiple targets: %v", ids)
+					}
+
+					// confirm
+					if !staticRouteUpdateParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("static-route-update", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						staticRouteUpdateParam.SetId(id)
+						p := *staticRouteUpdateParam // copy struct value
+						staticRouteUpdateParam := &p
+						go func() {
+							err := funcs.MobileGatewayStaticRouteUpdate(ctx, staticRouteUpdateParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "static-route-delete",
+				Usage:     "Delete static-route",
+				ArgsUsage: "<ID or Name(only single target)>",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "index",
+						Usage: "[Required] index of target static-route",
+					},
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = staticRouteDeleteParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, staticRouteDeleteParam)
+
+					// Set option values
+					if c.IsSet("index") {
+						staticRouteDeleteParam.Index = c.Int("index")
+					}
+					if c.IsSet("selector") {
+						staticRouteDeleteParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						staticRouteDeleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						staticRouteDeleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						staticRouteDeleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						staticRouteDeleteParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						staticRouteDeleteParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayStaticRouteDeleteCompleteArgs(ctx, staticRouteDeleteParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayStaticRouteDeleteCompleteArgs(ctx, staticRouteDeleteParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayStaticRouteDeleteCompleteFlags(ctx, staticRouteDeleteParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayStaticRouteDeleteCompleteArgs(ctx, staticRouteDeleteParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					staticRouteDeleteParam.ParamTemplate = c.String("param-template")
+					staticRouteDeleteParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(staticRouteDeleteParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewStaticRouteDeleteMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(staticRouteDeleteParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("index") {
+						staticRouteDeleteParam.Index = c.Int("index")
+					}
+					if c.IsSet("selector") {
+						staticRouteDeleteParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						staticRouteDeleteParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						staticRouteDeleteParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						staticRouteDeleteParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						staticRouteDeleteParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						staticRouteDeleteParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = staticRouteDeleteParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if staticRouteDeleteParam.GenerateSkeleton {
+						staticRouteDeleteParam.GenerateSkeleton = false
+						staticRouteDeleteParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(staticRouteDeleteParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := staticRouteDeleteParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), staticRouteDeleteParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(staticRouteDeleteParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, staticRouteDeleteParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", staticRouteDeleteParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(staticRouteDeleteParam.Selector) == 0 || hasTags(&v, staticRouteDeleteParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					if len(ids) != 1 {
+						return fmt.Errorf("Can't run with multiple targets: %v", ids)
+					}
+
+					// confirm
+					if !staticRouteDeleteParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("static-route-delete", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						staticRouteDeleteParam.SetId(id)
+						p := *staticRouteDeleteParam // copy struct value
+						staticRouteDeleteParam := &p
+						go func() {
+							err := funcs.MobileGatewayStaticRouteDelete(ctx, staticRouteDeleteParam)
 							if err != nil {
 								errs = append(errs, err)
 							}
@@ -6769,6 +7805,342 @@ func init() {
 				},
 			},
 			{
+				Name:      "dns-update",
+				Usage:     "Update interface",
+				ArgsUsage: "<ID or Name(only single target)>",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "dns1",
+						Usage: "[Required] set DNS server address",
+					},
+					&cli.StringFlag{
+						Name:  "dns2",
+						Usage: "[Required] set DNS server address",
+					},
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = dnsUpdateParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, dnsUpdateParam)
+
+					// Set option values
+					if c.IsSet("dns1") {
+						dnsUpdateParam.Dns1 = c.String("dns1")
+					}
+					if c.IsSet("dns2") {
+						dnsUpdateParam.Dns2 = c.String("dns2")
+					}
+					if c.IsSet("selector") {
+						dnsUpdateParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						dnsUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						dnsUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						dnsUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						dnsUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						dnsUpdateParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayDnsUpdateCompleteArgs(ctx, dnsUpdateParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayDnsUpdateCompleteArgs(ctx, dnsUpdateParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayDnsUpdateCompleteFlags(ctx, dnsUpdateParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayDnsUpdateCompleteArgs(ctx, dnsUpdateParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					dnsUpdateParam.ParamTemplate = c.String("param-template")
+					dnsUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(dnsUpdateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDnsUpdateMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(dnsUpdateParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("dns1") {
+						dnsUpdateParam.Dns1 = c.String("dns1")
+					}
+					if c.IsSet("dns2") {
+						dnsUpdateParam.Dns2 = c.String("dns2")
+					}
+					if c.IsSet("selector") {
+						dnsUpdateParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						dnsUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						dnsUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						dnsUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						dnsUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						dnsUpdateParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = dnsUpdateParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if dnsUpdateParam.GenerateSkeleton {
+						dnsUpdateParam.GenerateSkeleton = false
+						dnsUpdateParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(dnsUpdateParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := dnsUpdateParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), dnsUpdateParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(dnsUpdateParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, dnsUpdateParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", dnsUpdateParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(dnsUpdateParam.Selector) == 0 || hasTags(&v, dnsUpdateParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					if len(ids) != 1 {
+						return fmt.Errorf("Can't run with multiple targets: %v", ids)
+					}
+
+					// confirm
+					if !dnsUpdateParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("dns-update", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						dnsUpdateParam.SetId(id)
+						p := *dnsUpdateParam // copy struct value
+						dnsUpdateParam := &p
+						go func() {
+							err := funcs.MobileGatewayDnsUpdate(ctx, dnsUpdateParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
 				Name:      "logs",
 				Usage:     "Logs MobileGateway",
 				ArgsUsage: "<ID or Name(only single target)>",
@@ -7115,7 +8487,7 @@ func init() {
 	AppendCommandCategoryMap("mobile-gateway", "dns-update", &schema.Category{
 		Key:         "dns",
 		DisplayName: "DNS Management",
-		Order:       40,
+		Order:       60,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "interface-connect", &schema.Category{
 		Key:         "nic",
@@ -7145,7 +8517,7 @@ func init() {
 	AppendCommandCategoryMap("mobile-gateway", "logs", &schema.Category{
 		Key:         "monitor",
 		DisplayName: "Monitoring",
-		Order:       50,
+		Order:       70,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "read", &schema.Category{
 		Key:         "basic",
@@ -7170,21 +8542,41 @@ func init() {
 	AppendCommandCategoryMap("mobile-gateway", "sim-add", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       40,
+		Order:       50,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-delete", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       40,
+		Order:       50,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-info", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       40,
+		Order:       50,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-update", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
+		Order:       50,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "static-route-add", &schema.Category{
+		Key:         "static-route",
+		DisplayName: "StaticRoute Management",
+		Order:       40,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "static-route-delete", &schema.Category{
+		Key:         "static-route",
+		DisplayName: "StaticRoute Management",
+		Order:       40,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "static-route-info", &schema.Category{
+		Key:         "static-route",
+		DisplayName: "StaticRoute Management",
+		Order:       40,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "static-route-update", &schema.Category{
+		Key:         "static-route",
+		DisplayName: "StaticRoute Management",
 		Order:       40,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "update", &schema.Category{
@@ -8009,6 +9401,181 @@ func init() {
 		Key:         "interface",
 		DisplayName: "Interface options",
 		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "next-hop", &schema.Category{
+		Key:         "Static-Route",
+		DisplayName: "Static-Route options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "prefix", &schema.Category{
+		Key:         "Static-Route",
+		DisplayName: "Static-Route options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-add", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-delete", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-delete", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-delete", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-delete", "index", &schema.Category{
+		Key:         "Static-Route",
+		DisplayName: "Static-Route options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-delete", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-delete", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-delete", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "column", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "format", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "format-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "output-type", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "quiet", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "index", &schema.Category{
+		Key:         "Static-Route",
+		DisplayName: "Static-Route options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "next-hop", &schema.Category{
+		Key:         "Static-Route",
+		DisplayName: "Static-Route options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "prefix", &schema.Category{
+		Key:         "Static-Route",
+		DisplayName: "Static-Route options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-update", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
 	})
 	AppendFlagCategoryMap("mobile-gateway", "update", "assumeyes", &schema.Category{
 		Key:         "Input",

--- a/command/completion/mobile_gateway_args_gen.go
+++ b/command/completion/mobile_gateway_args_gen.go
@@ -420,7 +420,100 @@ func MobileGatewayInterfaceDisconnectCompleteArgs(ctx command.Context, params *p
 
 }
 
-func MobileGatewayDnsUpdateCompleteArgs(ctx command.Context, params *params.DnsUpdateMobileGatewayParam, cur, prev, commandName string) {
+func MobileGatewayStaticRouteInfoCompleteArgs(ctx command.Context, params *params.StaticRouteInfoMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewayStaticRouteAddCompleteArgs(ctx command.Context, params *params.StaticRouteAddMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewayStaticRouteUpdateCompleteArgs(ctx command.Context, params *params.StaticRouteUpdateMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewayStaticRouteDeleteCompleteArgs(ctx command.Context, params *params.StaticRouteDeleteMobileGatewayParam, cur, prev, commandName string) {
 
 	if !command.GlobalOption.Valid {
 		return
@@ -545,6 +638,37 @@ func MobileGatewaySimUpdateCompleteArgs(ctx command.Context, params *params.SimU
 }
 
 func MobileGatewaySimDeleteCompleteArgs(ctx command.Context, params *params.SimDeleteMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewayDnsUpdateCompleteArgs(ctx command.Context, params *params.DnsUpdateMobileGatewayParam, cur, prev, commandName string) {
 
 	if !command.GlobalOption.Valid {
 		return

--- a/command/completion/mobile_gateway_args_gen.go
+++ b/command/completion/mobile_gateway_args_gen.go
@@ -668,6 +668,130 @@ func MobileGatewaySimDeleteCompleteArgs(ctx command.Context, params *params.SimD
 
 }
 
+func MobileGatewaySimRouteInfoCompleteArgs(ctx command.Context, params *params.SimRouteInfoMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewaySimRouteAddCompleteArgs(ctx command.Context, params *params.SimRouteAddMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewaySimRouteUpdateCompleteArgs(ctx command.Context, params *params.SimRouteUpdateMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewaySimRouteDeleteCompleteArgs(ctx command.Context, params *params.SimRouteDeleteMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
 func MobileGatewayDnsUpdateCompleteArgs(ctx command.Context, params *params.DnsUpdateMobileGatewayParam, cur, prev, commandName string) {
 
 	if !command.GlobalOption.Valid {

--- a/command/completion/mobile_gateway_flags_gen.go
+++ b/command/completion/mobile_gateway_flags_gen.go
@@ -473,27 +473,121 @@ func MobileGatewayInterfaceDisconnectCompleteFlags(ctx command.Context, params *
 	}
 }
 
-func MobileGatewayDnsUpdateCompleteFlags(ctx command.Context, params *params.DnsUpdateMobileGatewayParam, flagName string, currentValue string) {
+func MobileGatewayStaticRouteInfoCompleteFlags(ctx command.Context, params *params.StaticRouteInfoMobileGatewayParam, flagName string, currentValue string) {
 	var comp schema.CompletionFunc
 
 	switch flagName {
-	case "dns1":
-		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("dns1")
-		if param != nil {
-			comp = param.Param.CompleteFunc
-		}
-	case "dns2":
-		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("dns2")
-		if param != nil {
-			comp = param.Param.CompleteFunc
-		}
 	case "selector":
-		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("selector")
+		param := define.Resources["MobileGateway"].Commands["static-route-info"].BuildedParams().Get("selector")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
 	case "id":
-		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("id")
+		param := define.Resources["MobileGateway"].Commands["static-route-info"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out":
+		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewayStaticRouteAddCompleteFlags(ctx command.Context, params *params.StaticRouteAddMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "prefix":
+		param := define.Resources["MobileGateway"].Commands["static-route-add"].BuildedParams().Get("prefix")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "next-hop":
+		param := define.Resources["MobileGateway"].Commands["static-route-add"].BuildedParams().Get("next-hop")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["static-route-add"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["static-route-add"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewayStaticRouteUpdateCompleteFlags(ctx command.Context, params *params.StaticRouteUpdateMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "index":
+		param := define.Resources["MobileGateway"].Commands["static-route-update"].BuildedParams().Get("index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "prefix":
+		param := define.Resources["MobileGateway"].Commands["static-route-update"].BuildedParams().Get("prefix")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "next-hop":
+		param := define.Resources["MobileGateway"].Commands["static-route-update"].BuildedParams().Get("next-hop")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["static-route-update"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["static-route-update"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewayStaticRouteDeleteCompleteFlags(ctx command.Context, params *params.StaticRouteDeleteMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "index":
+		param := define.Resources["MobileGateway"].Commands["static-route-delete"].BuildedParams().Get("index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["static-route-delete"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["static-route-delete"].BuildedParams().Get("id")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -617,6 +711,40 @@ func MobileGatewaySimDeleteCompleteFlags(ctx command.Context, params *params.Sim
 		}
 	case "id":
 		param := define.Resources["MobileGateway"].Commands["sim-delete"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewayDnsUpdateCompleteFlags(ctx command.Context, params *params.DnsUpdateMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "dns1":
+		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("dns1")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "dns2":
+		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("dns2")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["dns-update"].BuildedParams().Get("id")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}

--- a/command/completion/mobile_gateway_flags_gen.go
+++ b/command/completion/mobile_gateway_flags_gen.go
@@ -724,6 +724,134 @@ func MobileGatewaySimDeleteCompleteFlags(ctx command.Context, params *params.Sim
 	}
 }
 
+func MobileGatewaySimRouteInfoCompleteFlags(ctx command.Context, params *params.SimRouteInfoMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["sim-route-info"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["sim-route-info"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out":
+		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewaySimRouteAddCompleteFlags(ctx command.Context, params *params.SimRouteAddMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "prefix":
+		param := define.Resources["MobileGateway"].Commands["sim-route-add"].BuildedParams().Get("prefix")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "sim":
+		param := define.Resources["MobileGateway"].Commands["sim-route-add"].BuildedParams().Get("sim")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["sim-route-add"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["sim-route-add"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewaySimRouteUpdateCompleteFlags(ctx command.Context, params *params.SimRouteUpdateMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "index":
+		param := define.Resources["MobileGateway"].Commands["sim-route-update"].BuildedParams().Get("index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "prefix":
+		param := define.Resources["MobileGateway"].Commands["sim-route-update"].BuildedParams().Get("prefix")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "sim":
+		param := define.Resources["MobileGateway"].Commands["sim-route-update"].BuildedParams().Get("sim")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["sim-route-update"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["sim-route-update"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewaySimRouteDeleteCompleteFlags(ctx command.Context, params *params.SimRouteDeleteMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "index":
+		param := define.Resources["MobileGateway"].Commands["sim-route-delete"].BuildedParams().Get("index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["sim-route-delete"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["sim-route-delete"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
 func MobileGatewayDnsUpdateCompleteFlags(ctx command.Context, params *params.DnsUpdateMobileGatewayParam, flagName string, currentValue string) {
 	var comp schema.CompletionFunc
 

--- a/command/funcs/mobile_gateway_sim_route_add.go
+++ b/command/funcs/mobile_gateway_sim_route_add.go
@@ -1,0 +1,46 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewaySimRouteAdd(ctx command.Context, params *params.SimRouteAddMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	_, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewaySimRouteAdd is failed: %s", e)
+	}
+
+	routeList, err := api.GetSIMRoutes(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteAdd is failed: %s", err)
+	}
+
+	routes := &sacloud.MobileGatewaySIMRoutes{
+		SIMRoutes: routeList,
+	}
+
+	if _, exists := routes.FindSIMRoute(params.Sim, params.Prefix); exists != nil {
+		fmt.Fprintf(command.GlobalOption.Out, "SIM Route[%s -> %d] already exists", params.Prefix, params.Sim)
+		return nil
+	}
+
+	if _, err := client.GetSIMAPI().Read(params.Sim); err != nil {
+		return fmt.Errorf("SIM[%d] is not found: %s", params.Sim, err)
+	}
+
+	if _, err := api.AddSIMRoute(params.Id, params.Sim, params.Prefix); err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteAdd is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteAdd is failed: %s", err)
+	}
+	return nil
+}

--- a/command/funcs/mobile_gateway_sim_route_delete.go
+++ b/command/funcs/mobile_gateway_sim_route_delete.go
@@ -1,0 +1,52 @@
+package funcs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewaySimRouteDelete(ctx command.Context, params *params.SimRouteDeleteMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	_, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewaySimRouteDelete is failed: %s", e)
+	}
+
+	routes, err := api.GetSIMRoutes(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteDelete is failed: %s", err)
+	}
+
+	if len(routes) == 0 {
+		fmt.Fprintf(command.GlobalOption.Err, "MobileGateway[%d] don't have any SIM routes\n", params.Id)
+		return nil
+	}
+
+	// validate
+	if params.Index <= 0 || params.Index-1 >= len(routes) {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
+	}
+
+	simRoutes := &sacloud.MobileGatewaySIMRoutes{
+		SIMRoutes: routes,
+	}
+
+	if !simRoutes.DeleteSIMRouteAt(params.Index - 1) {
+		return errors.New("MobileGatewaySimRouteDelete is failed: DeleteSIMRouteAt is failed")
+	}
+	if _, err := api.SetSIMRoutes(params.Id, simRoutes); err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteDelete is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteDelete is failed: %s", err)
+	}
+
+	return nil
+}

--- a/command/funcs/mobile_gateway_sim_route_info.go
+++ b/command/funcs/mobile_gateway_sim_route_info.go
@@ -1,0 +1,37 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewaySimRouteInfo(ctx command.Context, params *params.SimRouteInfoMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	_, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewaySimRouteInfo is failed: %s", e)
+	}
+
+	routes, err := api.GetSIMRoutes(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteInfo is failed: %s", err)
+	}
+
+	if len(routes) == 0 {
+		fmt.Fprintf(command.GlobalOption.Err, "MobileGateway[%d] don't have any SIM routes\n", params.Id)
+		return nil
+	}
+
+	// build parameters to display table
+	list := []interface{}{}
+	for i := range routes {
+		list = append(list, &routes[i])
+	}
+
+	return ctx.GetOutput().Print(list...)
+
+}

--- a/command/funcs/mobile_gateway_sim_route_update.go
+++ b/command/funcs/mobile_gateway_sim_route_update.go
@@ -1,0 +1,56 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewaySimRouteUpdate(ctx command.Context, params *params.SimRouteUpdateMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	_, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewaySimRouteUpdate is failed: %s", e)
+	}
+
+	routes, err := api.GetSIMRoutes(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewaySimRouteUpdate is failed: %s", err)
+	}
+
+	if len(routes) == 0 {
+		fmt.Fprintf(command.GlobalOption.Err, "MobileGateway[%d] don't have any SIM routes\n", params.Id)
+		return nil
+	}
+
+	// validate
+	if params.Index <= 0 || params.Index-1 >= len(routes) {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
+	}
+
+	route := routes[params.Index-1]
+	if ctx.IsSet("prefix") {
+		route.Prefix = params.Prefix
+	}
+	if ctx.IsSet("sim") {
+		route.ResourceID = fmt.Sprintf("%d", params.Sim)
+	}
+
+	simRoutes := &sacloud.MobileGatewaySIMRoutes{
+		SIMRoutes: routes,
+	}
+
+	if _, err := api.SetSIMRoutes(params.Id, simRoutes); err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteUpdate is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteUpdate is failed: %s", err)
+	}
+
+	return nil
+}

--- a/command/funcs/mobile_gateway_static_route_add.go
+++ b/command/funcs/mobile_gateway_static_route_add.go
@@ -1,0 +1,34 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayStaticRouteAdd(ctx command.Context, params *params.StaticRouteAddMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteAdd is failed: %s", e)
+	}
+
+	if _, exists := p.Settings.MobileGateway.FindStaticRoute(params.Prefix, params.NextHop); exists != nil {
+		fmt.Fprintf(command.GlobalOption.Out, "StaticRoute[%s -> %s] already exists", params.Prefix, params.NextHop)
+		return nil
+	}
+
+	p.Settings.MobileGateway.AddStaticRoute(params.Prefix, params.NextHop)
+	_, err := api.UpdateSetting(params.Id, p)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteAdd is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteAdd is failed: %s", err)
+	}
+	return nil
+}

--- a/command/funcs/mobile_gateway_static_route_delete.go
+++ b/command/funcs/mobile_gateway_static_route_delete.go
@@ -1,0 +1,40 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayStaticRouteDelete(ctx command.Context, params *params.StaticRouteDeleteMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteDelete is failed: %s", e)
+	}
+
+	if !p.HasStaticRoutes() {
+		return fmt.Errorf("MobileGateway[%d] don't have any static-routes", params.Id)
+	}
+
+	// validate
+	if params.Index <= 0 || params.Index-1 >= len(p.Settings.MobileGateway.StaticRoutes) {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
+	}
+
+	p.Settings.MobileGateway.RemoveStaticRouteAt(params.Index - 1)
+
+	_, err := api.UpdateSetting(params.Id, p)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteDelete is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteDelete is failed: %s", err)
+	}
+
+	return nil
+}

--- a/command/funcs/mobile_gateway_static_route_info.go
+++ b/command/funcs/mobile_gateway_static_route_info.go
@@ -1,0 +1,33 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayStaticRouteInfo(ctx command.Context, params *params.StaticRouteInfoMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteInfo is failed: %s", e)
+	}
+
+	if !p.HasStaticRoutes() {
+		fmt.Fprintf(command.GlobalOption.Err, "MobileGateway[%d] don't have any static-routes\n", params.Id)
+		return nil
+	}
+
+	routes := p.Settings.MobileGateway.StaticRoutes
+	// build parameters to display table
+	list := []interface{}{}
+	for i := range routes {
+		list = append(list, &routes[i])
+	}
+
+	return ctx.GetOutput().Print(list...)
+
+}

--- a/command/funcs/mobile_gateway_static_route_update.go
+++ b/command/funcs/mobile_gateway_static_route_update.go
@@ -1,0 +1,47 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayStaticRouteUpdate(ctx command.Context, params *params.StaticRouteUpdateMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteUpdate is failed: %s", e)
+	}
+
+	if !p.HasStaticRoutes() {
+		return fmt.Errorf("MobileGateway[%d] don't have any static-routes", params.Id)
+	}
+
+	// validate
+	if params.Index <= 0 || params.Index-1 >= len(p.Settings.MobileGateway.StaticRoutes) {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
+	}
+
+	route := p.Settings.MobileGateway.StaticRoutes[params.Index-1]
+	if ctx.IsSet("prefix") {
+		route.Prefix = params.Prefix
+	}
+	if ctx.IsSet("next-hop") {
+		route.NextHop = params.NextHop
+	}
+
+	_, err := api.UpdateSetting(params.Id, p)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteUpdate is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayStaticRouteUpdate is failed: %s", err)
+	}
+
+	return nil
+
+}

--- a/command/params/params_mobile_gateway_gen.go
+++ b/command/params/params_mobile_gateway_gen.go
@@ -2588,10 +2588,204 @@ func (p *InterfaceDisconnectMobileGatewayParam) GetId() int64 {
 	return p.Id
 }
 
-// DnsUpdateMobileGatewayParam is input parameters for the sacloud API
-type DnsUpdateMobileGatewayParam struct {
-	Dns1              string   `json:"dns1"`
-	Dns2              string   `json:"dns2"`
+// StaticRouteInfoMobileGatewayParam is input parameters for the sacloud API
+type StaticRouteInfoMobileGatewayParam struct {
+	Selector          []string `json:"selector"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	Id                int64    `json:"id"`
+}
+
+// NewStaticRouteInfoMobileGatewayParam return new StaticRouteInfoMobileGatewayParam
+func NewStaticRouteInfoMobileGatewayParam() *StaticRouteInfoMobileGatewayParam {
+	return &StaticRouteInfoMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *StaticRouteInfoMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *StaticRouteInfoMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["static-route-info"]
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetColumn() []string {
+	return p.Column
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetFormat() string {
+	return p.Format
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetQuery() string {
+	return p.Query
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// StaticRouteAddMobileGatewayParam is input parameters for the sacloud API
+type StaticRouteAddMobileGatewayParam struct {
+	Prefix            string   `json:"prefix"`
+	NextHop           string   `json:"next-hop"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
 	ParamTemplate     string   `json:"param-template"`
@@ -2600,18 +2794,18 @@ type DnsUpdateMobileGatewayParam struct {
 	Id                int64    `json:"id"`
 }
 
-// NewDnsUpdateMobileGatewayParam return new DnsUpdateMobileGatewayParam
-func NewDnsUpdateMobileGatewayParam() *DnsUpdateMobileGatewayParam {
-	return &DnsUpdateMobileGatewayParam{}
+// NewStaticRouteAddMobileGatewayParam return new StaticRouteAddMobileGatewayParam
+func NewStaticRouteAddMobileGatewayParam() *StaticRouteAddMobileGatewayParam {
+	return &StaticRouteAddMobileGatewayParam{}
 }
 
 // FillValueToSkeleton fill values to empty fields
-func (p *DnsUpdateMobileGatewayParam) FillValueToSkeleton() {
-	if isEmpty(p.Dns1) {
-		p.Dns1 = ""
+func (p *StaticRouteAddMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Prefix) {
+		p.Prefix = ""
 	}
-	if isEmpty(p.Dns2) {
-		p.Dns2 = ""
+	if isEmpty(p.NextHop) {
+		p.NextHop = ""
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -2635,32 +2829,32 @@ func (p *DnsUpdateMobileGatewayParam) FillValueToSkeleton() {
 }
 
 // Validate checks current values in model
-func (p *DnsUpdateMobileGatewayParam) Validate() []error {
+func (p *StaticRouteAddMobileGatewayParam) Validate() []error {
 	errors := []error{}
 	{
 		validator := validateRequired
-		errs := validator("--dns1", p.Dns1)
+		errs := validator("--prefix", p.Prefix)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["MobileGateway"].Commands["dns-update"].Params["dns1"].ValidateFunc
-		errs := validator("--dns1", p.Dns1)
+		validator := define.Resources["MobileGateway"].Commands["static-route-add"].Params["prefix"].ValidateFunc
+		errs := validator("--prefix", p.Prefix)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
 		validator := validateRequired
-		errs := validator("--dns2", p.Dns2)
+		errs := validator("--next-hop", p.NextHop)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
 	}
 	{
-		validator := define.Resources["MobileGateway"].Commands["dns-update"].Params["dns2"].ValidateFunc
-		errs := validator("--dns2", p.Dns2)
+		validator := define.Resources["MobileGateway"].Commands["static-route-add"].Params["next-hop"].ValidateFunc
+		errs := validator("--next-hop", p.NextHop)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2676,84 +2870,394 @@ func (p *DnsUpdateMobileGatewayParam) Validate() []error {
 	return errors
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetResourceDef() *schema.Resource {
+func (p *StaticRouteAddMobileGatewayParam) GetResourceDef() *schema.Resource {
 	return define.Resources["MobileGateway"]
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetCommandDef() *schema.Command {
-	return p.GetResourceDef().Commands["dns-update"]
+func (p *StaticRouteAddMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["static-route-add"]
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetIncludeFields() []string {
+func (p *StaticRouteAddMobileGatewayParam) GetIncludeFields() []string {
 	return p.GetCommandDef().IncludeFields
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetExcludeFields() []string {
+func (p *StaticRouteAddMobileGatewayParam) GetExcludeFields() []string {
 	return p.GetCommandDef().ExcludeFields
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetTableType() output.TableType {
+func (p *StaticRouteAddMobileGatewayParam) GetTableType() output.TableType {
 	return p.GetCommandDef().TableType
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+func (p *StaticRouteAddMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
 	return p.GetCommandDef().TableColumnDefines
 }
 
-func (p *DnsUpdateMobileGatewayParam) SetDns1(v string) {
-	p.Dns1 = v
+func (p *StaticRouteAddMobileGatewayParam) SetPrefix(v string) {
+	p.Prefix = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetDns1() string {
-	return p.Dns1
+func (p *StaticRouteAddMobileGatewayParam) GetPrefix() string {
+	return p.Prefix
 }
-func (p *DnsUpdateMobileGatewayParam) SetDns2(v string) {
-	p.Dns2 = v
+func (p *StaticRouteAddMobileGatewayParam) SetNextHop(v string) {
+	p.NextHop = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetDns2() string {
-	return p.Dns2
+func (p *StaticRouteAddMobileGatewayParam) GetNextHop() string {
+	return p.NextHop
 }
-func (p *DnsUpdateMobileGatewayParam) SetSelector(v []string) {
+func (p *StaticRouteAddMobileGatewayParam) SetSelector(v []string) {
 	p.Selector = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetSelector() []string {
+func (p *StaticRouteAddMobileGatewayParam) GetSelector() []string {
 	return p.Selector
 }
-func (p *DnsUpdateMobileGatewayParam) SetAssumeyes(v bool) {
+func (p *StaticRouteAddMobileGatewayParam) SetAssumeyes(v bool) {
 	p.Assumeyes = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetAssumeyes() bool {
+func (p *StaticRouteAddMobileGatewayParam) GetAssumeyes() bool {
 	return p.Assumeyes
 }
-func (p *DnsUpdateMobileGatewayParam) SetParamTemplate(v string) {
+func (p *StaticRouteAddMobileGatewayParam) SetParamTemplate(v string) {
 	p.ParamTemplate = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetParamTemplate() string {
+func (p *StaticRouteAddMobileGatewayParam) GetParamTemplate() string {
 	return p.ParamTemplate
 }
-func (p *DnsUpdateMobileGatewayParam) SetParamTemplateFile(v string) {
+func (p *StaticRouteAddMobileGatewayParam) SetParamTemplateFile(v string) {
 	p.ParamTemplateFile = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetParamTemplateFile() string {
+func (p *StaticRouteAddMobileGatewayParam) GetParamTemplateFile() string {
 	return p.ParamTemplateFile
 }
-func (p *DnsUpdateMobileGatewayParam) SetGenerateSkeleton(v bool) {
+func (p *StaticRouteAddMobileGatewayParam) SetGenerateSkeleton(v bool) {
 	p.GenerateSkeleton = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetGenerateSkeleton() bool {
+func (p *StaticRouteAddMobileGatewayParam) GetGenerateSkeleton() bool {
 	return p.GenerateSkeleton
 }
-func (p *DnsUpdateMobileGatewayParam) SetId(v int64) {
+func (p *StaticRouteAddMobileGatewayParam) SetId(v int64) {
 	p.Id = v
 }
 
-func (p *DnsUpdateMobileGatewayParam) GetId() int64 {
+func (p *StaticRouteAddMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// StaticRouteUpdateMobileGatewayParam is input parameters for the sacloud API
+type StaticRouteUpdateMobileGatewayParam struct {
+	Index             int      `json:"index"`
+	Prefix            string   `json:"prefix"`
+	NextHop           string   `json:"next-hop"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewStaticRouteUpdateMobileGatewayParam return new StaticRouteUpdateMobileGatewayParam
+func NewStaticRouteUpdateMobileGatewayParam() *StaticRouteUpdateMobileGatewayParam {
+	return &StaticRouteUpdateMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *StaticRouteUpdateMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Index) {
+		p.Index = 0
+	}
+	if isEmpty(p.Prefix) {
+		p.Prefix = ""
+	}
+	if isEmpty(p.NextHop) {
+		p.NextHop = ""
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *StaticRouteUpdateMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--index", p.Index)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["static-route-update"].Params["prefix"].ValidateFunc
+		errs := validator("--prefix", p.Prefix)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["static-route-update"].Params["next-hop"].ValidateFunc
+		errs := validator("--next-hop", p.NextHop)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["static-route-update"]
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) SetIndex(v int) {
+	p.Index = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetIndex() int {
+	return p.Index
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetPrefix(v string) {
+	p.Prefix = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetPrefix() string {
+	return p.Prefix
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetNextHop(v string) {
+	p.NextHop = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetNextHop() string {
+	return p.NextHop
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *StaticRouteUpdateMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *StaticRouteUpdateMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// StaticRouteDeleteMobileGatewayParam is input parameters for the sacloud API
+type StaticRouteDeleteMobileGatewayParam struct {
+	Index             int      `json:"index"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewStaticRouteDeleteMobileGatewayParam return new StaticRouteDeleteMobileGatewayParam
+func NewStaticRouteDeleteMobileGatewayParam() *StaticRouteDeleteMobileGatewayParam {
+	return &StaticRouteDeleteMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *StaticRouteDeleteMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Index) {
+		p.Index = 0
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *StaticRouteDeleteMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--index", p.Index)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["static-route-delete"]
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) SetIndex(v int) {
+	p.Index = v
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetIndex() int {
+	return p.Index
+}
+func (p *StaticRouteDeleteMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *StaticRouteDeleteMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *StaticRouteDeleteMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *StaticRouteDeleteMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *StaticRouteDeleteMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *StaticRouteDeleteMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *StaticRouteDeleteMobileGatewayParam) GetId() int64 {
 	return p.Id
 }
 
@@ -3423,6 +3927,175 @@ func (p *SimDeleteMobileGatewayParam) SetId(v int64) {
 }
 
 func (p *SimDeleteMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// DnsUpdateMobileGatewayParam is input parameters for the sacloud API
+type DnsUpdateMobileGatewayParam struct {
+	Dns1              string   `json:"dns1"`
+	Dns2              string   `json:"dns2"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewDnsUpdateMobileGatewayParam return new DnsUpdateMobileGatewayParam
+func NewDnsUpdateMobileGatewayParam() *DnsUpdateMobileGatewayParam {
+	return &DnsUpdateMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *DnsUpdateMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Dns1) {
+		p.Dns1 = ""
+	}
+	if isEmpty(p.Dns2) {
+		p.Dns2 = ""
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *DnsUpdateMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--dns1", p.Dns1)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["dns-update"].Params["dns1"].ValidateFunc
+		errs := validator("--dns1", p.Dns1)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateRequired
+		errs := validator("--dns2", p.Dns2)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["dns-update"].Params["dns2"].ValidateFunc
+		errs := validator("--dns2", p.Dns2)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["dns-update"]
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *DnsUpdateMobileGatewayParam) SetDns1(v string) {
+	p.Dns1 = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetDns1() string {
+	return p.Dns1
+}
+func (p *DnsUpdateMobileGatewayParam) SetDns2(v string) {
+	p.Dns2 = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetDns2() string {
+	return p.Dns2
+}
+func (p *DnsUpdateMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *DnsUpdateMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *DnsUpdateMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DnsUpdateMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *DnsUpdateMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *DnsUpdateMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *DnsUpdateMobileGatewayParam) GetId() int64 {
 	return p.Id
 }
 

--- a/command/params/params_mobile_gateway_gen.go
+++ b/command/params/params_mobile_gateway_gen.go
@@ -3930,6 +3930,679 @@ func (p *SimDeleteMobileGatewayParam) GetId() int64 {
 	return p.Id
 }
 
+// SimRouteInfoMobileGatewayParam is input parameters for the sacloud API
+type SimRouteInfoMobileGatewayParam struct {
+	Selector          []string `json:"selector"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	Id                int64    `json:"id"`
+}
+
+// NewSimRouteInfoMobileGatewayParam return new SimRouteInfoMobileGatewayParam
+func NewSimRouteInfoMobileGatewayParam() *SimRouteInfoMobileGatewayParam {
+	return &SimRouteInfoMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *SimRouteInfoMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *SimRouteInfoMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["sim-route-info"]
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *SimRouteInfoMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *SimRouteInfoMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SimRouteInfoMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *SimRouteInfoMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *SimRouteInfoMobileGatewayParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *SimRouteInfoMobileGatewayParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetColumn() []string {
+	return p.Column
+}
+func (p *SimRouteInfoMobileGatewayParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *SimRouteInfoMobileGatewayParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetFormat() string {
+	return p.Format
+}
+func (p *SimRouteInfoMobileGatewayParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *SimRouteInfoMobileGatewayParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetQuery() string {
+	return p.Query
+}
+func (p *SimRouteInfoMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// SimRouteAddMobileGatewayParam is input parameters for the sacloud API
+type SimRouteAddMobileGatewayParam struct {
+	Prefix            string   `json:"prefix"`
+	Sim               int64    `json:"sim"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewSimRouteAddMobileGatewayParam return new SimRouteAddMobileGatewayParam
+func NewSimRouteAddMobileGatewayParam() *SimRouteAddMobileGatewayParam {
+	return &SimRouteAddMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *SimRouteAddMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Prefix) {
+		p.Prefix = ""
+	}
+	if isEmpty(p.Sim) {
+		p.Sim = 0
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *SimRouteAddMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--prefix", p.Prefix)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["sim-route-add"].Params["prefix"].ValidateFunc
+		errs := validator("--prefix", p.Prefix)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateRequired
+		errs := validator("--sim", p.Sim)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["sim-route-add"].Params["sim"].ValidateFunc
+		errs := validator("--sim", p.Sim)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["sim-route-add"]
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *SimRouteAddMobileGatewayParam) SetPrefix(v string) {
+	p.Prefix = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetPrefix() string {
+	return p.Prefix
+}
+func (p *SimRouteAddMobileGatewayParam) SetSim(v int64) {
+	p.Sim = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetSim() int64 {
+	return p.Sim
+}
+func (p *SimRouteAddMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *SimRouteAddMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *SimRouteAddMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SimRouteAddMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *SimRouteAddMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *SimRouteAddMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *SimRouteAddMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// SimRouteUpdateMobileGatewayParam is input parameters for the sacloud API
+type SimRouteUpdateMobileGatewayParam struct {
+	Index             int      `json:"index"`
+	Prefix            string   `json:"prefix"`
+	Sim               int64    `json:"sim"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewSimRouteUpdateMobileGatewayParam return new SimRouteUpdateMobileGatewayParam
+func NewSimRouteUpdateMobileGatewayParam() *SimRouteUpdateMobileGatewayParam {
+	return &SimRouteUpdateMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *SimRouteUpdateMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Index) {
+		p.Index = 0
+	}
+	if isEmpty(p.Prefix) {
+		p.Prefix = ""
+	}
+	if isEmpty(p.Sim) {
+		p.Sim = 0
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *SimRouteUpdateMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--index", p.Index)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["sim-route-update"].Params["prefix"].ValidateFunc
+		errs := validator("--prefix", p.Prefix)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["sim-route-update"].Params["sim"].ValidateFunc
+		errs := validator("--sim", p.Sim)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["sim-route-update"]
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) SetIndex(v int) {
+	p.Index = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetIndex() int {
+	return p.Index
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetPrefix(v string) {
+	p.Prefix = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetPrefix() string {
+	return p.Prefix
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetSim(v int64) {
+	p.Sim = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetSim() int64 {
+	return p.Sim
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *SimRouteUpdateMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *SimRouteUpdateMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// SimRouteDeleteMobileGatewayParam is input parameters for the sacloud API
+type SimRouteDeleteMobileGatewayParam struct {
+	Index             int      `json:"index"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewSimRouteDeleteMobileGatewayParam return new SimRouteDeleteMobileGatewayParam
+func NewSimRouteDeleteMobileGatewayParam() *SimRouteDeleteMobileGatewayParam {
+	return &SimRouteDeleteMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *SimRouteDeleteMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Index) {
+		p.Index = 0
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *SimRouteDeleteMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--index", p.Index)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["sim-route-delete"]
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) SetIndex(v int) {
+	p.Index = v
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetIndex() int {
+	return p.Index
+}
+func (p *SimRouteDeleteMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *SimRouteDeleteMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *SimRouteDeleteMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *SimRouteDeleteMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *SimRouteDeleteMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *SimRouteDeleteMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *SimRouteDeleteMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
 // DnsUpdateMobileGatewayParam is input parameters for the sacloud API
 type DnsUpdateMobileGatewayParam struct {
 	Dns1              string   `json:"dns1"`

--- a/define/mobile_gateway.go
+++ b/define/mobile_gateway.go
@@ -228,6 +228,45 @@ func MobileGatewayResource() *schema.Resource {
 			Order:            40,
 			NoOutput:         true,
 		},
+		"sim-route-info": {
+			Type:               schema.CommandManipulateSingle,
+			Params:             mobileGatewaySIMRouteInfoParam(),
+			Aliases:            []string{"sim-route-list"},
+			Usage:              "Show information of sim-routes",
+			TableType:          output.TableSimple,
+			TableColumnDefines: mobileGatewaySIMRouteListColumns(),
+			UseCustomCommand:   true,
+			Category:           "sim-route",
+			Order:              10,
+			NeedlessConfirm:    true,
+		},
+		"sim-route-add": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           mobileGatewaySIMRouteAddParam(),
+			Usage:            "Add sim-route",
+			UseCustomCommand: true,
+			Category:         "sim-route",
+			Order:            20,
+			NoOutput:         true,
+		},
+		"sim-route-update": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           mobileGatewaySIMRouteUpdateParam(),
+			Usage:            "Update sim-route",
+			UseCustomCommand: true,
+			Category:         "sim-route",
+			Order:            30,
+			NoOutput:         true,
+		},
+		"sim-route-delete": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           mobileGatewaySIMRouteDeleteParam(),
+			Usage:            "Delete sim-route",
+			UseCustomCommand: true,
+			Category:         "sim-route",
+			Order:            40,
+			NoOutput:         true,
+		},
 		"dns-update": {
 			Type:             schema.CommandManipulateSingle,
 			Params:           mobileGatewayDNSUpdateParam(),
@@ -279,6 +318,11 @@ var MobileGatewayCommandCategories = []schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
 		Order:       50,
+	},
+	{
+		Key:         "sim-route",
+		DisplayName: "SIM Route Management",
+		Order:       55,
 	},
 	{
 		Key:         "dns",
@@ -352,6 +396,24 @@ func mobileGatewayStaticRouteListColumns() []output.ColumnDef {
 		{Name: "__ORDER__"}, // magic column name(generated on demand)
 		{Name: "Prefix"},
 		{Name: "NextHop"},
+	}
+}
+
+func mobileGatewaySIMRouteListColumns() []output.ColumnDef {
+	return []output.ColumnDef{
+		{Name: "__ORDER__"}, // magic column name(generated on demand)
+		{
+			Name:    "Prefix",
+			Sources: []string{"prefix"},
+		},
+		{
+			Name:    "SIM ID",
+			Sources: []string{"resource_id"},
+		},
+		{
+			Name:    "ICCID",
+			Sources: []string{"iccid"},
+		},
 	}
 }
 
@@ -745,6 +807,75 @@ func mobileGatewaySIMDeleteParam() map[string]*schema.Schema {
 			Required:     true,
 			Category:     "interface",
 			Order:        10,
+		},
+	}
+}
+
+func mobileGatewaySIMRouteInfoParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func mobileGatewaySIMRouteAddParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"prefix": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set prefix",
+			Required:     true,
+			ValidateFunc: validateIPv4AddressWithPrefix(),
+			Category:     "SIM-Route",
+			Order:        10,
+		},
+		"sim": {
+			Type:         schema.TypeInt64,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set sim",
+			Required:     true,
+			ValidateFunc: validateSakuraID(),
+			Category:     "SIM-Route",
+			Order:        20,
+		},
+	}
+}
+
+func mobileGatewaySIMRouteUpdateParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target sim-route",
+			Required:    true,
+			Category:    "SIM-Route",
+			Order:       1,
+		},
+		"prefix": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set prefix",
+			ValidateFunc: validateIPv4AddressWithPrefix(),
+			Category:     "SIM-Route",
+			Order:        10,
+		},
+		"sim": {
+			Type:         schema.TypeInt64,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set sim",
+			ValidateFunc: validateSakuraID(),
+			Category:     "SIM-Route",
+			Order:        20,
+		},
+	}
+}
+
+func mobileGatewaySIMRouteDeleteParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target sim-route",
+			Required:    true,
+			Category:    "SIM-Route",
+			Order:       1,
 		},
 	}
 }

--- a/define/mobile_gateway.go
+++ b/define/mobile_gateway.go
@@ -150,6 +150,45 @@ func MobileGatewayResource() *schema.Resource {
 			Order:            40,
 			NoOutput:         true,
 		},
+		"static-route-info": {
+			Type:               schema.CommandManipulateSingle,
+			Params:             mobileGatewayStaticRouteInfoParam(),
+			Aliases:            []string{"static-route-list"},
+			Usage:              "Show information of static-routes",
+			TableType:          output.TableSimple,
+			TableColumnDefines: mobileGatewayStaticRouteListColumns(),
+			UseCustomCommand:   true,
+			Category:           "static-route",
+			Order:              10,
+			NeedlessConfirm:    true,
+		},
+		"static-route-add": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           mobileGatewayStaticRouteAddParam(),
+			Usage:            "Add static-route",
+			UseCustomCommand: true,
+			Category:         "static-route",
+			Order:            20,
+			NoOutput:         true,
+		},
+		"static-route-update": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           mobileGatewayStaticRouteUpdateParam(),
+			Usage:            "Update static-route",
+			UseCustomCommand: true,
+			Category:         "static-route",
+			Order:            30,
+			NoOutput:         true,
+		},
+		"static-route-delete": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           mobileGatewayStaticRouteDeleteParam(),
+			Usage:            "Delete static-route",
+			UseCustomCommand: true,
+			Category:         "static-route",
+			Order:            40,
+			NoOutput:         true,
+		},
 		"sim-info": {
 			Type:               schema.CommandManipulateSingle,
 			Params:             mobileGatewaySIMInfoParam(),
@@ -232,19 +271,24 @@ var MobileGatewayCommandCategories = []schema.Category{
 		Order:       30,
 	},
 	{
+		Key:         "static-route",
+		DisplayName: "StaticRoute Management",
+		Order:       40,
+	},
+	{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       40,
+		Order:       50,
 	},
 	{
 		Key:         "dns",
 		DisplayName: "DNS Management",
-		Order:       40,
+		Order:       60,
 	},
 	{
 		Key:         "monitor",
 		DisplayName: "Monitoring",
-		Order:       50,
+		Order:       70,
 	},
 	{
 		Key:         "other",
@@ -300,6 +344,14 @@ func mobileGatewayInterfaceListColumns() []output.ColumnDef {
 		{Name: "Switch"},
 		{Name: "IPAddress"},
 		{Name: "NetworkMaskLen"},
+	}
+}
+
+func mobileGatewayStaticRouteListColumns() []output.ColumnDef {
+	return []output.ColumnDef{
+		{Name: "__ORDER__"}, // magic column name(generated on demand)
+		{Name: "Prefix"},
+		{Name: "NextHop"},
 	}
 }
 
@@ -559,6 +611,75 @@ func mobileGatewayLogsParam() map[string]*schema.Schema {
 			Description:  "log refresh interval second",
 			Category:     "monitor",
 			Order:        20,
+		},
+	}
+}
+
+func mobileGatewayStaticRouteInfoParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func mobileGatewayStaticRouteAddParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"prefix": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set prefix",
+			Required:     true,
+			ValidateFunc: validateIPv4AddressWithPrefix(),
+			Category:     "Static-Route",
+			Order:        10,
+		},
+		"next-hop": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set next-hop",
+			Required:     true,
+			ValidateFunc: validateIPv4Address(),
+			Category:     "Static-Route",
+			Order:        20,
+		},
+	}
+}
+
+func mobileGatewayStaticRouteUpdateParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target static-route",
+			Required:    true,
+			Category:    "Static-Route",
+			Order:       1,
+		},
+		"prefix": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set prefix",
+			ValidateFunc: validateIPv4AddressWithPrefix(),
+			Category:     "Static-Route",
+			Order:        10,
+		},
+		"next-hop": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set next-hop",
+			ValidateFunc: validateIPv4Address(),
+			Category:     "Static-Route",
+			Order:        20,
+		},
+	}
+}
+
+func mobileGatewayStaticRouteDeleteParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target static-route",
+			Required:    true,
+			Category:    "Static-Route",
+			Order:       1,
 		},
 	}
 }

--- a/vendor/github.com/sacloud/libsacloud/api/sim.go
+++ b/vendor/github.com/sacloud/libsacloud/api/sim.go
@@ -18,6 +18,7 @@ type SearchSIMResponse struct {
 	// CommonServiceSIMItems SIMリスト
 	CommonServiceSIMItems []sacloud.SIM `json:"CommonServiceItems,omitempty"`
 }
+
 type simRequest struct {
 	CommonServiceSIMItem *sacloud.SIM           `json:"CommonServiceItem,omitempty"`
 	From                 int                    `json:",omitempty"`
@@ -27,6 +28,7 @@ type simRequest struct {
 	Exclude              []string               `json:",omitempty"`
 	Include              []string               `json:",omitempty"`
 }
+
 type simResponse struct {
 	*sacloud.ResultFlagValue
 	*sacloud.SIM `json:"CommonServiceItem,omitempty"`


### PR DESCRIPTION
- スタティックルートの一覧/作成/更新/削除
- SIMルートの一覧/作成/更新/削除

```bash
$ usacloud mobile-gateway -h 
NAME:
   usacloud mobile-gateway - A manage commands of MobileGateway

USAGE:
   usacloud mobile-gateway command [command options] [arguments...]

COMMANDS:
...

 === StaticRoute Management ===
   static-route-info, static-route-list  Show information of static-routes
   static-route-add                      Add static-route
   static-route-update                   Update static-route
   static-route-delete                   Delete static-route

...

 === SIM Route Management ===
   sim-route-info, sim-route-list  Show information of sim-routes
   sim-route-add                   Add sim-route
   sim-route-update                Update sim-route
   sim-route-delete                Delete sim-route

...
```