### PR TITLE
ロードバランサーVIPでの説明欄

### DIFF
--- a/command/cli/cli_load_balancer_gen.go
+++ b/command/cli/cli_load_balancer_gen.go
@@ -4154,6 +4154,11 @@ func init() {
 						Name:  "sorry-server",
 						Usage: "set IPAddress of sorry-server",
 					},
+					&cli.StringFlag{
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set Description of VIP",
+					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
 						Usage: "Set target filter by tag",
@@ -4230,6 +4235,9 @@ func init() {
 					}
 					if c.IsSet("sorry-server") {
 						vipAddParam.SorryServer = c.String("sorry-server")
+					}
+					if c.IsSet("description") {
+						vipAddParam.Description = c.String("description")
 					}
 					if c.IsSet("selector") {
 						vipAddParam.Selector = c.StringSlice("selector")
@@ -4345,6 +4353,9 @@ func init() {
 					}
 					if c.IsSet("sorry-server") {
 						vipAddParam.SorryServer = c.String("sorry-server")
+					}
+					if c.IsSet("description") {
+						vipAddParam.Description = c.String("description")
 					}
 					if c.IsSet("selector") {
 						vipAddParam.Selector = c.StringSlice("selector")
@@ -4515,6 +4526,11 @@ func init() {
 						Name:  "sorry-server",
 						Usage: "set IPAddress of sorry-server",
 					},
+					&cli.StringFlag{
+						Name:    "description",
+						Aliases: []string{"desc"},
+						Usage:   "set Description of VIP",
+					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
 						Usage: "Set target filter by tag",
@@ -4594,6 +4610,9 @@ func init() {
 					}
 					if c.IsSet("sorry-server") {
 						vipUpdateParam.SorryServer = c.String("sorry-server")
+					}
+					if c.IsSet("description") {
+						vipUpdateParam.Description = c.String("description")
 					}
 					if c.IsSet("selector") {
 						vipUpdateParam.Selector = c.StringSlice("selector")
@@ -4712,6 +4731,9 @@ func init() {
 					}
 					if c.IsSet("sorry-server") {
 						vipUpdateParam.SorryServer = c.String("sorry-server")
+					}
+					if c.IsSet("description") {
+						vipUpdateParam.Description = c.String("description")
 					}
 					if c.IsSet("selector") {
 						vipUpdateParam.Selector = c.StringSlice("selector")
@@ -8073,6 +8095,11 @@ func init() {
 		DisplayName: "Vip options",
 		Order:       1,
 	})
+	AppendFlagCategoryMap("load-balancer", "vip-add", "description", &schema.Category{
+		Key:         "vip",
+		DisplayName: "Vip options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("load-balancer", "vip-add", "generate-skeleton", &schema.Category{
 		Key:         "Input",
 		DisplayName: "Input options",
@@ -8209,6 +8236,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("load-balancer", "vip-update", "delay-loop", &schema.Category{
+		Key:         "vip",
+		DisplayName: "Vip options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("load-balancer", "vip-update", "description", &schema.Category{
 		Key:         "vip",
 		DisplayName: "Vip options",
 		Order:       1,

--- a/command/completion/load_balancer_flags_gen.go
+++ b/command/completion/load_balancer_flags_gen.go
@@ -430,6 +430,11 @@ func LoadBalancerVipAddCompleteFlags(ctx command.Context, params *params.VipAddL
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
+	case "description", "desc":
+		param := define.Resources["LoadBalancer"].Commands["vip-add"].BuildedParams().Get("description")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "selector":
 		param := define.Resources["LoadBalancer"].Commands["vip-add"].BuildedParams().Get("selector")
 		if param != nil {
@@ -476,6 +481,11 @@ func LoadBalancerVipUpdateCompleteFlags(ctx command.Context, params *params.VipU
 		}
 	case "sorry-server":
 		param := define.Resources["LoadBalancer"].Commands["vip-update"].BuildedParams().Get("sorry-server")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "description", "desc":
+		param := define.Resources["LoadBalancer"].Commands["vip-update"].BuildedParams().Get("description")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}

--- a/command/funcs/load_balancer_vip_add.go
+++ b/command/funcs/load_balancer_vip_add.go
@@ -36,6 +36,7 @@ func LoadBalancerVipAdd(ctx command.Context, params *params.VipAddLoadBalancerPa
 		Port:             fmt.Sprintf("%d", params.Port),
 		DelayLoop:        fmt.Sprintf("%d", params.DelayLoop),
 		SorryServer:      params.SorryServer,
+		Description: params.Description,
 	}
 
 	p.AddLoadBalancerSetting(vip)

--- a/command/funcs/load_balancer_vip_update.go
+++ b/command/funcs/load_balancer_vip_update.go
@@ -48,6 +48,9 @@ func LoadBalancerVipUpdate(ctx command.Context, params *params.VipUpdateLoadBala
 	if ctx.IsSet("sorry-server") {
 		vip.SorryServer = params.SorryServer
 	}
+	if ctx.IsSet("description") {
+		vip.Description = params.Description
+	}
 
 	p, err := client.LoadBalancer.Update(params.Id, p)
 	if err != nil {

--- a/command/params/params_load_balancer_gen.go
+++ b/command/params/params_load_balancer_gen.go
@@ -2267,6 +2267,7 @@ type VipAddLoadBalancerParam struct {
 	Port              int      `json:"port"`
 	DelayLoop         int      `json:"delay-loop"`
 	SorryServer       string   `json:"sorry-server"`
+	Description       string   `json:"description"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
 	ParamTemplate     string   `json:"param-template"`
@@ -2296,6 +2297,9 @@ func (p *VipAddLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.SorryServer) {
 		p.SorryServer = ""
+	}
+	if isEmpty(p.Description) {
+		p.Description = ""
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -2426,6 +2430,13 @@ func (p *VipAddLoadBalancerParam) SetSorryServer(v string) {
 func (p *VipAddLoadBalancerParam) GetSorryServer() string {
 	return p.SorryServer
 }
+func (p *VipAddLoadBalancerParam) SetDescription(v string) {
+	p.Description = v
+}
+
+func (p *VipAddLoadBalancerParam) GetDescription() string {
+	return p.Description
+}
 func (p *VipAddLoadBalancerParam) SetSelector(v []string) {
 	p.Selector = v
 }
@@ -2476,6 +2487,7 @@ type VipUpdateLoadBalancerParam struct {
 	Port              int      `json:"port"`
 	DelayLoop         int      `json:"delay-loop"`
 	SorryServer       string   `json:"sorry-server"`
+	Description       string   `json:"description"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
 	ParamTemplate     string   `json:"param-template"`
@@ -2508,6 +2520,9 @@ func (p *VipUpdateLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.SorryServer) {
 		p.SorryServer = ""
+	}
+	if isEmpty(p.Description) {
+		p.Description = ""
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -2637,6 +2652,13 @@ func (p *VipUpdateLoadBalancerParam) SetSorryServer(v string) {
 
 func (p *VipUpdateLoadBalancerParam) GetSorryServer() string {
 	return p.SorryServer
+}
+func (p *VipUpdateLoadBalancerParam) SetDescription(v string) {
+	p.Description = v
+}
+
+func (p *VipUpdateLoadBalancerParam) GetDescription() string {
+	return p.Description
 }
 func (p *VipUpdateLoadBalancerParam) SetSelector(v []string) {
 	p.Selector = v

--- a/define/load_balancer.go
+++ b/define/load_balancer.go
@@ -350,6 +350,7 @@ func loadBalancerVIPListColumns() []output.ColumnDef {
 		{Name: "Port"},
 		{Name: "DelayLoop"},
 		{Name: "SorryServer"},
+		{Name: "Description"},
 	}
 }
 
@@ -580,6 +581,14 @@ func loadBalancerVIPAddParam() map[string]*schema.Schema {
 			Category:     "vip",
 			Order:        40,
 		},
+		"description": {
+			Type:        schema.TypeString,
+			HandlerType: schema.HandlerNoop,
+			Aliases:     []string{"desc"},
+			Description: "set Description of VIP",
+			Category:    "vip",
+			Order:       50,
+		},
 	}
 }
 
@@ -625,6 +634,14 @@ func loadBalancerVIPUpdateParam() map[string]*schema.Schema {
 			ValidateFunc: validateIPv4Address(),
 			Category:     "vip",
 			Order:        40,
+		},
+		"description": {
+			Type:        schema.TypeString,
+			HandlerType: schema.HandlerNoop,
+			Aliases:     []string{"desc"},
+			Description: "set Description of VIP",
+			Category:    "vip",
+			Order:       50,
 		},
 	}
 }


### PR DESCRIPTION
ロードバランサーのVIPに説明を設定可能にする。

- `--description/--desc` : 説明

#### 利用例

```bash
# VIPの作成
$ usacloud load-balancer vip-add --vip 192.2.0.10 --port 80 --description foo <ID or 名称>

# VIPの表示(Description列が追加された)
$ usacloud load-balancer vip-info <ID or 名称>

# VIPの更新
$ usacloud load-balancer vip-update --desc bar --index 1 <ID or 名称> 
```