### PR TITLE
トラフィックコントロール機能

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,7 @@
     "sacloud/ostype",
     "utils/server"
   ]
-  revision = "54457d615f2d8bdcb006b5421e0e9f31d849fb7e"
+  revision = "a8c99f916529fe0914bb0ff075e6ac23ffdff217"
 
 [[projects]]
   branch = "master"

--- a/command/cli/cli_mobile_gateway_gen.go
+++ b/command/cli/cli_mobile_gateway_gen.go
@@ -33,6 +33,10 @@ func init() {
 	interfaceConnectParam := params.NewInterfaceConnectMobileGatewayParam()
 	interfaceUpdateParam := params.NewInterfaceUpdateMobileGatewayParam()
 	interfaceDisconnectParam := params.NewInterfaceDisconnectMobileGatewayParam()
+	trafficControlInfoParam := params.NewTrafficControlInfoMobileGatewayParam()
+	trafficControlEnableParam := params.NewTrafficControlEnableMobileGatewayParam()
+	trafficControlUpdateParam := params.NewTrafficControlUpdateMobileGatewayParam()
+	trafficControlDisableParam := params.NewTrafficControlDisableMobileGatewayParam()
 	staticRouteInfoParam := params.NewStaticRouteInfoMobileGatewayParam()
 	staticRouteAddParam := params.NewStaticRouteAddMobileGatewayParam()
 	staticRouteUpdateParam := params.NewStaticRouteUpdateMobileGatewayParam()
@@ -5081,6 +5085,1394 @@ func init() {
 				},
 			},
 			{
+				Name:      "traffic-control-info",
+				Usage:     "Show information of traffic-control",
+				ArgsUsage: "<ID or Name(only single target)>",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.StringFlag{
+						Name:    "output-type",
+						Aliases: []string{"out"},
+						Usage:   "Output type [table/json/csv/tsv]",
+					},
+					&cli.StringSliceFlag{
+						Name:    "column",
+						Aliases: []string{"col"},
+						Usage:   "Output columns(using when '--output-type' is in [csv/tsv] only)",
+					},
+					&cli.BoolFlag{
+						Name:    "quiet",
+						Aliases: []string{"q"},
+						Usage:   "Only display IDs",
+					},
+					&cli.StringFlag{
+						Name:    "format",
+						Aliases: []string{"fmt"},
+						Usage:   "Output format(see text/template package document for detail)",
+					},
+					&cli.StringFlag{
+						Name:  "format-file",
+						Usage: "Output format from file(see text/template package document for detail)",
+					},
+					&cli.StringFlag{
+						Name:  "query",
+						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = trafficControlInfoParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, trafficControlInfoParam)
+
+					// Set option values
+					if c.IsSet("selector") {
+						trafficControlInfoParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("param-template") {
+						trafficControlInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlInfoParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("output-type") {
+						trafficControlInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						trafficControlInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						trafficControlInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						trafficControlInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						trafficControlInfoParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("query") {
+						trafficControlInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("id") {
+						trafficControlInfoParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayTrafficControlInfoCompleteArgs(ctx, trafficControlInfoParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayTrafficControlInfoCompleteArgs(ctx, trafficControlInfoParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayTrafficControlInfoCompleteFlags(ctx, trafficControlInfoParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayTrafficControlInfoCompleteArgs(ctx, trafficControlInfoParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					trafficControlInfoParam.ParamTemplate = c.String("param-template")
+					trafficControlInfoParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(trafficControlInfoParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewTrafficControlInfoMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(trafficControlInfoParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("selector") {
+						trafficControlInfoParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("param-template") {
+						trafficControlInfoParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlInfoParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlInfoParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("output-type") {
+						trafficControlInfoParam.OutputType = c.String("output-type")
+					}
+					if c.IsSet("column") {
+						trafficControlInfoParam.Column = c.StringSlice("column")
+					}
+					if c.IsSet("quiet") {
+						trafficControlInfoParam.Quiet = c.Bool("quiet")
+					}
+					if c.IsSet("format") {
+						trafficControlInfoParam.Format = c.String("format")
+					}
+					if c.IsSet("format-file") {
+						trafficControlInfoParam.FormatFile = c.String("format-file")
+					}
+					if c.IsSet("query") {
+						trafficControlInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("id") {
+						trafficControlInfoParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = trafficControlInfoParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if trafficControlInfoParam.GenerateSkeleton {
+						trafficControlInfoParam.GenerateSkeleton = false
+						trafficControlInfoParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(trafficControlInfoParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := trafficControlInfoParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), trafficControlInfoParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(trafficControlInfoParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, trafficControlInfoParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", trafficControlInfoParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(trafficControlInfoParam.Selector) == 0 || hasTags(&v, trafficControlInfoParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					if len(ids) != 1 {
+						return fmt.Errorf("Can't run with multiple targets: %v", ids)
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						trafficControlInfoParam.SetId(id)
+						p := *trafficControlInfoParam // copy struct value
+						trafficControlInfoParam := &p
+						go func() {
+							err := funcs.MobileGatewayTrafficControlInfo(ctx, trafficControlInfoParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "traffic-control-enable",
+				Usage:     "Enable traffic-control",
+				ArgsUsage: "<ID or Name(allow multiple target)>",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "quota",
+						Usage: "[Required] ",
+						Value: 512,
+					},
+					&cli.IntFlag{
+						Name: "band-width-limit",
+					},
+					&cli.BoolFlag{
+						Name: "enable-email",
+					},
+					&cli.StringFlag{
+						Name: "slack-webhook-url",
+					},
+					&cli.BoolFlag{
+						Name: "auto-traffic-shaping",
+					},
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = trafficControlEnableParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, trafficControlEnableParam)
+
+					// Set option values
+					if c.IsSet("quota") {
+						trafficControlEnableParam.Quota = c.Int("quota")
+					}
+					if c.IsSet("band-width-limit") {
+						trafficControlEnableParam.BandWidthLimit = c.Int("band-width-limit")
+					}
+					if c.IsSet("enable-email") {
+						trafficControlEnableParam.EnableEmail = c.Bool("enable-email")
+					}
+					if c.IsSet("slack-webhook-url") {
+						trafficControlEnableParam.SlackWebhookUrl = c.String("slack-webhook-url")
+					}
+					if c.IsSet("auto-traffic-shaping") {
+						trafficControlEnableParam.AutoTrafficShaping = c.Bool("auto-traffic-shaping")
+					}
+					if c.IsSet("selector") {
+						trafficControlEnableParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						trafficControlEnableParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						trafficControlEnableParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlEnableParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlEnableParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						trafficControlEnableParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayTrafficControlEnableCompleteArgs(ctx, trafficControlEnableParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayTrafficControlEnableCompleteArgs(ctx, trafficControlEnableParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayTrafficControlEnableCompleteFlags(ctx, trafficControlEnableParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayTrafficControlEnableCompleteArgs(ctx, trafficControlEnableParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					trafficControlEnableParam.ParamTemplate = c.String("param-template")
+					trafficControlEnableParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(trafficControlEnableParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewTrafficControlEnableMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(trafficControlEnableParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("quota") {
+						trafficControlEnableParam.Quota = c.Int("quota")
+					}
+					if c.IsSet("band-width-limit") {
+						trafficControlEnableParam.BandWidthLimit = c.Int("band-width-limit")
+					}
+					if c.IsSet("enable-email") {
+						trafficControlEnableParam.EnableEmail = c.Bool("enable-email")
+					}
+					if c.IsSet("slack-webhook-url") {
+						trafficControlEnableParam.SlackWebhookUrl = c.String("slack-webhook-url")
+					}
+					if c.IsSet("auto-traffic-shaping") {
+						trafficControlEnableParam.AutoTrafficShaping = c.Bool("auto-traffic-shaping")
+					}
+					if c.IsSet("selector") {
+						trafficControlEnableParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						trafficControlEnableParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						trafficControlEnableParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlEnableParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlEnableParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						trafficControlEnableParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = trafficControlEnableParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if trafficControlEnableParam.GenerateSkeleton {
+						trafficControlEnableParam.GenerateSkeleton = false
+						trafficControlEnableParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(trafficControlEnableParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := trafficControlEnableParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), trafficControlEnableParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(trafficControlEnableParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, trafficControlEnableParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", trafficControlEnableParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(trafficControlEnableParam.Selector) == 0 || hasTags(&v, trafficControlEnableParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					// confirm
+					if !trafficControlEnableParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("traffic-control-enable", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						trafficControlEnableParam.SetId(id)
+						p := *trafficControlEnableParam // copy struct value
+						trafficControlEnableParam := &p
+						go func() {
+							err := funcs.MobileGatewayTrafficControlEnable(ctx, trafficControlEnableParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "traffic-control-update",
+				Usage:     "Update traffic-control config",
+				ArgsUsage: "<ID or Name(allow multiple target)>",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name: "quota",
+					},
+					&cli.IntFlag{
+						Name: "band-width-limit",
+					},
+					&cli.BoolFlag{
+						Name: "enable-email",
+					},
+					&cli.StringFlag{
+						Name: "slack-webhook-url",
+					},
+					&cli.BoolFlag{
+						Name: "auto-traffic-shaping",
+					},
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = trafficControlUpdateParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, trafficControlUpdateParam)
+
+					// Set option values
+					if c.IsSet("quota") {
+						trafficControlUpdateParam.Quota = c.Int("quota")
+					}
+					if c.IsSet("band-width-limit") {
+						trafficControlUpdateParam.BandWidthLimit = c.Int("band-width-limit")
+					}
+					if c.IsSet("enable-email") {
+						trafficControlUpdateParam.EnableEmail = c.Bool("enable-email")
+					}
+					if c.IsSet("slack-webhook-url") {
+						trafficControlUpdateParam.SlackWebhookUrl = c.String("slack-webhook-url")
+					}
+					if c.IsSet("auto-traffic-shaping") {
+						trafficControlUpdateParam.AutoTrafficShaping = c.Bool("auto-traffic-shaping")
+					}
+					if c.IsSet("selector") {
+						trafficControlUpdateParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						trafficControlUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						trafficControlUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						trafficControlUpdateParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayTrafficControlUpdateCompleteArgs(ctx, trafficControlUpdateParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayTrafficControlUpdateCompleteArgs(ctx, trafficControlUpdateParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayTrafficControlUpdateCompleteFlags(ctx, trafficControlUpdateParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayTrafficControlUpdateCompleteArgs(ctx, trafficControlUpdateParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					trafficControlUpdateParam.ParamTemplate = c.String("param-template")
+					trafficControlUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(trafficControlUpdateParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewTrafficControlUpdateMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(trafficControlUpdateParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("quota") {
+						trafficControlUpdateParam.Quota = c.Int("quota")
+					}
+					if c.IsSet("band-width-limit") {
+						trafficControlUpdateParam.BandWidthLimit = c.Int("band-width-limit")
+					}
+					if c.IsSet("enable-email") {
+						trafficControlUpdateParam.EnableEmail = c.Bool("enable-email")
+					}
+					if c.IsSet("slack-webhook-url") {
+						trafficControlUpdateParam.SlackWebhookUrl = c.String("slack-webhook-url")
+					}
+					if c.IsSet("auto-traffic-shaping") {
+						trafficControlUpdateParam.AutoTrafficShaping = c.Bool("auto-traffic-shaping")
+					}
+					if c.IsSet("selector") {
+						trafficControlUpdateParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						trafficControlUpdateParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						trafficControlUpdateParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlUpdateParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlUpdateParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						trafficControlUpdateParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = trafficControlUpdateParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if trafficControlUpdateParam.GenerateSkeleton {
+						trafficControlUpdateParam.GenerateSkeleton = false
+						trafficControlUpdateParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(trafficControlUpdateParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := trafficControlUpdateParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), trafficControlUpdateParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(trafficControlUpdateParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, trafficControlUpdateParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", trafficControlUpdateParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(trafficControlUpdateParam.Selector) == 0 || hasTags(&v, trafficControlUpdateParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					// confirm
+					if !trafficControlUpdateParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("traffic-control-update", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						trafficControlUpdateParam.SetId(id)
+						p := *trafficControlUpdateParam // copy struct value
+						trafficControlUpdateParam := &p
+						go func() {
+							err := funcs.MobileGatewayTrafficControlUpdate(ctx, trafficControlUpdateParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
+				Name:      "traffic-control-disable",
+				Aliases:   []string{"traffic-control-delete"},
+				Usage:     "Disable traffic-control config",
+				ArgsUsage: "<ID or Name(allow multiple target)>",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "selector",
+						Usage: "Set target filter by tag",
+					},
+					&cli.BoolFlag{
+						Name:    "assumeyes",
+						Aliases: []string{"y"},
+						Usage:   "Assume that the answer to any question which would be asked is yes",
+					},
+					&cli.StringFlag{
+						Name:  "param-template",
+						Usage: "Set input parameter from string(JSON)",
+					},
+					&cli.StringFlag{
+						Name:  "param-template-file",
+						Usage: "Set input parameter from file",
+					},
+					&cli.BoolFlag{
+						Name:  "generate-skeleton",
+						Usage: "Output skelton of parameter JSON",
+					},
+					&cli.Int64Flag{
+						Name:   "id",
+						Usage:  "Set target ID",
+						Hidden: true,
+					},
+				},
+				ShellComplete: func(c *cli.Context) {
+
+					if c.NArg() < 3 { // invalid args
+						return
+					}
+
+					if err := checkConfigVersion(); err != nil {
+						return
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return
+					}
+
+					// c.Args() == arg1 arg2 arg3 -- [cur] [prev] [commandName]
+					args := c.Args().Slice()
+					commandName := args[c.NArg()-1]
+					prev := args[c.NArg()-2]
+					cur := args[c.NArg()-3]
+
+					// set real args
+					realArgs := args[0 : c.NArg()-3]
+
+					// Validate global params
+					command.GlobalOption.Validate(false)
+
+					// set default output-type
+					// when params have output-type option and have empty value
+					var outputTypeHolder interface{} = trafficControlDisableParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// build command context
+					ctx := command.NewContext(c, realArgs, trafficControlDisableParam)
+
+					// Set option values
+					if c.IsSet("selector") {
+						trafficControlDisableParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						trafficControlDisableParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						trafficControlDisableParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlDisableParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlDisableParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						trafficControlDisableParam.Id = c.Int64("id")
+					}
+
+					if strings.HasPrefix(prev, "-") {
+						// prev if flag , is values setted?
+						if strings.Contains(prev, "=") {
+							if strings.HasPrefix(cur, "-") {
+								completion.FlagNames(c, commandName)
+								return
+							} else {
+								completion.MobileGatewayTrafficControlDisableCompleteArgs(ctx, trafficControlDisableParam, cur, prev, commandName)
+								return
+							}
+						}
+
+						// cleanup flag name
+						name := prev
+						for {
+							if !strings.HasPrefix(name, "-") {
+								break
+							}
+							name = strings.Replace(name, "-", "", 1)
+						}
+
+						// flag is exists? , is BoolFlag?
+						exists := false
+						for _, flag := range c.App.Command(commandName).Flags {
+
+							for _, n := range flag.Names() {
+								if n == name {
+									exists = true
+									break
+								}
+							}
+
+							if exists {
+								if _, ok := flag.(*cli.BoolFlag); ok {
+									if strings.HasPrefix(cur, "-") {
+										completion.FlagNames(c, commandName)
+										return
+									} else {
+										completion.MobileGatewayTrafficControlDisableCompleteArgs(ctx, trafficControlDisableParam, cur, prev, commandName)
+										return
+									}
+								} else {
+									// prev is flag , call completion func of each flags
+									completion.MobileGatewayTrafficControlDisableCompleteFlags(ctx, trafficControlDisableParam, name, cur)
+									return
+								}
+							}
+						}
+						// here, prev is wrong, so noop.
+					} else {
+						if strings.HasPrefix(cur, "-") {
+							completion.FlagNames(c, commandName)
+							return
+						} else {
+							completion.MobileGatewayTrafficControlDisableCompleteArgs(ctx, trafficControlDisableParam, cur, prev, commandName)
+							return
+						}
+					}
+				},
+				Action: func(c *cli.Context) error {
+
+					if err := checkConfigVersion(); err != nil {
+						return err
+					}
+					if err := applyConfigFromFile(c); err != nil {
+						return err
+					}
+
+					trafficControlDisableParam.ParamTemplate = c.String("param-template")
+					trafficControlDisableParam.ParamTemplateFile = c.String("param-template-file")
+					strInput, err := command.GetParamTemplateValue(trafficControlDisableParam)
+					if err != nil {
+						return err
+					}
+					if strInput != "" {
+						p := params.NewTrafficControlDisableMobileGatewayParam()
+						err := json.Unmarshal([]byte(strInput), p)
+						if err != nil {
+							return fmt.Errorf("Failed to parse JSON: %s", err)
+						}
+						mergo.Merge(trafficControlDisableParam, p, mergo.WithOverride)
+					}
+
+					// Set option values
+					if c.IsSet("selector") {
+						trafficControlDisableParam.Selector = c.StringSlice("selector")
+					}
+					if c.IsSet("assumeyes") {
+						trafficControlDisableParam.Assumeyes = c.Bool("assumeyes")
+					}
+					if c.IsSet("param-template") {
+						trafficControlDisableParam.ParamTemplate = c.String("param-template")
+					}
+					if c.IsSet("param-template-file") {
+						trafficControlDisableParam.ParamTemplateFile = c.String("param-template-file")
+					}
+					if c.IsSet("generate-skeleton") {
+						trafficControlDisableParam.GenerateSkeleton = c.Bool("generate-skeleton")
+					}
+					if c.IsSet("id") {
+						trafficControlDisableParam.Id = c.Int64("id")
+					}
+
+					// Validate global params
+					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "GlobalOptions")
+					}
+
+					var outputTypeHolder interface{} = trafficControlDisableParam
+					if v, ok := outputTypeHolder.(command.OutputTypeHolder); ok {
+						if v.GetOutputType() == "" {
+							v.SetOutputType(command.GlobalOption.DefaultOutputType)
+						}
+					}
+
+					// Generate skeleton
+					if trafficControlDisableParam.GenerateSkeleton {
+						trafficControlDisableParam.GenerateSkeleton = false
+						trafficControlDisableParam.FillValueToSkeleton()
+						d, err := json.MarshalIndent(trafficControlDisableParam, "", "\t")
+						if err != nil {
+							return fmt.Errorf("Failed to Marshal JSON: %s", err)
+						}
+						fmt.Fprintln(command.GlobalOption.Out, string(d))
+						return nil
+					}
+
+					// Validate specific for each command params
+					if errors := trafficControlDisableParam.Validate(); len(errors) > 0 {
+						return command.FlattenErrorsWithPrefix(errors, "Options")
+					}
+
+					// create command context
+					ctx := command.NewContext(c, c.Args().Slice(), trafficControlDisableParam)
+
+					apiClient := ctx.GetAPIClient().MobileGateway
+					ids := []int64{}
+
+					if c.NArg() == 0 {
+
+						if len(trafficControlDisableParam.Selector) == 0 {
+							return fmt.Errorf("ID or Name argument or --selector option is required")
+						}
+						apiClient.Reset()
+						res, err := apiClient.Find()
+						if err != nil {
+							return fmt.Errorf("Find ID is failed: %s", err)
+						}
+						for _, v := range res.MobileGateways {
+							if hasTags(&v, trafficControlDisableParam.Selector) {
+								ids = append(ids, v.GetID())
+							}
+						}
+						if len(ids) == 0 {
+							return fmt.Errorf("Find ID is failed: Not Found[with search param tags=%s]", trafficControlDisableParam.Selector)
+						}
+
+					} else {
+
+						for _, arg := range c.Args().Slice() {
+
+							for _, a := range strings.Split(arg, "\n") {
+								idOrName := a
+								if id, ok := toSakuraID(idOrName); ok {
+									ids = append(ids, id)
+								} else {
+									apiClient.Reset()
+									apiClient.SetFilterBy("Name", idOrName)
+									res, err := apiClient.Find()
+									if err != nil {
+										return fmt.Errorf("Find ID is failed: %s", err)
+									}
+									if res.Count == 0 {
+										return fmt.Errorf("Find ID is failed: Not Found[with search param %q]", idOrName)
+									}
+									for _, v := range res.MobileGateways {
+										if len(trafficControlDisableParam.Selector) == 0 || hasTags(&v, trafficControlDisableParam.Selector) {
+											ids = append(ids, v.GetID())
+										}
+									}
+								}
+							}
+
+						}
+
+					}
+
+					ids = command.UniqIDs(ids)
+					if len(ids) == 0 {
+						return fmt.Errorf("Target resource is not found")
+					}
+
+					// confirm
+					if !trafficControlDisableParam.Assumeyes {
+						if !isTerminal() {
+							return fmt.Errorf("When using redirect/pipe, specify --assumeyes(-y) option")
+						}
+						if !command.ConfirmContinue("traffic-control-disable", ids...) {
+							return nil
+						}
+					}
+
+					wg := sync.WaitGroup{}
+					errs := []error{}
+
+					for _, id := range ids {
+						wg.Add(1)
+						trafficControlDisableParam.SetId(id)
+						p := *trafficControlDisableParam // copy struct value
+						trafficControlDisableParam := &p
+						go func() {
+							err := funcs.MobileGatewayTrafficControlDisable(ctx, trafficControlDisableParam)
+							if err != nil {
+								errs = append(errs, err)
+							}
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					return command.FlattenErrors(errs)
+
+				},
+			},
+			{
 				Name:      "static-route-info",
 				Aliases:   []string{"static-route-list"},
 				Usage:     "Show information of static-routes",
@@ -9859,7 +11251,7 @@ func init() {
 	AppendCommandCategoryMap("mobile-gateway", "dns-update", &schema.Category{
 		Key:         "dns",
 		DisplayName: "DNS Management",
-		Order:       60,
+		Order:       70,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "interface-connect", &schema.Category{
 		Key:         "nic",
@@ -9889,7 +11281,7 @@ func init() {
 	AppendCommandCategoryMap("mobile-gateway", "logs", &schema.Category{
 		Key:         "monitor",
 		DisplayName: "Monitoring",
-		Order:       70,
+		Order:       80,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "read", &schema.Category{
 		Key:         "basic",
@@ -9914,61 +11306,81 @@ func init() {
 	AppendCommandCategoryMap("mobile-gateway", "sim-add", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       50,
+		Order:       60,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-delete", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       50,
+		Order:       60,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-info", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       50,
+		Order:       60,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-route-add", &schema.Category{
 		Key:         "sim-route",
 		DisplayName: "SIM Route Management",
-		Order:       55,
+		Order:       65,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-route-delete", &schema.Category{
 		Key:         "sim-route",
 		DisplayName: "SIM Route Management",
-		Order:       55,
+		Order:       65,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-route-info", &schema.Category{
 		Key:         "sim-route",
 		DisplayName: "SIM Route Management",
-		Order:       55,
+		Order:       65,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-route-update", &schema.Category{
 		Key:         "sim-route",
 		DisplayName: "SIM Route Management",
-		Order:       55,
+		Order:       65,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "sim-update", &schema.Category{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       50,
+		Order:       60,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "static-route-add", &schema.Category{
 		Key:         "static-route",
 		DisplayName: "StaticRoute Management",
-		Order:       40,
+		Order:       50,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "static-route-delete", &schema.Category{
 		Key:         "static-route",
 		DisplayName: "StaticRoute Management",
-		Order:       40,
+		Order:       50,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "static-route-info", &schema.Category{
 		Key:         "static-route",
 		DisplayName: "StaticRoute Management",
-		Order:       40,
+		Order:       50,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "static-route-update", &schema.Category{
 		Key:         "static-route",
 		DisplayName: "StaticRoute Management",
+		Order:       50,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "traffic-control-disable", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic Control",
+		Order:       40,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "traffic-control-enable", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic Control",
+		Order:       40,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "traffic-control-info", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic Control",
+		Order:       40,
+	})
+	AppendCommandCategoryMap("mobile-gateway", "traffic-control-update", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic Control",
 		Order:       40,
 	})
 	AppendCommandCategoryMap("mobile-gateway", "update", &schema.Category{
@@ -11143,6 +12555,201 @@ func init() {
 		Key:         "filter",
 		DisplayName: "Filter options",
 		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-disable", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-disable", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-disable", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-disable", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-disable", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-disable", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "auto-traffic-shaping", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "band-width-limit", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "enable-email", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "quota", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-enable", "slack-webhook-url", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "column", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "format", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "format-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "output-type", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "quiet", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "assumeyes", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "auto-traffic-shaping", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "band-width-limit", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "enable-email", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "generate-skeleton", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "id", &schema.Category{
+		Key:         "default",
+		DisplayName: "Other options",
+		Order:       2147483647,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "param-template", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "param-template-file", &schema.Category{
+		Key:         "Input",
+		DisplayName: "Input options",
+		Order:       2147483627,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "quota", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "selector", &schema.Category{
+		Key:         "filter",
+		DisplayName: "Filter options",
+		Order:       2147483587,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-update", "slack-webhook-url", &schema.Category{
+		Key:         "traffic-control",
+		DisplayName: "Traffic-Control options",
+		Order:       1,
 	})
 	AppendFlagCategoryMap("mobile-gateway", "update", "assumeyes", &schema.Category{
 		Key:         "Input",

--- a/command/completion/mobile_gateway_args_gen.go
+++ b/command/completion/mobile_gateway_args_gen.go
@@ -420,6 +420,130 @@ func MobileGatewayInterfaceDisconnectCompleteArgs(ctx command.Context, params *p
 
 }
 
+func MobileGatewayTrafficControlInfoCompleteArgs(ctx command.Context, params *params.TrafficControlInfoMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewayTrafficControlEnableCompleteArgs(ctx command.Context, params *params.TrafficControlEnableMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewayTrafficControlUpdateCompleteArgs(ctx command.Context, params *params.TrafficControlUpdateMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func MobileGatewayTrafficControlDisableCompleteArgs(ctx command.Context, params *params.TrafficControlDisableMobileGatewayParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetMobileGatewayAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.MobileGateways {
+		fmt.Println(res.MobileGateways[i].ID)
+		var target interface{} = &res.MobileGateways[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
 func MobileGatewayStaticRouteInfoCompleteArgs(ctx command.Context, params *params.StaticRouteInfoMobileGatewayParam, cur, prev, commandName string) {
 
 	if !command.GlobalOption.Valid {

--- a/command/completion/mobile_gateway_flags_gen.go
+++ b/command/completion/mobile_gateway_flags_gen.go
@@ -473,6 +473,154 @@ func MobileGatewayInterfaceDisconnectCompleteFlags(ctx command.Context, params *
 	}
 }
 
+func MobileGatewayTrafficControlInfoCompleteFlags(ctx command.Context, params *params.TrafficControlInfoMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-info"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-info"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out":
+		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewayTrafficControlEnableCompleteFlags(ctx command.Context, params *params.TrafficControlEnableMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "quota":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-enable"].BuildedParams().Get("quota")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "band-width-limit":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-enable"].BuildedParams().Get("band-width-limit")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "enable-email":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-enable"].BuildedParams().Get("enable-email")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "slack-webhook-url":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-enable"].BuildedParams().Get("slack-webhook-url")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "auto-traffic-shaping":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-enable"].BuildedParams().Get("auto-traffic-shaping")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-enable"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-enable"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewayTrafficControlUpdateCompleteFlags(ctx command.Context, params *params.TrafficControlUpdateMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "quota":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-update"].BuildedParams().Get("quota")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "band-width-limit":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-update"].BuildedParams().Get("band-width-limit")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "enable-email":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-update"].BuildedParams().Get("enable-email")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "slack-webhook-url":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-update"].BuildedParams().Get("slack-webhook-url")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "auto-traffic-shaping":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-update"].BuildedParams().Get("auto-traffic-shaping")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-update"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-update"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func MobileGatewayTrafficControlDisableCompleteFlags(ctx command.Context, params *params.TrafficControlDisableMobileGatewayParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "selector":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-disable"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["MobileGateway"].Commands["traffic-control-disable"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
 func MobileGatewayStaticRouteInfoCompleteFlags(ctx command.Context, params *params.StaticRouteInfoMobileGatewayParam, flagName string, currentValue string) {
 	var comp schema.CompletionFunc
 

--- a/command/funcs/mobile_gateway_traffic_control_disable.go
+++ b/command/funcs/mobile_gateway_traffic_control_disable.go
@@ -1,0 +1,25 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayTrafficControlDisable(ctx command.Context, params *params.TrafficControlDisableMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	_, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewayTrafficControlDisable is failed: %s", e)
+	}
+
+	// set params
+	_, err := api.DisableTrafficMonitoringConfig(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayTrafficControlDisable is failed: %s", err)
+	}
+	return nil
+}

--- a/command/funcs/mobile_gateway_traffic_control_enable.go
+++ b/command/funcs/mobile_gateway_traffic_control_enable.go
@@ -1,0 +1,46 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayTrafficControlEnable(ctx command.Context, params *params.TrafficControlEnableMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	_, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewayTrafficControlEnable is failed: %s", e)
+	}
+
+	// set params
+	config := &sacloud.TrafficMonitoringConfig{}
+	config.TrafficQuotaInMB = params.Quota
+	config.BandWidthLimitInKbps = params.BandWidthLimit
+	config.AutoTrafficShaping = params.AutoTrafficShaping
+
+	config.EMailConfig = &sacloud.TrafficMonitoringNotifyEmail{
+		Enabled: params.EnableEmail,
+	}
+
+	config.SlackConfig = &sacloud.TrafficMonitoringNotifySlack{
+		Enabled: false,
+	}
+	if params.SlackWebhookUrl != "" {
+		config.SlackConfig = &sacloud.TrafficMonitoringNotifySlack{
+			Enabled:             true,
+			IncomingWebhooksURL: params.SlackWebhookUrl,
+		}
+	}
+
+	// call Update(id)
+	if _, err := api.SetTrafficMonitoringConfig(params.Id, config); err != nil {
+		return fmt.Errorf("MobileGatewayTrafficControlEnable is failed: %s", err)
+	}
+
+	return nil
+}

--- a/command/funcs/mobile_gateway_traffic_control_info.go
+++ b/command/funcs/mobile_gateway_traffic_control_info.go
@@ -1,0 +1,46 @@
+package funcs
+
+import (
+	"fmt"
+	"net/http"
+
+	sacloudapi "github.com/sacloud/libsacloud/api"
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayTrafficControlInfo(ctx command.Context, params *params.TrafficControlInfoMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+
+	// set params
+
+	// call Read(id)
+	conf, err := api.GetTrafficMonitoringConfig(params.Id)
+	if err != nil {
+		if e, ok := err.(sacloudapi.Error); ok && e.ResponseCode() == http.StatusNotFound {
+			return fmt.Errorf("MobileGatewayTrafficControlInfo is failed: Traffic Monitoring is disabled")
+		}
+		return fmt.Errorf("MobileGatewayTrafficControlInfo is failed: %s", err)
+	}
+
+	status, err := api.GetTrafficStatus(params.Id)
+	if err != nil {
+		if e, ok := err.(sacloudapi.Error); ok && e.ResponseCode() == http.StatusNotFound {
+			return fmt.Errorf("MobileGatewayTrafficControlInfo is failed: Traffic Status Not Found")
+		}
+		return fmt.Errorf("MobileGatewayTrafficControlInfo is failed: %s", err)
+	}
+
+	info := &struct {
+		*sacloud.TrafficMonitoringConfig `json:"config,omitempty"`
+		*sacloud.TrafficStatus           `json:"status,omitempty"`
+	}{
+		TrafficMonitoringConfig: conf,
+		TrafficStatus:           status,
+	}
+
+	return ctx.GetOutput().Print(info)
+}

--- a/command/funcs/mobile_gateway_traffic_control_update.go
+++ b/command/funcs/mobile_gateway_traffic_control_update.go
@@ -1,0 +1,61 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func MobileGatewayTrafficControlUpdate(ctx command.Context, params *params.TrafficControlUpdateMobileGatewayParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetMobileGatewayAPI()
+	_, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("MobileGatewayTrafficControlUpdate is failed: %s", e)
+	}
+
+	// set params
+	config, err := api.GetTrafficMonitoringConfig(params.Id)
+	if err != nil {
+		return fmt.Errorf("MobileGatewayTrafficControlUpdate is failed: %s", err)
+	}
+
+	if ctx.IsSet("quota") {
+		config.TrafficQuotaInMB = params.Quota
+	}
+	if ctx.IsSet("band-width-limit") {
+		config.BandWidthLimitInKbps = params.BandWidthLimit
+	}
+	if ctx.IsSet("auto-traffic-shaping") {
+		config.AutoTrafficShaping = params.AutoTrafficShaping
+	}
+
+	if ctx.IsSet("enable-email") {
+		config.EMailConfig = &sacloud.TrafficMonitoringNotifyEmail{
+			Enabled: params.EnableEmail,
+		}
+	}
+
+	if ctx.IsSet("slack-webhook-url") {
+		if params.SlackWebhookUrl == "" {
+			config.SlackConfig = &sacloud.TrafficMonitoringNotifySlack{
+				Enabled: false,
+			}
+		} else {
+			config.SlackConfig = &sacloud.TrafficMonitoringNotifySlack{
+				Enabled:             true,
+				IncomingWebhooksURL: params.SlackWebhookUrl,
+			}
+		}
+	}
+
+	// call Update(id)
+	if _, err = api.SetTrafficMonitoringConfig(params.Id, config); err != nil {
+		return fmt.Errorf("MobileGatewayTrafficControlEnable is failed: %s", err)
+	}
+
+	return nil
+}

--- a/command/funcs/vpc_router_l2tp_server_info.go
+++ b/command/funcs/vpc_router_l2tp_server_info.go
@@ -26,7 +26,7 @@ func VPCRouterL2tpServerInfo(ctx command.Context, params *params.L2tpServerInfoV
 	if p.HasL2TPIPsecServer() {
 		cnf = &l2tpConf{
 			VPCRouterL2TPIPsecServerConfig: p.Settings.Router.L2TPIPsecServer.Config,
-			Enabled: p.Settings.Router.L2TPIPsecServer.Enabled,
+			Enabled:                        p.Settings.Router.L2TPIPsecServer.Enabled,
 		}
 	} else {
 		cnf = &l2tpConf{

--- a/command/params/params_mobile_gateway_gen.go
+++ b/command/params/params_mobile_gateway_gen.go
@@ -2588,6 +2588,719 @@ func (p *InterfaceDisconnectMobileGatewayParam) GetId() int64 {
 	return p.Id
 }
 
+// TrafficControlInfoMobileGatewayParam is input parameters for the sacloud API
+type TrafficControlInfoMobileGatewayParam struct {
+	Selector          []string `json:"selector"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	Id                int64    `json:"id"`
+}
+
+// NewTrafficControlInfoMobileGatewayParam return new TrafficControlInfoMobileGatewayParam
+func NewTrafficControlInfoMobileGatewayParam() *TrafficControlInfoMobileGatewayParam {
+	return &TrafficControlInfoMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *TrafficControlInfoMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *TrafficControlInfoMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["traffic-control-info"]
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetColumn() []string {
+	return p.Column
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetFormat() string {
+	return p.Format
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetQuery() string {
+	return p.Query
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// TrafficControlEnableMobileGatewayParam is input parameters for the sacloud API
+type TrafficControlEnableMobileGatewayParam struct {
+	Quota              int      `json:"quota"`
+	BandWidthLimit     int      `json:"band-width-limit"`
+	EnableEmail        bool     `json:"enable-email"`
+	SlackWebhookUrl    string   `json:"slack-webhook-url"`
+	AutoTrafficShaping bool     `json:"auto-traffic-shaping"`
+	Selector           []string `json:"selector"`
+	Assumeyes          bool     `json:"assumeyes"`
+	ParamTemplate      string   `json:"param-template"`
+	ParamTemplateFile  string   `json:"param-template-file"`
+	GenerateSkeleton   bool     `json:"generate-skeleton"`
+	Id                 int64    `json:"id"`
+}
+
+// NewTrafficControlEnableMobileGatewayParam return new TrafficControlEnableMobileGatewayParam
+func NewTrafficControlEnableMobileGatewayParam() *TrafficControlEnableMobileGatewayParam {
+	return &TrafficControlEnableMobileGatewayParam{
+
+		Quota: 512,
+	}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *TrafficControlEnableMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Quota) {
+		p.Quota = 0
+	}
+	if isEmpty(p.BandWidthLimit) {
+		p.BandWidthLimit = 0
+	}
+	if isEmpty(p.EnableEmail) {
+		p.EnableEmail = false
+	}
+	if isEmpty(p.SlackWebhookUrl) {
+		p.SlackWebhookUrl = ""
+	}
+	if isEmpty(p.AutoTrafficShaping) {
+		p.AutoTrafficShaping = false
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *TrafficControlEnableMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--quota", p.Quota)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["traffic-control-enable"].Params["quota"].ValidateFunc
+		errs := validator("--quota", p.Quota)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["traffic-control-enable"].Params["band-width-limit"].ValidateFunc
+		errs := validator("--band-width-limit", p.BandWidthLimit)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["traffic-control-enable"].Params["slack-webhook-url"].ValidateFunc
+		errs := validator("--slack-webhook-url", p.SlackWebhookUrl)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["traffic-control-enable"]
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) SetQuota(v int) {
+	p.Quota = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetQuota() int {
+	return p.Quota
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetBandWidthLimit(v int) {
+	p.BandWidthLimit = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetBandWidthLimit() int {
+	return p.BandWidthLimit
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetEnableEmail(v bool) {
+	p.EnableEmail = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetEnableEmail() bool {
+	return p.EnableEmail
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetSlackWebhookUrl(v string) {
+	p.SlackWebhookUrl = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetSlackWebhookUrl() string {
+	return p.SlackWebhookUrl
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetAutoTrafficShaping(v bool) {
+	p.AutoTrafficShaping = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetAutoTrafficShaping() bool {
+	return p.AutoTrafficShaping
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *TrafficControlEnableMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *TrafficControlEnableMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// TrafficControlUpdateMobileGatewayParam is input parameters for the sacloud API
+type TrafficControlUpdateMobileGatewayParam struct {
+	Quota              int      `json:"quota"`
+	BandWidthLimit     int      `json:"band-width-limit"`
+	EnableEmail        bool     `json:"enable-email"`
+	SlackWebhookUrl    string   `json:"slack-webhook-url"`
+	AutoTrafficShaping bool     `json:"auto-traffic-shaping"`
+	Selector           []string `json:"selector"`
+	Assumeyes          bool     `json:"assumeyes"`
+	ParamTemplate      string   `json:"param-template"`
+	ParamTemplateFile  string   `json:"param-template-file"`
+	GenerateSkeleton   bool     `json:"generate-skeleton"`
+	Id                 int64    `json:"id"`
+}
+
+// NewTrafficControlUpdateMobileGatewayParam return new TrafficControlUpdateMobileGatewayParam
+func NewTrafficControlUpdateMobileGatewayParam() *TrafficControlUpdateMobileGatewayParam {
+	return &TrafficControlUpdateMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *TrafficControlUpdateMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Quota) {
+		p.Quota = 0
+	}
+	if isEmpty(p.BandWidthLimit) {
+		p.BandWidthLimit = 0
+	}
+	if isEmpty(p.EnableEmail) {
+		p.EnableEmail = false
+	}
+	if isEmpty(p.SlackWebhookUrl) {
+		p.SlackWebhookUrl = ""
+	}
+	if isEmpty(p.AutoTrafficShaping) {
+		p.AutoTrafficShaping = false
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *TrafficControlUpdateMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := define.Resources["MobileGateway"].Commands["traffic-control-update"].Params["quota"].ValidateFunc
+		errs := validator("--quota", p.Quota)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["traffic-control-update"].Params["band-width-limit"].ValidateFunc
+		errs := validator("--band-width-limit", p.BandWidthLimit)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["MobileGateway"].Commands["traffic-control-update"].Params["slack-webhook-url"].ValidateFunc
+		errs := validator("--slack-webhook-url", p.SlackWebhookUrl)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["traffic-control-update"]
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) SetQuota(v int) {
+	p.Quota = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetQuota() int {
+	return p.Quota
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetBandWidthLimit(v int) {
+	p.BandWidthLimit = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetBandWidthLimit() int {
+	return p.BandWidthLimit
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetEnableEmail(v bool) {
+	p.EnableEmail = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetEnableEmail() bool {
+	return p.EnableEmail
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetSlackWebhookUrl(v string) {
+	p.SlackWebhookUrl = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetSlackWebhookUrl() string {
+	return p.SlackWebhookUrl
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetAutoTrafficShaping(v bool) {
+	p.AutoTrafficShaping = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetAutoTrafficShaping() bool {
+	return p.AutoTrafficShaping
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *TrafficControlUpdateMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *TrafficControlUpdateMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
+// TrafficControlDisableMobileGatewayParam is input parameters for the sacloud API
+type TrafficControlDisableMobileGatewayParam struct {
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	Id                int64    `json:"id"`
+}
+
+// NewTrafficControlDisableMobileGatewayParam return new TrafficControlDisableMobileGatewayParam
+func NewTrafficControlDisableMobileGatewayParam() *TrafficControlDisableMobileGatewayParam {
+	return &TrafficControlDisableMobileGatewayParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *TrafficControlDisableMobileGatewayParam) FillValueToSkeleton() {
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *TrafficControlDisableMobileGatewayParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetResourceDef() *schema.Resource {
+	return define.Resources["MobileGateway"]
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["traffic-control-disable"]
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *TrafficControlDisableMobileGatewayParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *TrafficControlDisableMobileGatewayParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *TrafficControlDisableMobileGatewayParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *TrafficControlDisableMobileGatewayParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *TrafficControlDisableMobileGatewayParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *TrafficControlDisableMobileGatewayParam) GetId() int64 {
+	return p.Id
+}
+
 // StaticRouteInfoMobileGatewayParam is input parameters for the sacloud API
 type StaticRouteInfoMobileGatewayParam struct {
 	Selector          []string `json:"selector"`

--- a/define/helper.go
+++ b/define/helper.go
@@ -48,6 +48,10 @@ func validateMemberCD() schema.ValidateFunc {
 	return schema.ValidateMemberCD()
 }
 
+func validateSlackWebhookURL() schema.ValidateFunc {
+	return schema.ValidateSlackWebhookURL()
+}
+
 func validateFileExists() schema.ValidateFunc {
 	return schema.ValidateFileExists()
 }

--- a/define/mobile_gateway.go
+++ b/define/mobile_gateway.go
@@ -150,6 +150,44 @@ func MobileGatewayResource() *schema.Resource {
 			Order:            40,
 			NoOutput:         true,
 		},
+		"traffic-control-info": {
+			Type:               schema.CommandRead,
+			Params:             mobileGatewayTrafficControlInfoParam(),
+			Usage:              "Show information of traffic-control",
+			TableType:          output.TableSimple,
+			TableColumnDefines: mobileGatewayTrafficControlInfoColumns(),
+			UseCustomCommand:   true,
+			Category:           "traffic-control",
+			Order:              10,
+		},
+		"traffic-control-enable": {
+			Type:             schema.CommandUpdate,
+			Params:           mobileGatewayTrafficControlCreateParam(),
+			Usage:            "Enable traffic-control",
+			NoOutput:         true,
+			UseCustomCommand: true,
+			Category:         "traffic-control",
+			Order:            20,
+		},
+		"traffic-control-update": {
+			Type:             schema.CommandUpdate,
+			Params:           mobileGatewayTrafficControlUpdateParam(),
+			Usage:            "Update traffic-control config",
+			NoOutput:         true,
+			UseCustomCommand: true,
+			Category:         "traffic-control",
+			Order:            30,
+		},
+		"traffic-control-disable": {
+			Type:             schema.CommandUpdate,
+			Aliases:          []string{"traffic-control-delete"},
+			Params:           mobileGatewayTrafficControlDeleteParam(),
+			Usage:            "Disable traffic-control config",
+			NoOutput:         true,
+			UseCustomCommand: true,
+			Category:         "traffic-control",
+			Order:            40,
+		},
 		"static-route-info": {
 			Type:               schema.CommandManipulateSingle,
 			Params:             mobileGatewayStaticRouteInfoParam(),
@@ -310,29 +348,34 @@ var MobileGatewayCommandCategories = []schema.Category{
 		Order:       30,
 	},
 	{
+		Key:         "traffic-control",
+		DisplayName: "Traffic Control",
+		Order:       40,
+	},
+	{
 		Key:         "static-route",
 		DisplayName: "StaticRoute Management",
-		Order:       40,
+		Order:       50,
 	},
 	{
 		Key:         "sim",
 		DisplayName: "SIM Management",
-		Order:       50,
+		Order:       60,
 	},
 	{
 		Key:         "sim-route",
 		DisplayName: "SIM Route Management",
-		Order:       55,
+		Order:       65,
 	},
 	{
 		Key:         "dns",
 		DisplayName: "DNS Management",
-		Order:       60,
+		Order:       70,
 	},
 	{
 		Key:         "monitor",
 		DisplayName: "Monitoring",
-		Order:       70,
+		Order:       80,
 	},
 	{
 		Key:         "other",
@@ -388,6 +431,39 @@ func mobileGatewayInterfaceListColumns() []output.ColumnDef {
 		{Name: "Switch"},
 		{Name: "IPAddress"},
 		{Name: "NetworkMaskLen"},
+	}
+}
+
+func mobileGatewayTrafficControlInfoColumns() []output.ColumnDef {
+	return []output.ColumnDef{
+		{
+			Name:    "Quota(MB)",
+			Sources: []string{"config.traffic_quota_in_mb"},
+		},
+		{
+			Name:    "Limit(Kbps)",
+			Sources: []string{"config.bandwidth_limit_in_kbps"},
+		},
+		{
+			Name:    "Email",
+			Sources: []string{"config.email_config.enabled"},
+		},
+		{
+			Name:    "Slack",
+			Sources: []string{"config.slack_config.slack_url"},
+		},
+		{
+			Name:    "TrafficShaping",
+			Sources: []string{"config.auto_traffic_shaping"},
+		},
+		{
+			Name:    "UplinkBPS",
+			Sources: []string{"status.uplink_bytes"},
+		},
+		{
+			Name:    "DownlinkBPS",
+			Sources: []string{"status.downlink_bytes"},
+		},
 	}
 }
 
@@ -629,6 +705,92 @@ func mobileGatewayInterfaceUpdateParam() map[string]*schema.Schema {
 }
 
 func mobileGatewayInterfaceDisconnectParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func mobileGatewayTrafficControlInfoParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func mobileGatewayTrafficControlCreateParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"quota": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			Required:     true,
+			DefaultValue: 512,
+			ValidateFunc: validateIntRange(1, math.MaxInt32),
+			Category:     "traffic-control",
+			Order:        10,
+		},
+		"band-width-limit": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			ValidateFunc: validateIntRange(1, math.MaxInt32),
+			Category:     "traffic-control",
+			Order:        20,
+		},
+		"enable-email": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Category:    "traffic-control",
+			Order:       30,
+		},
+		"slack-webhook-url": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Category:     "traffic-control",
+			ValidateFunc: validateSlackWebhookURL(),
+			Order:        40,
+		},
+		"auto-traffic-shaping": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Category:    "traffic-control",
+			Order:       50,
+		},
+	}
+}
+
+func mobileGatewayTrafficControlUpdateParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"quota": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			ValidateFunc: validateIntRange(1, math.MaxInt32),
+			Category:     "traffic-control",
+			Order:        10,
+		},
+		"band-width-limit": {
+			Type:         schema.TypeInt,
+			HandlerType:  schema.HandlerNoop,
+			ValidateFunc: validateIntRange(1, math.MaxInt32),
+			Category:     "traffic-control",
+			Order:        20,
+		},
+		"enable-email": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Category:    "traffic-control",
+			Order:       30,
+		},
+		"slack-webhook-url": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Category:     "traffic-control",
+			ValidateFunc: validateSlackWebhookURL(),
+			Order:        40,
+		},
+		"auto-traffic-shaping": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Category:    "traffic-control",
+			Order:       50,
+		},
+	}
+}
+
+func mobileGatewayTrafficControlDeleteParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{}
 }
 

--- a/define/sim.go
+++ b/define/sim.go
@@ -217,7 +217,7 @@ func simMonitorColumns() []output.ColumnDef {
 		{Name: "TimeStamp"},
 		{Name: "UnixTime"},
 		{Name: "UplinkBPS"},
-		{Name: "DownlingBPS"},
+		{Name: "DownlinkBPS"},
 	}
 }
 

--- a/output/simple_table_writer_test.go
+++ b/output/simple_table_writer_test.go
@@ -43,11 +43,11 @@ func newTestSimpleTableWriter(out io.Writer, columnDefs []ColumnDef) *testSimple
 
 func simpleTableTestValue() map[string]string {
 	return map[string]string{
-		"ID":                                            "999999999999",
-		"Name":                                          "TestValue",
-		"Dummy":                                         "1",
-		"Interfaces.0.IPAddress":                        "192.2.0.1",
-		"Interfaces.0.UserIPAddress":                    "192.2.0.2",
+		"ID":                         "999999999999",
+		"Name":                       "TestValue",
+		"Dummy":                      "1",
+		"Interfaces.0.IPAddress":     "192.2.0.1",
+		"Interfaces.0.UserIPAddress": "192.2.0.2",
 		"Interfaces.0.Switch.UserSubnet.NetworkMaskLen": "24",
 		"Interfaces.0.Switch.Scope":                     "shared",
 	}

--- a/schema/validators.go
+++ b/schema/validators.go
@@ -285,6 +285,30 @@ func ValidateMemberCD() ValidateFunc {
 	}
 }
 
+func ValidateSlackWebhookURL() ValidateFunc {
+	return func(fieldName string, object interface{}) []error {
+		res := []error{}
+
+		// if target is nil , return OK(Use required attr if necessary)
+		if object == nil {
+			return res
+		}
+
+		if cd, ok := object.(string); ok {
+			if cd == "" {
+				return res
+			}
+
+			r := regexp.MustCompile(`^https://hooks.slack.com/services/\w+/\w+/\w+$`)
+			if !r.MatchString(cd) {
+				res = append(res, fmt.Errorf(`%q: slack webhook url must be ^https://hooks.slack.com/services/\w+/\w+/\w+$`, fieldName))
+			}
+		}
+
+		return res
+	}
+}
+
 func ValidateFileExists() ValidateFunc {
 	return func(fieldName string, object interface{}) []error {
 		res := []error{}

--- a/schema/validators_test.go
+++ b/schema/validators_test.go
@@ -9,11 +9,11 @@ import (
 func TestValidateIPv4(t *testing.T) {
 
 	expects := map[string]bool{
-		"192.168.0.1":           true,
-		"192.168.0.1.1":         false,
-		"192.168.0.0/24":        false,
-		"2401:2500:10a:100e::1": false,
-		"fe::1":                 false,
+		"192.168.0.1":                  true,
+		"192.168.0.1.1":                false,
+		"192.168.0.0/24":               false,
+		"2401:2500:10a:100e::1":        false,
+		"fe::1":                        false,
 		"2401:2500:10a:100e::xxxxxxxx": false,
 	}
 
@@ -30,9 +30,9 @@ func TestValidateIPv4(t *testing.T) {
 func TestValidateIPv6(t *testing.T) {
 
 	expects := map[string]bool{
-		"192.168.0.1":           false,
-		"2401:2500:10a:100e::1": true,
-		"fe::1":                 true,
+		"192.168.0.1":                  false,
+		"2401:2500:10a:100e::1":        true,
+		"fe::1":                        true,
 		"2401:2500:10a:100e::xxxxxxxx": false,
 	}
 

--- a/vendor/github.com/sacloud/libsacloud/api/mobile_gateway.go
+++ b/vendor/github.com/sacloud/libsacloud/api/mobile_gateway.go
@@ -449,6 +449,15 @@ func (api *MobileGatewayAPI) SetTrafficMonitoringConfig(id int64, trafficMonConf
 	return api.modify(method, uri, req)
 }
 
+// DisableTrafficMonitoringConfig トラフィックコントロール 解除
+func (api *MobileGatewayAPI) DisableTrafficMonitoringConfig(id int64) (bool, error) {
+	var (
+		method = "DELETE"
+		uri    = fmt.Sprintf("%s/%d/mobilegateway/traffic_monitoring", api.getResourceURL(), id)
+	)
+	return api.modify(method, uri, nil)
+}
+
 // GetTrafficStatus 当月通信量 取得
 func (api *MobileGatewayAPI) GetTrafficStatus(id int64) (*sacloud.TrafficStatus, error) {
 	var (

--- a/vendor/github.com/sacloud/libsacloud/sacloud/mobile_gateway.go
+++ b/vendor/github.com/sacloud/libsacloud/sacloud/mobile_gateway.go
@@ -349,6 +349,6 @@ type TrafficMonitoringNotifyEmail struct {
 
 // TrafficMonitoringNotifySlack トラフィックコントロール通知設定
 type TrafficMonitoringNotifySlack struct {
-	Enabled             bool   `json:"enabled"`   // 有効/無効
-	IncomingWebhooksURL string `json:"slack_url"` // Slack通知の場合のWebhook URL
+	Enabled             bool   `json:"enabled"`             // 有効/無効
+	IncomingWebhooksURL string `json:"slack_url,omitempty"` // Slack通知の場合のWebhook URL
 }


### PR DESCRIPTION
モバイルゲートウェイでのトラフィックコントロール機能向けコマンドを追加する。

#### 現在の設定/通信量の表示

```bash
$ usacloud mobile-gateway traffic-control-info <ID or 名称>
+-----------+-------------+-------+----------------------------------------------+----------------+-----------+-------------+
| Quota(MB) | Limit(Kbps) | Email |                    Slack                     | TrafficShaping | UplinkBPS | DownlinkBPS |
+-----------+-------------+-------+----------------------------------------------+----------------+-----------+-------------+
| 1024      | 512         | false | https://hooks.slack.com/services/xxx/xxx/xxx | true           | 1111      | 2222        |
+-----------+-------------+-------+----------------------------------------------+----------------+-----------+-------------+
```

#### トラフィックコントロール有効化

```bash
$ usacloud mobile-gateway traffic-control-enable <オプション> <ID or 名称>
```

##### オプション

- `--quota` 通信量しきい値(単位: MB, デフォルト512)
- `--band-width-limit` 通信量閾値(単位: KB)
- `--enable-email` Eメール通知有効化
- `--slack-webhook-url` Slack通知用Webhook URL
- `--auto-traffic-shaping` 帯域制限 有効化

#### トラフィックコントロール設定変更

```bash
$ usacloud mobile-gateway traffic-control-update <オプション> <ID or 名称>
```

#### トラフィックコントロール有効化

```bash
$ usacloud mobile-gateway traffic-control-disable <ID or 名称>
```
