### PR TITLE
VPCルータでのインターネット接続 有効/無効 設定

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,7 @@
     "sacloud/ostype",
     "utils/server"
   ]
-  revision = "2fd1b17a85c8ed7bf58ecdc103368a0c0cb3e631"
+  revision = "30b4283b6fd10fea46802704cc0a3f33f30cdb39"
 
 [[projects]]
   branch = "master"
@@ -160,7 +160,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "7138fd3d9dc8335c567ca206f4333fb75eb05d56"
+  revision = "151529c776cdc58ddbe7963ba9af779f3577b419"
 
 [[projects]]
   name = "gopkg.in/urfave/cli.v2"

--- a/command/cli/cli_vpc_router_gen.go
+++ b/command/cli/cli_vpc_router_gen.go
@@ -29,6 +29,8 @@ func init() {
 	resetParam := params.NewResetVPCRouterParam()
 	waitForBootParam := params.NewWaitForBootVPCRouterParam()
 	waitForDownParam := params.NewWaitForDownVPCRouterParam()
+	enableInternetConnectionParam := params.NewEnableInternetConnectionVPCRouterParam()
+	disableInternetConnectionParam := params.NewDisableInternetConnectionVPCRouterParam()
 	interfaceInfoParam := params.NewInterfaceInfoVPCRouterParam()
 	interfaceConnectParam := params.NewInterfaceConnectVPCRouterParam()
 	interfaceUpdateParam := params.NewInterfaceUpdateVPCRouterParam()
@@ -434,6 +436,11 @@ func init() {
 						Usage:   "set ipaddress(#2)",
 					},
 					&cli.BoolFlag{
+						Name:  "disable-internet-connection",
+						Usage: "disable internet connection from VPCRouter",
+						Value: false,
+					},
+					&cli.BoolFlag{
 						Name:  "boot-after-create",
 						Usage: "boot after create",
 					},
@@ -555,6 +562,9 @@ func init() {
 					}
 					if c.IsSet("ipaddress2") {
 						createParam.Ipaddress2 = c.String("ipaddress2")
+					}
+					if c.IsSet("disable-internet-connection") {
+						createParam.DisableInternetConnection = c.Bool("disable-internet-connection")
 					}
 					if c.IsSet("boot-after-create") {
 						createParam.BootAfterCreate = c.Bool("boot-after-create")
@@ -703,6 +713,9 @@ func init() {
 					}
 					if c.IsSet("ipaddress2") {
 						createParam.Ipaddress2 = c.String("ipaddress2")
+					}
+					if c.IsSet("disable-internet-connection") {
+						createParam.DisableInternetConnection = c.Bool("disable-internet-connection")
 					}
 					if c.IsSet("boot-after-create") {
 						createParam.BootAfterCreate = c.Bool("boot-after-create")
@@ -1165,6 +1178,10 @@ func init() {
 						Name:  "syslog-host",
 						Usage: "set syslog host IPAddress",
 					},
+					&cli.BoolFlag{
+						Name:  "internet-connection",
+						Usage: "set internet connection from VPCRouter",
+					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
 						Usage: "Set target filter by tag",
@@ -1277,6 +1294,9 @@ func init() {
 					// Set option values
 					if c.IsSet("syslog-host") {
 						updateParam.SyslogHost = c.String("syslog-host")
+					}
+					if c.IsSet("internet-connection") {
+						updateParam.InternetConnection = c.Bool("internet-connection")
 					}
 					if c.IsSet("selector") {
 						updateParam.Selector = c.StringSlice("selector")
@@ -1413,6 +1433,9 @@ func init() {
 					// Set option values
 					if c.IsSet("syslog-host") {
 						updateParam.SyslogHost = c.String("syslog-host")
+					}
+					if c.IsSet("internet-connection") {
+						updateParam.InternetConnection = c.Bool("internet-connection")
 					}
 					if c.IsSet("selector") {
 						updateParam.Selector = c.StringSlice("selector")
@@ -3793,6 +3816,638 @@ func init() {
 						waitForDownParam := &p
 						go func() {
 							err := funcs.VPCRouterWaitForDown(ctx, waitForDownParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "enable-internet-connection",
+				Usage:     "Enable internet connection from VPCRouter",
+				ArgsUsage: "<ID or Name(only single target)>",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = enableInternetConnectionParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, enableInternetConnectionParam)
+
+					// Set option values
+					if c.IsSet("selector") {
+						enableInternetConnectionParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						enableInternetConnectionParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						enableInternetConnectionParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						enableInternetConnectionParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						enableInternetConnectionParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						enableInternetConnectionParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.VPCRouterEnableInternetConnectionCompleteArgs(ctx, enableInternetConnectionParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.VPCRouterEnableInternetConnectionCompleteArgs(ctx, enableInternetConnectionParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.VPCRouterEnableInternetConnectionCompleteFlags(ctx, enableInternetConnectionParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.VPCRouterEnableInternetConnectionCompleteArgs(ctx, enableInternetConnectionParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					enableInternetConnectionParam.ParamTemplate = c.String("param-template")
+					enableInternetConnectionParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(enableInternetConnectionParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewEnableInternetConnectionVPCRouterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(enableInternetConnectionParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("selector") {
+						enableInternetConnectionParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						enableInternetConnectionParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						enableInternetConnectionParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						enableInternetConnectionParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						enableInternetConnectionParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						enableInternetConnectionParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = enableInternetConnectionParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if enableInternetConnectionParam.GenerateSkeleton {
+						enableInternetConnectionParam.GenerateSkeleton = false
+						enableInternetConnectionParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(enableInternetConnectionParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := enableInternetConnectionParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), enableInternetConnectionParam)
+
+					apiClient := ctx.GetAPIClient().VPCRouter
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(enableInternetConnectionParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.VPCRouters {
+							if hasTags(&v, enableInternetConnectionParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", enableInternetConnectionParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.VPCRouters {
+										if len(enableInternetConnectionParam.Selector) == 0 || hasTags(&v, enableInternetConnectionParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					if len(ids) != 1 {
+						return fmt.Errorf("Can't run with multiple targets: %v", ids)
+					}
+
+					// confirm
+					if !enableInternetConnectionParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("enable-internet-connection", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						enableInternetConnectionParam.SetId(id)
+						p := *enableInternetConnectionParam // copy struct value
+						enableInternetConnectionParam := &p
+						go func() {
+							err := funcs.VPCRouterEnableInternetConnection(ctx, enableInternetConnectionParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "disable-internet-connection",
+				Usage:     "Enable internet connection from VPCRouter",
+				ArgsUsage: "<ID or Name(only single target)>",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = disableInternetConnectionParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, disableInternetConnectionParam)
+
+					// Set option values
+					if c.IsSet("selector") {
+						disableInternetConnectionParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						disableInternetConnectionParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						disableInternetConnectionParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						disableInternetConnectionParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						disableInternetConnectionParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						disableInternetConnectionParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.VPCRouterDisableInternetConnectionCompleteArgs(ctx, disableInternetConnectionParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.VPCRouterDisableInternetConnectionCompleteArgs(ctx, disableInternetConnectionParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.VPCRouterDisableInternetConnectionCompleteFlags(ctx, disableInternetConnectionParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.VPCRouterDisableInternetConnectionCompleteArgs(ctx, disableInternetConnectionParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					disableInternetConnectionParam.ParamTemplate = c.String("param-template")
+					disableInternetConnectionParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(disableInternetConnectionParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewDisableInternetConnectionVPCRouterParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(disableInternetConnectionParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("selector") {
+						disableInternetConnectionParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						disableInternetConnectionParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						disableInternetConnectionParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						disableInternetConnectionParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						disableInternetConnectionParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						disableInternetConnectionParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = disableInternetConnectionParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if disableInternetConnectionParam.GenerateSkeleton {
+						disableInternetConnectionParam.GenerateSkeleton = false
+						disableInternetConnectionParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(disableInternetConnectionParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := disableInternetConnectionParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), disableInternetConnectionParam)
+
+					apiClient := ctx.GetAPIClient().VPCRouter
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(disableInternetConnectionParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.VPCRouters {
+							if hasTags(&v, disableInternetConnectionParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", disableInternetConnectionParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.VPCRouters {
+										if len(disableInternetConnectionParam.Selector) == 0 || hasTags(&v, disableInternetConnectionParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					if len(ids) != 1 {
+						return fmt.Errorf("Can't run with multiple targets: %v", ids)
+					}
+
+					// confirm
+					if !disableInternetConnectionParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("disable-internet-connection", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						disableInternetConnectionParam.SetId(id)
+						p := *disableInternetConnectionParam // copy struct value
+						disableInternetConnectionParam := &p
+						go func() {
+							err := funcs.VPCRouterDisableInternetConnection(ctx, disableInternetConnectionParam)
 							if err != nil {
 								errs = append(errs, err)
 							}
@@ -18871,6 +19526,16 @@ func init() {
 		DisplayName: "DHCP Static Map Setting Management",
 		Order:       65,
 	})
+	AppendCommandCategoryMap("vpc-router", "disable-internet-connection", &schema.Category{
+		Key:         "nic",
+		DisplayName: "Network Interface Management",
+		Order:       30,
+	})
+	AppendCommandCategoryMap("vpc-router", "enable-internet-connection", &schema.Category{
+		Key:         "nic",
+		DisplayName: "Network Interface Management",
+		Order:       30,
+	})
 	AppendCommandCategoryMap("vpc-router", "firewall-add", &schema.Category{
 		Key:         "fw",
 		DisplayName: "Firewall Setting Management",
@@ -19133,6 +19798,11 @@ func init() {
 		Key:         "common",
 		DisplayName: "Common options",
 		Order:       2147483617,
+	})
+	AppendFlagCategoryMap("vpc-router", "create", "disable-internet-connection", &schema.Category{
+		Key:         "network",
+		DisplayName: "Network options",
+		Order:       20,
 	})
 	AppendFlagCategoryMap("vpc-router", "create", "format", &schema.Category{
 		Key:         "output",
@@ -19645,6 +20315,66 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "dhcp-static-mapping-update", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("vpc-router", "disable-internet-connection", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "disable-internet-connection", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "disable-internet-connection", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("vpc-router", "disable-internet-connection", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "disable-internet-connection", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "disable-internet-connection", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("vpc-router", "enable-internet-connection", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "enable-internet-connection", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "enable-internet-connection", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("vpc-router", "enable-internet-connection", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "enable-internet-connection", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("vpc-router", "enable-internet-connection", "selector", &schema.Category{
 		Key:         "filter",
 		DisplayName: "Filter options",
 		Order:       2147483587,
@@ -21508,6 +22238,11 @@ func init() {
 		Key:         "default",
 		DisplayName: "Other options",
 		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("vpc-router", "update", "internet-connection", &schema.Category{
+		Key:         "router",
+		DisplayName: "VPCRouter options",
+		Order:       10,
 	})
 	AppendFlagCategoryMap("vpc-router", "update", "name", &schema.Category{
 		Key:         "common",

--- a/command/completion/vpc_router_args_gen.go
+++ b/command/completion/vpc_router_args_gen.go
@@ -296,6 +296,68 @@ func VPCRouterWaitForDownCompleteArgs(ctx command.Context, params *params.WaitFo
 
 }
 
+func VPCRouterEnableInternetConnectionCompleteArgs(ctx command.Context, params *params.EnableInternetConnectionVPCRouterParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetVPCRouterAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.VPCRouters {
+		fmt.Println(res.VPCRouters[i].ID)
+		var target interface{} = &res.VPCRouters[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func VPCRouterDisableInternetConnectionCompleteArgs(ctx command.Context, params *params.DisableInternetConnectionVPCRouterParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetVPCRouterAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.VPCRouters {
+		fmt.Println(res.VPCRouters[i].ID)
+		var target interface{} = &res.VPCRouters[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
 func VPCRouterInterfaceInfoCompleteArgs(ctx command.Context, params *params.InterfaceInfoVPCRouterParam, cur, prev, commandName string) {
 
 	if !command.GlobalOption.Valid {

--- a/command/completion/vpc_router_flags_gen.go
+++ b/command/completion/vpc_router_flags_gen.go
@@ -91,6 +91,11 @@ func VPCRouterCreateCompleteFlags(ctx command.Context, params *params.CreateVPCR
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
+	case "disable-internet-connection":
+		param := define.Resources["VPCRouter"].Commands["create"].BuildedParams().Get("disable-internet-connection")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "boot-after-create":
 		param := define.Resources["VPCRouter"].Commands["create"].BuildedParams().Get("boot-after-create")
 		if param != nil {
@@ -160,6 +165,11 @@ func VPCRouterUpdateCompleteFlags(ctx command.Context, params *params.UpdateVPCR
 	switch flagName {
 	case "syslog-host":
 		param := define.Resources["VPCRouter"].Commands["update"].BuildedParams().Get("syslog-host")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "internet-connection":
+		param := define.Resources["VPCRouter"].Commands["update"].BuildedParams().Get("internet-connection")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
@@ -367,6 +377,54 @@ func VPCRouterWaitForDownCompleteFlags(ctx command.Context, params *params.WaitF
 		}
 	case "id":
 		param := define.Resources["VPCRouter"].Commands["wait-for-down"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func VPCRouterEnableInternetConnectionCompleteFlags(ctx command.Context, params *params.EnableInternetConnectionVPCRouterParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "selector":
+		param := define.Resources["VPCRouter"].Commands["enable-internet-connection"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["VPCRouter"].Commands["enable-internet-connection"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func VPCRouterDisableInternetConnectionCompleteFlags(ctx command.Context, params *params.DisableInternetConnectionVPCRouterParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "selector":
+		param := define.Resources["VPCRouter"].Commands["disable-internet-connection"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["VPCRouter"].Commands["disable-internet-connection"].BuildedParams().Get("id")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}

--- a/command/funcs/vpc_router_create.go
+++ b/command/funcs/vpc_router_create.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"fmt"
 
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/internal"
 	"github.com/sacloud/usacloud/command/params"
@@ -53,6 +54,14 @@ func VPCRouterCreate(ctx command.Context, params *params.CreateVPCRouterParam) e
 	p.SetDescription(params.Description)
 	p.SetTags(params.Tags)
 	p.SetIconByID(params.IconId)
+
+	p.InitVPCRouterSetting()
+	p.Settings.Router.InternetConnection = &sacloud.VPCRouterInternetConnection{
+		Enabled: "True",
+	}
+	if params.DisableInternetConnection {
+		p.Settings.Router.InternetConnection.Enabled = "False"
+	}
 
 	// call Create(id)
 	res, err := api.Create(p)

--- a/command/funcs/vpc_router_disable_internet_connection.go
+++ b/command/funcs/vpc_router_disable_internet_connection.go
@@ -1,0 +1,41 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func VPCRouterDisableInternetConnection(ctx command.Context, params *params.DisableInternetConnectionVPCRouterParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetVPCRouterAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("VPCRouterDisableInternetConnection is failed: %s", e)
+	}
+
+	if !p.HasSetting() {
+		p.InitVPCRouterSetting()
+	}
+
+	if p.Settings.Router.InternetConnection == nil {
+		p.Settings.Router.InternetConnection = &sacloud.VPCRouterInternetConnection{
+			Enabled: "False",
+		}
+	}
+	p.Settings.Router.InternetConnection.Enabled = "False"
+
+	_, err := api.UpdateSetting(params.Id, p)
+	if err != nil {
+		return fmt.Errorf("VPCRouterDisableInternetConnection is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("VPCRouterDisableInternetConnection is failed: %s", err)
+	}
+	return nil
+
+}

--- a/command/funcs/vpc_router_enable_internet_connection.go
+++ b/command/funcs/vpc_router_enable_internet_connection.go
@@ -1,0 +1,41 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func VPCRouterEnableInternetConnection(ctx command.Context, params *params.EnableInternetConnectionVPCRouterParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetVPCRouterAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("VPCRouterEnableInternetConnection is failed: %s", e)
+	}
+
+	if !p.HasSetting() {
+		p.InitVPCRouterSetting()
+	}
+
+	if p.Settings.Router.InternetConnection == nil {
+		p.Settings.Router.InternetConnection = &sacloud.VPCRouterInternetConnection{
+			Enabled: "True",
+		}
+	}
+	p.Settings.Router.InternetConnection.Enabled = "True"
+
+	_, err := api.UpdateSetting(params.Id, p)
+	if err != nil {
+		return fmt.Errorf("VPCRouterEnableInternetConnection is failed: %s", err)
+	}
+	_, err = api.Config(params.Id)
+	if err != nil {
+		return fmt.Errorf("VPCRouterEnableInternetConnection is failed: %s", err)
+	}
+	return nil
+
+}

--- a/command/funcs/vpc_router_update.go
+++ b/command/funcs/vpc_router_update.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"fmt"
 
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
 )
@@ -33,13 +34,23 @@ func VPCRouterUpdate(ctx command.Context, params *params.UpdateVPCRouterParam) e
 	if ctx.IsSet("syslog-host") {
 		p.Settings.Router.SyslogHost = params.SyslogHost
 	}
+	if ctx.IsSet("internet-connection") {
+		p.Settings.Router.InternetConnection = &sacloud.VPCRouterInternetConnection{
+			Enabled: "False",
+		}
+		if params.InternetConnection {
+			p.Settings.Router.InternetConnection.Enabled = "True"
+		}
+	}
 
 	// call Update(id)
 	res, err := api.Update(params.Id, p)
 	if err != nil {
 		return fmt.Errorf("VPCRouterUpdate is failed: %s", err)
 	}
+	if _, err := api.Config(params.Id); err != nil {
+		return fmt.Errorf("VPCRouterUpdate is failed: %s", err)
+	}
 
 	return ctx.GetOutput().Print(res)
-
 }

--- a/command/params/params_vpc_router_gen.go
+++ b/command/params/params_vpc_router_gen.go
@@ -273,27 +273,28 @@ func (p *ListVPCRouterParam) GetQuery() string {
 
 // CreateVPCRouterParam is input parameters for the sacloud API
 type CreateVPCRouterParam struct {
-	Plan              string   `json:"plan"`
-	SwitchId          int64    `json:"switch-id"`
-	Vrid              int      `json:"vrid"`
-	Vip               string   `json:"vip"`
-	Ipaddress1        string   `json:"ipaddress1"`
-	Ipaddress2        string   `json:"ipaddress2"`
-	BootAfterCreate   bool     `json:"boot-after-create"`
-	Name              string   `json:"name"`
-	Description       string   `json:"description"`
-	Tags              []string `json:"tags"`
-	IconId            int64    `json:"icon-id"`
-	Assumeyes         bool     `json:"assumeyes"`
-	ParamTemplate     string   `json:"param-template"`
-	ParamTemplateFile string   `json:"param-template-file"`
-	GenerateSkeleton  bool     `json:"generate-skeleton"`
-	OutputType        string   `json:"output-type"`
-	Column            []string `json:"column"`
-	Quiet             bool     `json:"quiet"`
-	Format            string   `json:"format"`
-	FormatFile        string   `json:"format-file"`
-	Query             string   `json:"query"`
+	Plan                      string   `json:"plan"`
+	SwitchId                  int64    `json:"switch-id"`
+	Vrid                      int      `json:"vrid"`
+	Vip                       string   `json:"vip"`
+	Ipaddress1                string   `json:"ipaddress1"`
+	Ipaddress2                string   `json:"ipaddress2"`
+	DisableInternetConnection bool     `json:"disable-internet-connection"`
+	BootAfterCreate           bool     `json:"boot-after-create"`
+	Name                      string   `json:"name"`
+	Description               string   `json:"description"`
+	Tags                      []string `json:"tags"`
+	IconId                    int64    `json:"icon-id"`
+	Assumeyes                 bool     `json:"assumeyes"`
+	ParamTemplate             string   `json:"param-template"`
+	ParamTemplateFile         string   `json:"param-template-file"`
+	GenerateSkeleton          bool     `json:"generate-skeleton"`
+	OutputType                string   `json:"output-type"`
+	Column                    []string `json:"column"`
+	Quiet                     bool     `json:"quiet"`
+	Format                    string   `json:"format"`
+	FormatFile                string   `json:"format-file"`
+	Query                     string   `json:"query"`
 }
 
 // NewCreateVPCRouterParam return new CreateVPCRouterParam
@@ -324,6 +325,9 @@ func (p *CreateVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Ipaddress2) {
 		p.Ipaddress2 = ""
+	}
+	if isEmpty(p.DisableInternetConnection) {
+		p.DisableInternetConnection = false
 	}
 	if isEmpty(p.BootAfterCreate) {
 		p.BootAfterCreate = false
@@ -549,6 +553,13 @@ func (p *CreateVPCRouterParam) SetIpaddress2(v string) {
 
 func (p *CreateVPCRouterParam) GetIpaddress2() string {
 	return p.Ipaddress2
+}
+func (p *CreateVPCRouterParam) SetDisableInternetConnection(v bool) {
+	p.DisableInternetConnection = v
+}
+
+func (p *CreateVPCRouterParam) GetDisableInternetConnection() bool {
+	return p.DisableInternetConnection
 }
 func (p *CreateVPCRouterParam) SetBootAfterCreate(v bool) {
 	p.BootAfterCreate = v
@@ -852,23 +863,24 @@ func (p *ReadVPCRouterParam) GetId() int64 {
 
 // UpdateVPCRouterParam is input parameters for the sacloud API
 type UpdateVPCRouterParam struct {
-	SyslogHost        string   `json:"syslog-host"`
-	Selector          []string `json:"selector"`
-	Name              string   `json:"name"`
-	Description       string   `json:"description"`
-	Tags              []string `json:"tags"`
-	IconId            int64    `json:"icon-id"`
-	Assumeyes         bool     `json:"assumeyes"`
-	ParamTemplate     string   `json:"param-template"`
-	ParamTemplateFile string   `json:"param-template-file"`
-	GenerateSkeleton  bool     `json:"generate-skeleton"`
-	OutputType        string   `json:"output-type"`
-	Column            []string `json:"column"`
-	Quiet             bool     `json:"quiet"`
-	Format            string   `json:"format"`
-	FormatFile        string   `json:"format-file"`
-	Query             string   `json:"query"`
-	Id                int64    `json:"id"`
+	SyslogHost         string   `json:"syslog-host"`
+	InternetConnection bool     `json:"internet-connection"`
+	Selector           []string `json:"selector"`
+	Name               string   `json:"name"`
+	Description        string   `json:"description"`
+	Tags               []string `json:"tags"`
+	IconId             int64    `json:"icon-id"`
+	Assumeyes          bool     `json:"assumeyes"`
+	ParamTemplate      string   `json:"param-template"`
+	ParamTemplateFile  string   `json:"param-template-file"`
+	GenerateSkeleton   bool     `json:"generate-skeleton"`
+	OutputType         string   `json:"output-type"`
+	Column             []string `json:"column"`
+	Quiet              bool     `json:"quiet"`
+	Format             string   `json:"format"`
+	FormatFile         string   `json:"format-file"`
+	Query              string   `json:"query"`
+	Id                 int64    `json:"id"`
 }
 
 // NewUpdateVPCRouterParam return new UpdateVPCRouterParam
@@ -880,6 +892,9 @@ func NewUpdateVPCRouterParam() *UpdateVPCRouterParam {
 func (p *UpdateVPCRouterParam) FillValueToSkeleton() {
 	if isEmpty(p.SyslogHost) {
 		p.SyslogHost = ""
+	}
+	if isEmpty(p.InternetConnection) {
+		p.InternetConnection = false
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -1031,6 +1046,13 @@ func (p *UpdateVPCRouterParam) SetSyslogHost(v string) {
 
 func (p *UpdateVPCRouterParam) GetSyslogHost() string {
 	return p.SyslogHost
+}
+func (p *UpdateVPCRouterParam) SetInternetConnection(v bool) {
+	p.InternetConnection = v
+}
+
+func (p *UpdateVPCRouterParam) GetInternetConnection() bool {
+	return p.InternetConnection
 }
 func (p *UpdateVPCRouterParam) SetSelector(v []string) {
 	p.Selector = v
@@ -2050,6 +2072,244 @@ func (p *WaitForDownVPCRouterParam) SetId(v int64) {
 }
 
 func (p *WaitForDownVPCRouterParam) GetId() int64 {
+	return p.Id
+}
+
+// EnableInternetConnectionVPCRouterParam is input parameters for the sacloud API
+type EnableInternetConnectionVPCRouterParam struct {
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewEnableInternetConnectionVPCRouterParam return new EnableInternetConnectionVPCRouterParam
+func NewEnableInternetConnectionVPCRouterParam() *EnableInternetConnectionVPCRouterParam {
+	return &EnableInternetConnectionVPCRouterParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *EnableInternetConnectionVPCRouterParam) FillValueToSkeleton() {
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *EnableInternetConnectionVPCRouterParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetResourceDef() *schema.Resource {
+	return define.Resources["VPCRouter"]
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["enable-internet-connection"]
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *EnableInternetConnectionVPCRouterParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *EnableInternetConnectionVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *EnableInternetConnectionVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *EnableInternetConnectionVPCRouterParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *EnableInternetConnectionVPCRouterParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *EnableInternetConnectionVPCRouterParam) GetId() int64 {
+	return p.Id
+}
+
+// DisableInternetConnectionVPCRouterParam is input parameters for the sacloud API
+type DisableInternetConnectionVPCRouterParam struct {
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewDisableInternetConnectionVPCRouterParam return new DisableInternetConnectionVPCRouterParam
+func NewDisableInternetConnectionVPCRouterParam() *DisableInternetConnectionVPCRouterParam {
+	return &DisableInternetConnectionVPCRouterParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *DisableInternetConnectionVPCRouterParam) FillValueToSkeleton() {
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *DisableInternetConnectionVPCRouterParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetResourceDef() *schema.Resource {
+	return define.Resources["VPCRouter"]
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["disable-internet-connection"]
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *DisableInternetConnectionVPCRouterParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *DisableInternetConnectionVPCRouterParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *DisableInternetConnectionVPCRouterParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *DisableInternetConnectionVPCRouterParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *DisableInternetConnectionVPCRouterParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *DisableInternetConnectionVPCRouterParam) GetId() int64 {
 	return p.Id
 }
 

--- a/define/vpc_router.go
+++ b/define/vpc_router.go
@@ -115,6 +115,24 @@ func VPCRouterResource() *schema.Resource {
 			NoOutput:         true,
 			NeedlessConfirm:  true,
 		},
+		"enable-internet-connection": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           vpcRouterEnableInternetParam(),
+			Usage:            "Enable internet connection from VPCRouter",
+			UseCustomCommand: true,
+			Category:         "nic",
+			Order:            5,
+			NoOutput:         true,
+		},
+		"disable-internet-connection": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           vpcRouterEnableInternetParam(),
+			Usage:            "Enable internet connection from VPCRouter",
+			UseCustomCommand: true,
+			Category:         "nic",
+			Order:            6,
+			NoOutput:         true,
+		},
 		"interface-info": {
 			Type:               schema.CommandManipulateSingle,
 			Params:             vpcRouterInterfaceInfoParam(),
@@ -681,6 +699,15 @@ func vpcRouterListColumns() []output.ColumnDef {
 			},
 		},
 		{
+			Name: "Internet",
+			FormatFunc: func(values map[string]string) string {
+				if enabled, ok := values["Settings.Router.InternetConnection.Enabled"]; ok && enabled == "False" {
+					return "false"
+				}
+				return "true"
+			},
+		},
+		{
 			Name: "IPAddress",
 			FormatFunc: func(values map[string]string) string {
 				if plan, ok := values["Plan.ID"]; ok {
@@ -922,6 +949,14 @@ func vpcRouterCreateParam() map[string]*schema.Schema {
 			Category:     "network",
 			Order:        30,
 		},
+		"disable-internet-connection": {
+			Type:         schema.TypeBool,
+			HandlerType:  schema.HandlerNoop,
+			DefaultValue: false,
+			Description:  "disable internet connection from VPCRouter",
+			Category:     "network",
+			Order:        35,
+		},
 		"boot-after-create": {
 			Type:        schema.TypeBool,
 			HandlerType: schema.HandlerNoop,
@@ -981,6 +1016,13 @@ func vpcRouterUpdateParam() map[string]*schema.Schema {
 			Category:     "router",
 			Order:        10,
 		},
+		"internet-connection": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Description: "set internet connection from VPCRouter",
+			Category:    "router",
+			Order:       20,
+		},
 		"name":        paramName,
 		"description": paramDescription,
 		"tags":        paramTags,
@@ -999,6 +1041,14 @@ func vpcRouterDeleteParam() map[string]*schema.Schema {
 			Order:       10,
 		},
 	}
+}
+
+func vpcRouterEnableInternetParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func vpcRouterDisableInternetParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
 }
 
 func vpcRouterPowerOnParam() map[string]*schema.Schema {

--- a/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_setting.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/vpc_router_setting.go
@@ -22,6 +22,7 @@ type VPCRouterSetting struct {
 	RemoteAccessUsers  *VPCRouterRemoteAccessUsers  `json:",omitempty"` // リモートアクセスユーザー設定
 	SiteToSiteIPsecVPN *VPCRouterSiteToSiteIPsecVPN `json:",omitempty"` // サイト間VPN設定
 	StaticRoutes       *VPCRouterStaticRoutes       `json:",omitempty"` // スタティックルート設定
+	InternetConnection *VPCRouterInternetConnection `json:",omitempty"` // インターネット接続
 	VRID               *int                         `json:",omitempty"` // VRID
 	SyslogHost         string                       `json:",omitempty"` // syslog転送先ホスト
 
@@ -1155,4 +1156,21 @@ func (s *VPCRouterSetting) FindStaticRoute(prefix string, nextHop string) (int, 
 		}
 	}
 	return -1, nil
+}
+
+// VPCRouterInternetConnection インターネット接続
+type VPCRouterInternetConnection struct {
+	Enabled string `json:",omitempty"` // 有効/無効
+}
+
+// SetInternetConnection インターネット接続 有効/無効 設定
+func (s *VPCRouterSetting) SetInternetConnection(enabled bool) {
+	if s.InternetConnection == nil {
+		s.InternetConnection = &VPCRouterInternetConnection{
+			Enabled: "False",
+		}
+	}
+	if enabled {
+		s.InternetConnection.Enabled = "True"
+	}
 }


### PR DESCRIPTION
VPCルータでのインターネット接続 有効/無効を設定/参照する機能を追加する。

#### 一覧表示

`Internet`列に有効/無効を表示する

```bash
+--------------+------+-------+------+----------+-------+----------+-------------------+
|      ID      | Name | Power | VRID |   Plan   |  HA   | Internet |     IPAddress     |
+--------------+------+-------+------+----------+-------+----------+-------------------+
| xxxxxxxxxx01 | test | down  | -    | standard | false | true     | xxx.xxx.xx.xxx/24 |
+--------------+------+-------+------+----------+-------+----------+-------------------+
```

#### 作成

作成時に`--disable-internet-connection`オプションを指定可能とする。
このオプションを指定しない場合はインターネット接続有効となる。

#### 更新

更新時に`--internet-connection`パラメータ(bool型)を指定可能とする。

#### 有効/無効切り替えサブコマンド

インターネット接続の有効/無効を切り替えるサブコマンドを追加する。

```
# 有効化
$ usacloud vac-router enable-internet-connection <ID or 名称>

# 無効化
$ usacloud vac-router disable-internet-connection <ID or 名称>
```