### PR TITLE
Usacloud Sandboxへのリンク追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@
 - Go言語で実装されたシングルバイナリ、インストールはバイナリをコピーするだけ(yum/apt/brewもサポート)
 - SSH/SCP/SFTP/VNCなどをバイナリ単体でサポート
 
-## インストール
+# 使い方
+
+## オンラインで試す
+
+ブラウザ上でUsacloudをお試しいただけます。
+
+<a href="https://sandbox.usacloud.jp" target="_blank">https://sandbox.usacloud.jp</a>
+
+## ローカルマシンにインストール
 
 ### macOS(`brew`) / Linux(`apt` or `yum` or `brew`) / bash on Windows(Ubuntu)
 

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -17,7 +17,15 @@
 - Single binary implemented in Go language. Installation method is only binary copy (yum / apt / brew is also supported).
 - Supports SSH / SCP / SFTP / VNC etc. only with "binary".
 
-## Install
+# Usage
+
+## Try `usacloud` in sandbox
+
+You can try `usacloud` by using your web browser.
+
+<a href="https://sandbox.usacloud.jp" target="_blank">https://sandbox.usacloud.jp</a>
+
+## Install on local machine
 
 ### macOS(`brew`) / Linux(`apt` or `yum` or `brew`) / bash on Windows(Ubuntu)
 


### PR DESCRIPTION
ブラウザ上でUsacloudを試せる [Usacloud Sandbox](https://sandbox.usacloud.jp)へのリンクを追加。