### PR TITLE
Use sacloud/go-jmespath

### DIFF
--- a/command/validators.go
+++ b/command/validators.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jmespath/go-jmespath"
+	"github.com/sacloud/go-jmespath"
 	"github.com/sacloud/usacloud/output"
 	"github.com/sacloud/usacloud/schema"
 )

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/huandu/xstrings v0.0.0-20151130125119-3959339b3335
 	github.com/imdario/mergo v0.3.6
 	github.com/jgautheron/goconst v0.0.0-20170703170152-9740945f5dcb // indirect
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/kisielk/errcheck v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.0.9
 	github.com/mattn/go-isatty v0.0.4
@@ -32,6 +31,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/opennota/check v0.0.0-20180911053232-0c771f5545ff // indirect
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
+	github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08
 	github.com/sacloud/libsacloud v1.6.0
 	github.com/stretchr/testify v1.2.2
 	github.com/stripe/safesql v0.0.0-20171221195208-cddf355596fe // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jgautheron/goconst v0.0.0-20170703170152-9740945f5dcb h1:D5s1HIu80AcMGcqmk7fNIVptmAubVHHaj3v5Upex6Zs=
 github.com/jgautheron/goconst v0.0.0-20170703170152-9740945f5dcb/go.mod h1:82TxjOpWQiPmywlbIaB2ZkqJoSYJdLGPgAJDvM3PbKc=
-github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
-github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/kisielk/errcheck v1.1.0 h1:ZqfnKyx9KGpRcW04j5nnPDgRgoXUeLh2YFBeFzphcA0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
@@ -76,6 +74,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht3QdNJ13Stey0hR6asicabuEqU=
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
+github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08 h1:hGFzyq3AgiEHgI9xYPrtbK466gP7AimFCjrn3nZktc8=
+github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08/go.mod h1:PLy4tK2PN6G8fxd/cCWH6db2mJGmUlflYs4ASdfNulg=
 github.com/sacloud/libsacloud v1.6.0 h1:KA3StNYYMmJXxJlj/I2d2wKUZ+qqsUa/DAD5UaovL1g=
 github.com/sacloud/libsacloud v1.6.0/go.mod h1:js4lAYJrwAUoE6xR+xw+yFtwCBII98zgFGsT6gwXd8I=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=

--- a/output/json_output.go
+++ b/output/json_output.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/bitly/go-simplejson"
-	"github.com/jmespath/go-jmespath"
+	"github.com/sacloud/go-jmespath"
 )
 
 type jsonOutput struct {


### PR DESCRIPTION
これまでは以下のようにJMESPathで集計を行う際にエラーになっていた。

```bash
$ usacloud coupon --out json --query "sum([].Discount)"

JSONOutput:Query: jmespath.Search is Failed: Invalid type for: [10 20], expected: []jmespath.jpType{"array[number]"}
```

このエラーを[sacloud/go-jmespath](https://github.com/sacloud/go-jmespath)にて修正しているため、修正後のライブラリを利用するようにする。