### PR TITLE
サーバ/ディスクの新プラン対応

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,7 @@
     "sacloud/ostype",
     "utils/server"
   ]
-  revision = "16f103c07b57b84c8c38cc594e3e62f7282f47a1"
+  revision = "2a3de31ce7af865bcd15793976ecf8c688ad6118"
 
 [[projects]]
   branch = "master"

--- a/command/funcs/server_plan_change.go
+++ b/command/funcs/server_plan_change.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
 )
@@ -21,13 +22,13 @@ func ServerPlanChange(ctx command.Context, params *params.PlanChangeServerParam)
 		return fmt.Errorf("ServerPlanChange is failed: %s", "server is running")
 	}
 
-	plan, err := client.GetProductServerAPI().GetBySpec(params.Core, params.Memory)
+	plan, err := client.GetProductServerAPI().GetBySpec(params.Core, params.Memory, sacloud.PlanDefault)
 	if err != nil {
 		return fmt.Errorf("ServerPlanChange is failed: plan is invalid: %s", err)
 	}
 
 	// call manipurate functions
-	res, err := api.ChangePlan(params.Id, fmt.Sprintf("%d", plan.ID))
+	res, err := api.ChangePlan(params.Id, plan)
 	if err != nil {
 		return fmt.Errorf("ServerPlanChange is failed: %s", err)
 	}

--- a/define/product_server.go
+++ b/define/product_server.go
@@ -50,6 +50,7 @@ func productServerListColumns() []output.ColumnDef {
 			Sources: []string{"MemoryMB"},
 			Format:  "%sMB",
 		},
+		{Name: "Generation"},
 	}
 }
 
@@ -62,7 +63,7 @@ func productServerDetailExcludes() []string {
 }
 
 func productServerReadParam() map[string]*schema.Schema {
-	id := getParamResourceShortID("resource ID", 6)
+	id := getParamResourceShortID("resource ID", 9)
 	id.Hidden = true
 	return map[string]*schema.Schema{
 		"id": id,

--- a/vendor/github.com/sacloud/libsacloud/api/server.go
+++ b/vendor/github.com/sacloud/libsacloud/api/server.go
@@ -150,14 +150,18 @@ func (api *ServerAPI) SleepUntilDown(id int64, timeout time.Duration) error {
 }
 
 // ChangePlan サーバープラン変更(サーバーIDが変更となるため注意)
-func (api *ServerAPI) ChangePlan(serverID int64, planID string) (*sacloud.Server, error) {
+func (api *ServerAPI) ChangePlan(serverID int64, plan *sacloud.ProductServer) (*sacloud.Server, error) {
 	var (
 		method = "PUT"
-		uri    = fmt.Sprintf("%s/%d/to/plan/%s", api.getResourceURL(), serverID, planID)
+		uri    = fmt.Sprintf("%s/%d/plan", api.getResourceURL(), serverID)
+		body   = &sacloud.ProductServer{}
 	)
+	body.CPU = plan.CPU
+	body.MemoryMB = plan.MemoryMB
+	body.Generation = plan.Generation
 
 	return api.request(func(res *sacloud.Response) error {
-		return api.baseAPI.request(method, uri, nil, res)
+		return api.baseAPI.request(method, uri, body, res)
 	})
 }
 

--- a/vendor/github.com/sacloud/libsacloud/builder/server.go
+++ b/vendor/github.com/sacloud/libsacloud/builder/server.go
@@ -352,7 +352,7 @@ func (b *serverBuilder) buildServerParams() error {
 	b.callEventHandlerIfExists(ServerBuildOnSetPlanBefore)
 
 	// plan
-	plan, err := b.client.Product.Server.GetBySpec(b.core, b.memory)
+	plan, err := b.client.Product.Server.GetBySpec(b.core, b.memory, sacloud.PlanDefault)
 	if err != nil {
 		err = fmt.Errorf("Error building server parameters : setting plan / [%s]", err)
 		return err

--- a/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/common_types.go
@@ -324,3 +324,15 @@ var (
 
 // DatetimeLayout さくらのクラウドAPIで利用される日付型のレイアウト(RFC3339)
 var DatetimeLayout = "2006-01-02T15:04:05-07:00"
+
+// PlanGenerations サーバプラン世代
+type PlanGenerations int
+
+var (
+	// PlanDefault デフォルト
+	PlanDefault = PlanGenerations(0)
+	// PlanG1 第1世代(Generation:100)
+	PlanG1 = PlanGenerations(100)
+	// PlanG2 第2世代(Generation:200)
+	PlanG2 = PlanGenerations(200)
+)

--- a/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/disk.go
@@ -4,22 +4,23 @@ import "fmt"
 
 // Disk ディスク
 type Disk struct {
-	*Resource          // ID
-	propAvailability   // 有功状態
-	propName           // 名称
-	propDescription    // 説明
-	propSizeMB         // サイズ(MB単位)
-	propMigratedMB     // コピー済みデータサイズ(MB単位)
-	propCopySource     // コピー元情報
-	propJobStatus      // マイグレーションジョブステータス
-	propBundleInfo     // バンドル情報
-	propServer         // サーバー
-	propIcon           // アイコン
-	propTags           // タグ
-	propCreatedAt      // 作成日時
-	propPlanID         // プランID
-	propDiskConnection // ディスク接続情報
-	propDistantFrom    // ストレージ隔離対象ディスク
+	*Resource                          // ID
+	propAvailability                   // 有功状態
+	propName                           // 名称
+	propDescription                    // 説明
+	propSizeMB                         // サイズ(MB単位)
+	propMigratedMB                     // コピー済みデータサイズ(MB単位)
+	propCopySource                     // コピー元情報
+	propJobStatus                      // マイグレーションジョブステータス
+	propBundleInfo                     // バンドル情報
+	propServer                         // サーバー
+	propIcon                           // アイコン
+	propTags                           // タグ
+	propCreatedAt                      // 作成日時
+	propPlanID                         // プランID
+	propDiskConnection                 // ディスク接続情報
+	propDistantFrom                    // ストレージ隔離対象ディスク
+	Generation         PlanGenerations `json:",omitempty"` // プラン世代
 
 	ReinstallCount int `json:",omitempty"` // 再インストール回数
 

--- a/vendor/github.com/sacloud/libsacloud/sacloud/product_server.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/product_server.go
@@ -2,11 +2,12 @@ package sacloud
 
 // ProductServer サーバープラン
 type ProductServer struct {
-	*Resource        // ID
-	propName         // 名称
-	propDescription  // 説明
-	propAvailability // 有功状態
-	propCPU          // CPUコア数
-	propMemoryMB     // メモリサイズ(MB単位)
-	propServiceClass // サービスクラス
+	*Resource                        // ID
+	propName                         // 名称
+	propDescription                  // 説明
+	propAvailability                 // 有功状態
+	propCPU                          // CPUコア数
+	propMemoryMB                     // メモリサイズ(MB単位)
+	propServiceClass                 // サービスクラス
+	Generation       PlanGenerations `json:",omitempty"` // 世代
 }

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_memory.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_memory.go
@@ -17,3 +17,8 @@ func (p *propMemoryMB) GetMemoryGB() int {
 	}
 	return p.MemoryMB / 1024
 }
+
+// SetMemoryGB サイズ(GB単位) 設定
+func (p *propMemoryMB) SetMemoryGB(memoryGB int) {
+	p.MemoryMB = memoryGB / 1024
+}

--- a/vendor/github.com/sacloud/libsacloud/sacloud/prop_server_plan.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/prop_server_plan.go
@@ -23,6 +23,14 @@ func (p *propServerPlan) SetServerPlanByID(planID string) {
 	p.ServerPlan.Resource = NewResourceByStringID(planID)
 }
 
+// SetServerPlanByValue サーバープラン設定(値指定)
+func (p *propServerPlan) SetServerPlanByValue(cpu int, memoryGB int, gen PlanGenerations) {
+	plan := &ProductServer{}
+	plan.CPU = cpu
+	plan.SetMemoryGB(memoryGB)
+	plan.Generation = gen
+}
+
 // GetCPU CPUコア数 取得
 func (p *propServerPlan) GetCPU() int {
 	if p.ServerPlan == nil {
@@ -48,4 +56,8 @@ func (p *propServerPlan) GetMemoryGB() int {
 	}
 
 	return p.ServerPlan.GetMemoryGB()
+}
+
+func (p *propServerPlan) SetMemoryGB(memoryGB int) {
+	p.ServerPlan.SetMemoryGB(memoryGB)
 }


### PR DESCRIPTION
To fix #369 

- サーバ/ディスクでのプラン指定リクエストパラメータのレイアウト変更
- プラン変更時のエンドポイント変更
- プラン一覧表示での世代(Generation)表示追加

Note: 現時点では旧プランのサーバ/ディスク作成をサポートしない。  