### PR TITLE
パブリックアーカイブ追加/ストレージ分離オプションのリクエストレイアウト対応

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,7 @@
     "sacloud/ostype",
     "utils/server"
   ]
-  revision = "7afff3fbc0a3bdff2e008fe2c429d44d9f66f209"
+  revision = "a2a3e1260ec65508ed0a8b5af27d557fa382707d"
 
 [[projects]]
   branch = "master"

--- a/command/funcs/server_build.go
+++ b/command/funcs/server_build.go
@@ -84,7 +84,8 @@ func createServerBuilder(ctx command.Context, params *params.BuildServerParam) i
 				// Windows?
 				if isWindows(params.OsType) {
 					sb = builder.ServerPublicArchiveWindows(client, strToOSType(params.OsType), params.Name)
-				} else if params.OsType == "sophos-utm" { // [HACK] ディスク修正可否から判定するのが望ましいが、Sophos以外に対象がないため現状は決め打ち判定
+					// [HACK] ディスク修正可否から判定するのが望ましいが、Sophos/Netwiser/OPNsense以外に対象がないため現状は決め打ち判定
+				} else if params.OsType == "sophos-utm" || params.OsType == "netwiser" || params.OsType == "opnsense" {
 					sb = builder.ServerPublicArchiveFixedUnix(client, strToOSType(params.OsType), params.Name)
 				} else {
 					sb = builder.ServerPublicArchiveUnix(client, strToOSType(params.OsType), params.Name, params.Password)
@@ -354,7 +355,8 @@ func validateServerDiskModeParams(ctx command.Context, params *params.BuildServe
 
 		if params.SourceDiskId == 0 && params.SourceArchiveId == 0 {
 			// Windows?
-			if params.OsType != "" && !isWindows(params.OsType) && params.OsType != "sophos-utm" {
+			if params.OsType != "" && !isWindows(params.OsType) &&
+				params.OsType != "sophos-utm" && params.OsType != "netwiser" && params.OsType != "opnsense" {
 				appendErrors(validateRequired("password", params.Password))
 			}
 

--- a/command/funcs/server_build_test.go
+++ b/command/funcs/server_build_test.go
@@ -218,6 +218,30 @@ func TestServerBuild_CreateBuilder_WithConnect(t *testing.T) {
 	assert.EqualValues(t, expectedBuilder, actualBuilder)
 }
 
+func TestServerBuild_CreateBuilder_FixedUnix(t *testing.T) {
+	osTypes := []string{"sophos-utm", "netwiser", "opnsense"}
+	for _, ostype := range osTypes {
+
+		t.Run(ostype, func(t *testing.T) {
+			param := &params.BuildServerParam{
+				DiskMode: "create",
+				Name:     "fixedUnix",
+				OsType:   ostype,
+			}
+
+			sb := createServerBuilder(dummyContext, param)
+			assert.NotNil(t, sb)
+
+			// builder type should be *builder.CommonServerBuilder
+			expectedBuilder := sb.(*builder.FixedUnixArchiveServerBuilder)
+			assert.NotNil(t, expectedBuilder)
+
+			actualBuilder := builder.ServerPublicArchiveFixedUnix(dummyContext.GetAPIClient(), strToOSType(param.OsType), param.Name)
+			assert.EqualValues(t, expectedBuilder, actualBuilder)
+		})
+	}
+}
+
 func TestServerBuild_CreateBuilder_Diskless(t *testing.T) {
 	param := &params.BuildServerParam{
 		DiskMode: "diskless",

--- a/vendor/github.com/sacloud/libsacloud/api/archive.go
+++ b/vendor/github.com/sacloud/libsacloud/api/archive.go
@@ -25,6 +25,8 @@ var (
 	archiveLatestStableKusanagiTags                        = []string{"current-stable", "pkg-kusanagi"}
 	archiveLatestStableSophosUTMTags                       = []string{"current-stable", "pkg-sophosutm"}
 	archiveLatestStableFreeBSDTags                         = []string{"current-stable", "distro-freebsd"}
+	archiveLatestStableNetwiserTags                        = []string{"current-stable", "pkg-netwiserve"}
+	archiveLatestStableOPNsenseTags                        = []string{"current-stable", "distro-opnsense"}
 	archiveLatestStableWindows2012Tags                     = []string{"os-windows", "distro-ver-2012.2"}
 	archiveLatestStableWindows2012RDSTags                  = []string{"os-windows", "distro-ver-2012.2", "windows-rds"}
 	archiveLatestStableWindows2012RDSOfficeTags            = []string{"os-windows", "distro-ver-2012.2", "windows-rds", "with-office"}
@@ -60,6 +62,8 @@ func NewArchiveAPI(client *Client) *ArchiveAPI {
 		ostype.Kusanagi:                            api.FindLatestStableKusanagi,
 		ostype.SophosUTM:                           api.FindLatestStableSophosUTM,
 		ostype.FreeBSD:                             api.FindLatestStableFreeBSD,
+		ostype.Netwiser:                            api.FindLatestStableNetwiser,
+		ostype.OPNsense:                            api.FindLatestStableOPNsense,
 		ostype.Windows2012:                         api.FindLatestStableWindows2012,
 		ostype.Windows2012RDS:                      api.FindLatestStableWindows2012RDS,
 		ostype.Windows2012RDSOffice:                api.FindLatestStableWindows2012RDSOffice,
@@ -141,6 +145,14 @@ func (api *ArchiveAPI) CanEditDisk(id int64) (bool, error) {
 	if archive.HasTag("pkg-sophosutm") || archive.IsSophosUTM() {
 		return false, nil
 	}
+	// OPNsenseであれば編集不可
+	if archive.HasTag("distro-opnsense") {
+		return false, nil
+	}
+	// Netwiser VEであれば編集不可
+	if archive.HasTag("pkg-netwiserve") {
+		return false, nil
+	}
 
 	for _, t := range allowDiskEditTags {
 		if archive.HasTag(t) {
@@ -182,6 +194,14 @@ func (api *ArchiveAPI) GetPublicArchiveIDFromAncestors(id int64) (int64, bool) {
 
 	// SophosUTMであれば編集不可
 	if archive.HasTag("pkg-sophosutm") || archive.IsSophosUTM() {
+		return emptyID, false
+	}
+	// OPNsenseであれば編集不可
+	if archive.HasTag("distro-opnsense") {
+		return emptyID, false
+	}
+	// Netwiser VEであれば編集不可
+	if archive.HasTag("pkg-netwiserve") {
 		return emptyID, false
 	}
 
@@ -251,6 +271,16 @@ func (api *ArchiveAPI) FindLatestStableSophosUTM() (*sacloud.Archive, error) {
 // FindLatestStableFreeBSD 安定版最新のFreeBSDパブリックアーカイブを取得
 func (api *ArchiveAPI) FindLatestStableFreeBSD() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableFreeBSDTags)
+}
+
+// FindLatestStableNetwiser 安定版最新のNetwiserパブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableNetwiser() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableNetwiserTags)
+}
+
+// FindLatestStableOPNsense 安定版最新のOPNsenseパブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableOPNsense() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableOPNsenseTags)
 }
 
 // FindLatestStableWindows2012 安定版最新のWindows2012パブリックアーカイブを取得

--- a/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
@@ -213,7 +213,7 @@ type Request struct {
 	Filter               map[string]interface{} `json:",omitempty"` // フィルタ
 	Exclude              []string               `json:",omitempty"` // 除外する項目
 	Include              []string               `json:",omitempty"` // 取得する項目
-
+	DistantFrom          []int64                `json:",omitempty"` // ストレージ隔離対象ディスク
 }
 
 // AddFilter フィルタの追加

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archive_ostype.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archive_ostype.go
@@ -27,6 +27,10 @@ const (
 	SophosUTM
 	// FreeBSD OS種別:FreeBSD
 	FreeBSD
+	// Netwiser OS種別: Netwiser Virtual Edition
+	Netwiser
+	// OPNsense OS種別: OPNsense
+	OPNsense
 	// Windows2012 OS種別:Windows Server 2012 R2 Datacenter Edition
 	Windows2012
 	// Windows2012RDS OS種別:Windows Server 2012 R2 for RDS
@@ -57,6 +61,7 @@ const (
 var OSTypeShortNames = []string{
 	"centos", "centos6", "ubuntu", "debian", "vyos", "coreos",
 	"rancheros", "kusanagi", "sophos-utm", "freebsd",
+	"netwiser", "opnsense",
 	"windows2012", "windows2012-rds", "windows2012-rds-office",
 	"windows2016", "windows2016-rds", "windows2016-rds-office",
 	"windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all",
@@ -109,6 +114,10 @@ func StrToOSType(osType string) ArchiveOSTypes {
 		return SophosUTM
 	case "freebsd":
 		return FreeBSD
+	case "netwiser":
+		return Netwiser
+	case "opnsense":
+		return OPNsense
 	case "windows2012":
 		return Windows2012
 	case "windows2012-rds":

--- a/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archiveostypes_string.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/ostype/archiveostypes_string.go
@@ -4,9 +4,9 @@ package ostype
 
 import "strconv"
 
-const _ArchiveOSTypes_name = "CentOSCentOS6UbuntuDebianVyOSCoreOSRancherOSKusanagiSophosUTMFreeBSDWindows2012Windows2012RDSWindows2012RDSOfficeWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllCustom"
+const _ArchiveOSTypes_name = "CentOSCentOS6UbuntuDebianVyOSCoreOSRancherOSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2012Windows2012RDSWindows2012RDSOfficeWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllCustom"
 
-var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 19, 25, 29, 35, 44, 52, 61, 68, 79, 93, 113, 124, 138, 158, 181, 209, 241, 272, 307, 313}
+var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 19, 25, 29, 35, 44, 52, 61, 68, 76, 84, 95, 109, 129, 140, 154, 174, 197, 225, 257, 288, 323, 329}
 
 func (i ArchiveOSTypes) String() string {
 	if i < 0 || i >= ArchiveOSTypes(len(_ArchiveOSTypes_index)-1) {

--- a/vendor/github.com/sacloud/libsacloud/sacloud/server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/server.go
@@ -43,10 +43,13 @@ func (s *Server) IPAddress() string {
 
 // Gateway デフォルトゲートウェイアドレス
 func (s *Server) Gateway() string {
-	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil || s.Interfaces[0].Switch.UserSubnet == nil {
+	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil {
 		return ""
 	}
-	return s.Interfaces[0].Switch.UserSubnet.DefaultRoute
+	if s.Interfaces[0].Switch.UserSubnet != nil {
+		return s.Interfaces[0].Switch.UserSubnet.DefaultRoute
+	}
+	return s.Interfaces[0].Switch.Subnet.DefaultRoute
 }
 
 // DefaultRoute デフォルトゲートウェイアドレス(Gatewayのエイリアス)
@@ -56,10 +59,13 @@ func (s *Server) DefaultRoute() string {
 
 // NetworkMaskLen サーバの1番目のNIC(eth0)のネットワークマスク長
 func (s *Server) NetworkMaskLen() int {
-	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil || s.Interfaces[0].Switch.UserSubnet == nil {
+	if len(s.Interfaces) == 0 || s.Interfaces[0].Switch == nil {
 		return 0
 	}
-	return s.Interfaces[0].Switch.UserSubnet.NetworkMaskLen
+	if s.Interfaces[0].Switch.UserSubnet != nil {
+		return s.Interfaces[0].Switch.UserSubnet.NetworkMaskLen
+	}
+	return s.Interfaces[0].Switch.Subnet.NetworkMaskLen
 }
 
 // NetworkAddress サーバの1番目のNIC(eth0)のネットワークアドレス


### PR DESCRIPTION
libsacloudの更新に伴う対応

- `server build`の`os-type`パラメータで利用可能なパブリックアーカイブ追加
  - `opnsense`
  - `netwiser`
- ディスク作成時のDistantFromパラメータのリクエストパラメータレイアウト変更

