### PR TITLE
YAML出力オプションの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ curl -s -L https://releases.usacloud.jp/usacloud/contrib/completion/bash/usaclou
     	Enter zone[is1a/is1b/tk1a/tk1v](default:tk1a): [ENTER ZONE]
     	
     Setting Default Output Type => 
-	    Enter default-output-type[table/json/csv/tsv]: 
+	    Enter default-output-type[table/json/yaml/csv/tsv]: 
    
     Written your settings to ~/.usacloud/default/config.json
 ```
@@ -322,6 +322,9 @@ COPYRIGHT:
     # JSON形式
     $ usacloud switch ls --output-type json
 
+    # YAML形式
+    $ usacloud switch ls --output-type yaml
+     
     # CSV/TSV形式
     $ usacloud switch ls --output-type csv # or tsv
 

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -322,6 +322,9 @@ COPYRIGHT:
     # JSON format
     $ usacloud switch ls --output-type json
 
+    # YAML format
+    $ usacloud switch ls --output-type yaml
+     
     # CSV/TSV format
     $ usacloud switch ls --output-type csv # or tsv
 

--- a/build_docs/docs/start_guide.md
+++ b/build_docs/docs/start_guide.md
@@ -151,7 +151,7 @@ usacloud config
   	Enter zone[is1a/is1b/tk1a/tk1v](default:tk1a): [ゾーンを入力]
   
   Setting Default Output Type => 
-	Enter default-output-type[table/json/csv/tsv]: [デフォルトの出力形式を入力]
+	Enter default-output-type[table/json/yaml/csv/tsv]: [デフォルトの出力形式を入力]
 	
   Written your settings to ~/.usacloud/default/config.json
 ```

--- a/command/completion/archive_flags_gen.go
+++ b/command/completion/archive_flags_gen.go
@@ -61,7 +61,7 @@ func ArchiveListCompleteFlags(ctx command.Context, params *params.ListArchivePar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -117,7 +117,7 @@ func ArchiveCreateCompleteFlags(ctx command.Context, params *params.CreateArchiv
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -143,7 +143,7 @@ func ArchiveReadCompleteFlags(ctx command.Context, params *params.ReadArchivePar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -189,7 +189,7 @@ func ArchiveUpdateCompleteFlags(ctx command.Context, params *params.UpdateArchiv
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -215,7 +215,7 @@ func ArchiveDeleteCompleteFlags(ctx command.Context, params *params.DeleteArchiv
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -246,7 +246,7 @@ func ArchiveUploadCompleteFlags(ctx command.Context, params *params.UploadArchiv
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -301,7 +301,7 @@ func ArchiveFtpOpenCompleteFlags(ctx command.Context, params *params.FtpOpenArch
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/auth_status_flags_gen.go
+++ b/command/completion/auth_status_flags_gen.go
@@ -15,7 +15,7 @@ func AuthStatusShowCompleteFlags(ctx command.Context, params *params.ShowAuthSta
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/auto_backup_flags_gen.go
+++ b/command/completion/auto_backup_flags_gen.go
@@ -46,7 +46,7 @@ func AutoBackupListCompleteFlags(ctx command.Context, params *params.ListAutoBac
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -97,7 +97,7 @@ func AutoBackupCreateCompleteFlags(ctx command.Context, params *params.CreateAut
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -123,7 +123,7 @@ func AutoBackupReadCompleteFlags(ctx command.Context, params *params.ReadAutoBac
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -179,7 +179,7 @@ func AutoBackupUpdateCompleteFlags(ctx command.Context, params *params.UpdateAut
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -205,7 +205,7 @@ func AutoBackupDeleteCompleteFlags(ctx command.Context, params *params.DeleteAut
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/bill_flags_gen.go
+++ b/command/completion/bill_flags_gen.go
@@ -21,7 +21,7 @@ func BillCsvCompleteFlags(ctx command.Context, params *params.CsvBillParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -47,7 +47,7 @@ func BillListCompleteFlags(ctx command.Context, params *params.ListBillParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/bridge_flags_gen.go
+++ b/command/completion/bridge_flags_gen.go
@@ -41,7 +41,7 @@ func BridgeListCompleteFlags(ctx command.Context, params *params.ListBridgeParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -67,7 +67,7 @@ func BridgeCreateCompleteFlags(ctx command.Context, params *params.CreateBridgeP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -88,7 +88,7 @@ func BridgeReadCompleteFlags(ctx command.Context, params *params.ReadBridgeParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -119,7 +119,7 @@ func BridgeUpdateCompleteFlags(ctx command.Context, params *params.UpdateBridgeP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -140,7 +140,7 @@ func BridgeDeleteCompleteFlags(ctx command.Context, params *params.DeleteBridgeP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/coupon_flags_gen.go
+++ b/command/completion/coupon_flags_gen.go
@@ -15,7 +15,7 @@ func CouponListCompleteFlags(ctx command.Context, params *params.ListCouponParam
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/database_flags_gen.go
+++ b/command/completion/database_flags_gen.go
@@ -46,7 +46,7 @@ func DatabaseListCompleteFlags(ctx command.Context, params *params.ListDatabaseP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -157,7 +157,7 @@ func DatabaseCreateCompleteFlags(ctx command.Context, params *params.CreateDatab
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -183,7 +183,7 @@ func DatabaseReadCompleteFlags(ctx command.Context, params *params.ReadDatabaseP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -274,7 +274,7 @@ func DatabaseUpdateCompleteFlags(ctx command.Context, params *params.UpdateDatab
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -305,7 +305,7 @@ func DatabaseDeleteCompleteFlags(ctx command.Context, params *params.DeleteDatab
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -475,7 +475,7 @@ func DatabaseBackupInfoCompleteFlags(ctx command.Context, params *params.BackupI
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -496,7 +496,7 @@ func DatabaseBackupCreateCompleteFlags(ctx command.Context, params *params.Backu
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -522,7 +522,7 @@ func DatabaseBackupRestoreCompleteFlags(ctx command.Context, params *params.Back
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -548,7 +548,7 @@ func DatabaseBackupLockCompleteFlags(ctx command.Context, params *params.BackupL
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -574,7 +574,7 @@ func DatabaseBackupUnlockCompleteFlags(ctx command.Context, params *params.Backu
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -600,7 +600,7 @@ func DatabaseBackupRemoveCompleteFlags(ctx command.Context, params *params.Backu
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -701,7 +701,7 @@ func DatabaseCloneCompleteFlags(ctx command.Context, params *params.CloneDatabas
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -762,7 +762,7 @@ func DatabaseReplicaCreateCompleteFlags(ctx command.Context, params *params.Repl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -803,7 +803,7 @@ func DatabaseMonitorCpuCompleteFlags(ctx command.Context, params *params.Monitor
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -844,7 +844,7 @@ func DatabaseMonitorMemoryCompleteFlags(ctx command.Context, params *params.Moni
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -885,7 +885,7 @@ func DatabaseMonitorNicCompleteFlags(ctx command.Context, params *params.Monitor
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -926,7 +926,7 @@ func DatabaseMonitorSystemDiskCompleteFlags(ctx command.Context, params *params.
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -967,7 +967,7 @@ func DatabaseMonitorBackupDiskCompleteFlags(ctx command.Context, params *params.
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1008,7 +1008,7 @@ func DatabaseMonitorSystemDiskSizeCompleteFlags(ctx command.Context, params *par
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1049,7 +1049,7 @@ func DatabaseMonitorBackupDiskSizeCompleteFlags(ctx command.Context, params *par
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/disk_flags_gen.go
+++ b/command/completion/disk_flags_gen.go
@@ -66,7 +66,7 @@ func DiskListCompleteFlags(ctx command.Context, params *params.ListDiskParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -132,7 +132,7 @@ func DiskCreateCompleteFlags(ctx command.Context, params *params.CreateDiskParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -158,7 +158,7 @@ func DiskReadCompleteFlags(ctx command.Context, params *params.ReadDiskParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -209,7 +209,7 @@ func DiskUpdateCompleteFlags(ctx command.Context, params *params.UpdateDiskParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -235,7 +235,7 @@ func DiskDeleteCompleteFlags(ctx command.Context, params *params.DeleteDiskParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -301,7 +301,7 @@ func DiskEditCompleteFlags(ctx command.Context, params *params.EditDiskParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -492,7 +492,7 @@ func DiskMonitorCompleteFlags(ctx command.Context, params *params.MonitorDiskPar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/dns_flags_gen.go
+++ b/command/completion/dns_flags_gen.go
@@ -46,7 +46,7 @@ func DNSListCompleteFlags(ctx command.Context, params *params.ListDNSParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -82,7 +82,7 @@ func DNSRecordInfoCompleteFlags(ctx command.Context, params *params.RecordInfoDN
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -118,7 +118,7 @@ func DNSCreateCompleteFlags(ctx command.Context, params *params.CreateDNSParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -189,7 +189,7 @@ func DNSRecordAddCompleteFlags(ctx command.Context, params *params.RecordAddDNSP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -215,7 +215,7 @@ func DNSReadCompleteFlags(ctx command.Context, params *params.ReadDNSParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -291,7 +291,7 @@ func DNSRecordUpdateCompleteFlags(ctx command.Context, params *params.RecordUpda
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -322,7 +322,7 @@ func DNSRecordDeleteCompleteFlags(ctx command.Context, params *params.RecordDele
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -363,7 +363,7 @@ func DNSUpdateCompleteFlags(ctx command.Context, params *params.UpdateDNSParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -389,7 +389,7 @@ func DNSDeleteCompleteFlags(ctx command.Context, params *params.DeleteDNSParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/gslb_flags_gen.go
+++ b/command/completion/gslb_flags_gen.go
@@ -46,7 +46,7 @@ func GSLBListCompleteFlags(ctx command.Context, params *params.ListGSLBParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -72,7 +72,7 @@ func GSLBServerInfoCompleteFlags(ctx command.Context, params *params.ServerInfoG
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -148,7 +148,7 @@ func GSLBCreateCompleteFlags(ctx command.Context, params *params.CreateGSLBParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -189,7 +189,7 @@ func GSLBServerAddCompleteFlags(ctx command.Context, params *params.ServerAddGSL
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -215,7 +215,7 @@ func GSLBReadCompleteFlags(ctx command.Context, params *params.ReadGSLBParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -261,7 +261,7 @@ func GSLBServerUpdateCompleteFlags(ctx command.Context, params *params.ServerUpd
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -292,7 +292,7 @@ func GSLBServerDeleteCompleteFlags(ctx command.Context, params *params.ServerDel
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -378,7 +378,7 @@ func GSLBUpdateCompleteFlags(ctx command.Context, params *params.UpdateGSLBParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -404,7 +404,7 @@ func GSLBDeleteCompleteFlags(ctx command.Context, params *params.DeleteGSLBParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/icon_flags_gen.go
+++ b/command/completion/icon_flags_gen.go
@@ -51,7 +51,7 @@ func IconListCompleteFlags(ctx command.Context, params *params.ListIconParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -82,7 +82,7 @@ func IconCreateCompleteFlags(ctx command.Context, params *params.CreateIconParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -108,7 +108,7 @@ func IconReadCompleteFlags(ctx command.Context, params *params.ReadIconParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -144,7 +144,7 @@ func IconUpdateCompleteFlags(ctx command.Context, params *params.UpdateIconParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -170,7 +170,7 @@ func IconDeleteCompleteFlags(ctx command.Context, params *params.DeleteIconParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/interface_flags_gen.go
+++ b/command/completion/interface_flags_gen.go
@@ -41,7 +41,7 @@ func InterfaceListCompleteFlags(ctx command.Context, params *params.ListInterfac
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -86,7 +86,7 @@ func InterfaceCreateCompleteFlags(ctx command.Context, params *params.CreateInte
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -131,7 +131,7 @@ func InterfaceReadCompleteFlags(ctx command.Context, params *params.ReadInterfac
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -157,7 +157,7 @@ func InterfaceUpdateCompleteFlags(ctx command.Context, params *params.UpdateInte
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -178,7 +178,7 @@ func InterfaceDeleteCompleteFlags(ctx command.Context, params *params.DeleteInte
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/internet_flags_gen.go
+++ b/command/completion/internet_flags_gen.go
@@ -46,7 +46,7 @@ func InternetListCompleteFlags(ctx command.Context, params *params.ListInternetP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -92,7 +92,7 @@ func InternetCreateCompleteFlags(ctx command.Context, params *params.CreateInter
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -118,7 +118,7 @@ func InternetReadCompleteFlags(ctx command.Context, params *params.ReadInternetP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -169,7 +169,7 @@ func InternetUpdateCompleteFlags(ctx command.Context, params *params.UpdateInter
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -195,7 +195,7 @@ func InternetDeleteCompleteFlags(ctx command.Context, params *params.DeleteInter
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -226,7 +226,7 @@ func InternetUpdateBandwidthCompleteFlags(ctx command.Context, params *params.Up
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -252,7 +252,7 @@ func InternetSubnetInfoCompleteFlags(ctx command.Context, params *params.SubnetI
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -288,7 +288,7 @@ func InternetSubnetAddCompleteFlags(ctx command.Context, params *params.SubnetAd
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -353,7 +353,7 @@ func InternetSubnetUpdateCompleteFlags(ctx command.Context, params *params.Subne
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -379,7 +379,7 @@ func InternetIpv6InfoCompleteFlags(ctx command.Context, params *params.Ipv6InfoI
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -405,7 +405,7 @@ func InternetIpv6EnableCompleteFlags(ctx command.Context, params *params.Ipv6Ena
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -470,7 +470,7 @@ func InternetMonitorCompleteFlags(ctx command.Context, params *params.MonitorInt
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/ipv4_flags_gen.go
+++ b/command/completion/ipv4_flags_gen.go
@@ -41,7 +41,7 @@ func Ipv4ListCompleteFlags(ctx command.Context, params *params.ListIpv4Param, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -62,7 +62,7 @@ func Ipv4PtrAddCompleteFlags(ctx command.Context, params *params.PtrAddIpv4Param
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -78,7 +78,7 @@ func Ipv4PtrReadCompleteFlags(ctx command.Context, params *params.PtrReadIpv4Par
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -99,7 +99,7 @@ func Ipv4PtrUpdateCompleteFlags(ctx command.Context, params *params.PtrUpdateIpv
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -115,7 +115,7 @@ func Ipv4PtrDeleteCompleteFlags(ctx command.Context, params *params.PtrDeleteIpv
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/ipv6_flags_gen.go
+++ b/command/completion/ipv6_flags_gen.go
@@ -51,7 +51,7 @@ func Ipv6ListCompleteFlags(ctx command.Context, params *params.ListIpv6Param, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -72,7 +72,7 @@ func Ipv6PtrAddCompleteFlags(ctx command.Context, params *params.PtrAddIpv6Param
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -88,7 +88,7 @@ func Ipv6PtrReadCompleteFlags(ctx command.Context, params *params.PtrReadIpv6Par
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -109,7 +109,7 @@ func Ipv6PtrUpdateCompleteFlags(ctx command.Context, params *params.PtrUpdateIpv
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -125,7 +125,7 @@ func Ipv6PtrDeleteCompleteFlags(ctx command.Context, params *params.PtrDeleteIpv
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/iso_image_flags_gen.go
+++ b/command/completion/iso_image_flags_gen.go
@@ -51,7 +51,7 @@ func ISOImageListCompleteFlags(ctx command.Context, params *params.ListISOImageP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -97,7 +97,7 @@ func ISOImageCreateCompleteFlags(ctx command.Context, params *params.CreateISOIm
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -123,7 +123,7 @@ func ISOImageReadCompleteFlags(ctx command.Context, params *params.ReadISOImageP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -169,7 +169,7 @@ func ISOImageUpdateCompleteFlags(ctx command.Context, params *params.UpdateISOIm
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -195,7 +195,7 @@ func ISOImageDeleteCompleteFlags(ctx command.Context, params *params.DeleteISOIm
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -226,7 +226,7 @@ func ISOImageUploadCompleteFlags(ctx command.Context, params *params.UploadISOIm
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -281,7 +281,7 @@ func ISOImageFtpOpenCompleteFlags(ctx command.Context, params *params.FtpOpenISO
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/license_flags_gen.go
+++ b/command/completion/license_flags_gen.go
@@ -41,7 +41,7 @@ func LicenseListCompleteFlags(ctx command.Context, params *params.ListLicensePar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -67,7 +67,7 @@ func LicenseCreateCompleteFlags(ctx command.Context, params *params.CreateLicens
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -88,7 +88,7 @@ func LicenseReadCompleteFlags(ctx command.Context, params *params.ReadLicensePar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -114,7 +114,7 @@ func LicenseUpdateCompleteFlags(ctx command.Context, params *params.UpdateLicens
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -135,7 +135,7 @@ func LicenseDeleteCompleteFlags(ctx command.Context, params *params.DeleteLicens
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/load_balancer_flags_gen.go
+++ b/command/completion/load_balancer_flags_gen.go
@@ -46,7 +46,7 @@ func LoadBalancerListCompleteFlags(ctx command.Context, params *params.ListLoadB
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -122,7 +122,7 @@ func LoadBalancerCreateCompleteFlags(ctx command.Context, params *params.CreateL
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -148,7 +148,7 @@ func LoadBalancerReadCompleteFlags(ctx command.Context, params *params.ReadLoadB
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -194,7 +194,7 @@ func LoadBalancerUpdateCompleteFlags(ctx command.Context, params *params.UpdateL
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -225,7 +225,7 @@ func LoadBalancerDeleteCompleteFlags(ctx command.Context, params *params.DeleteL
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -395,7 +395,7 @@ func LoadBalancerVipInfoCompleteFlags(ctx command.Context, params *params.VipInf
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -568,7 +568,7 @@ func LoadBalancerServerInfoCompleteFlags(ctx command.Context, params *params.Ser
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -781,7 +781,7 @@ func LoadBalancerMonitorCompleteFlags(ctx command.Context, params *params.Monito
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/mobile_gateway_flags_gen.go
+++ b/command/completion/mobile_gateway_flags_gen.go
@@ -46,7 +46,7 @@ func MobileGatewayListCompleteFlags(ctx command.Context, params *params.ListMobi
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -87,7 +87,7 @@ func MobileGatewayCreateCompleteFlags(ctx command.Context, params *params.Create
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -113,7 +113,7 @@ func MobileGatewayReadCompleteFlags(ctx command.Context, params *params.ReadMobi
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -164,7 +164,7 @@ func MobileGatewayUpdateCompleteFlags(ctx command.Context, params *params.Update
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -195,7 +195,7 @@ func MobileGatewayDeleteCompleteFlags(ctx command.Context, params *params.Delete
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -365,7 +365,7 @@ func MobileGatewayInterfaceInfoCompleteFlags(ctx command.Context, params *params
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -488,7 +488,7 @@ func MobileGatewayTrafficControlInfoCompleteFlags(ctx command.Context, params *p
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -636,7 +636,7 @@ func MobileGatewayStaticRouteInfoCompleteFlags(ctx command.Context, params *para
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -764,7 +764,7 @@ func MobileGatewaySimInfoCompleteFlags(ctx command.Context, params *params.SimIn
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -887,7 +887,7 @@ func MobileGatewaySimRouteInfoCompleteFlags(ctx command.Context, params *params.
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/nfs_flags_gen.go
+++ b/command/completion/nfs_flags_gen.go
@@ -46,7 +46,7 @@ func NFSListCompleteFlags(ctx command.Context, params *params.ListNFSParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -107,7 +107,7 @@ func NFSCreateCompleteFlags(ctx command.Context, params *params.CreateNFSParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -133,7 +133,7 @@ func NFSReadCompleteFlags(ctx command.Context, params *params.ReadNFSParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -179,7 +179,7 @@ func NFSUpdateCompleteFlags(ctx command.Context, params *params.UpdateNFSParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -210,7 +210,7 @@ func NFSDeleteCompleteFlags(ctx command.Context, params *params.DeleteNFSParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -395,7 +395,7 @@ func NFSMonitorNicCompleteFlags(ctx command.Context, params *params.MonitorNicNF
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -436,7 +436,7 @@ func NFSMonitorFreeDiskSizeCompleteFlags(ctx command.Context, params *params.Mon
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/object_storage_flags_gen.go
+++ b/command/completion/object_storage_flags_gen.go
@@ -31,7 +31,7 @@ func ObjectStorageListCompleteFlags(ctx command.Context, params *params.ListObje
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/packet_filter_flags_gen.go
+++ b/command/completion/packet_filter_flags_gen.go
@@ -41,7 +41,7 @@ func PacketFilterListCompleteFlags(ctx command.Context, params *params.ListPacke
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -67,7 +67,7 @@ func PacketFilterCreateCompleteFlags(ctx command.Context, params *params.CreateP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -88,7 +88,7 @@ func PacketFilterReadCompleteFlags(ctx command.Context, params *params.ReadPacke
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -119,7 +119,7 @@ func PacketFilterUpdateCompleteFlags(ctx command.Context, params *params.UpdateP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -140,7 +140,7 @@ func PacketFilterDeleteCompleteFlags(ctx command.Context, params *params.DeleteP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -161,7 +161,7 @@ func PacketFilterRuleInfoCompleteFlags(ctx command.Context, params *params.RuleI
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -217,7 +217,7 @@ func PacketFilterRuleAddCompleteFlags(ctx command.Context, params *params.RuleAd
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -273,7 +273,7 @@ func PacketFilterRuleUpdateCompleteFlags(ctx command.Context, params *params.Rul
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -299,7 +299,7 @@ func PacketFilterRuleDeleteCompleteFlags(ctx command.Context, params *params.Rul
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/price_flags_gen.go
+++ b/command/completion/price_flags_gen.go
@@ -41,7 +41,7 @@ func PriceListCompleteFlags(ctx command.Context, params *params.ListPriceParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/private_host_flags_gen.go
+++ b/command/completion/private_host_flags_gen.go
@@ -46,7 +46,7 @@ func PrivateHostListCompleteFlags(ctx command.Context, params *params.ListPrivat
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -82,7 +82,7 @@ func PrivateHostCreateCompleteFlags(ctx command.Context, params *params.CreatePr
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -108,7 +108,7 @@ func PrivateHostReadCompleteFlags(ctx command.Context, params *params.ReadPrivat
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -154,7 +154,7 @@ func PrivateHostUpdateCompleteFlags(ctx command.Context, params *params.UpdatePr
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -180,7 +180,7 @@ func PrivateHostDeleteCompleteFlags(ctx command.Context, params *params.DeletePr
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -206,7 +206,7 @@ func PrivateHostServerInfoCompleteFlags(ctx command.Context, params *params.Serv
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -237,7 +237,7 @@ func PrivateHostServerAddCompleteFlags(ctx command.Context, params *params.Serve
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -268,7 +268,7 @@ func PrivateHostServerDeleteCompleteFlags(ctx command.Context, params *params.Se
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/product_disk_flags_gen.go
+++ b/command/completion/product_disk_flags_gen.go
@@ -41,7 +41,7 @@ func ProductDiskListCompleteFlags(ctx command.Context, params *params.ListProduc
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -62,7 +62,7 @@ func ProductDiskReadCompleteFlags(ctx command.Context, params *params.ReadProduc
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/product_internet_flags_gen.go
+++ b/command/completion/product_internet_flags_gen.go
@@ -41,7 +41,7 @@ func ProductInternetListCompleteFlags(ctx command.Context, params *params.ListPr
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -62,7 +62,7 @@ func ProductInternetReadCompleteFlags(ctx command.Context, params *params.ReadPr
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/product_license_flags_gen.go
+++ b/command/completion/product_license_flags_gen.go
@@ -41,7 +41,7 @@ func ProductLicenseListCompleteFlags(ctx command.Context, params *params.ListPro
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -62,7 +62,7 @@ func ProductLicenseReadCompleteFlags(ctx command.Context, params *params.ReadPro
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/product_server_flags_gen.go
+++ b/command/completion/product_server_flags_gen.go
@@ -41,7 +41,7 @@ func ProductServerListCompleteFlags(ctx command.Context, params *params.ListProd
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -62,7 +62,7 @@ func ProductServerReadCompleteFlags(ctx command.Context, params *params.ReadProd
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/region_flags_gen.go
+++ b/command/completion/region_flags_gen.go
@@ -41,7 +41,7 @@ func RegionListCompleteFlags(ctx command.Context, params *params.ListRegionParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -62,7 +62,7 @@ func RegionReadCompleteFlags(ctx command.Context, params *params.ReadRegionParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/server_flags_gen.go
+++ b/command/completion/server_flags_gen.go
@@ -46,7 +46,7 @@ func ServerListCompleteFlags(ctx command.Context, params *params.ListServerParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -267,7 +267,7 @@ func ServerBuildCompleteFlags(ctx command.Context, params *params.BuildServerPar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -293,7 +293,7 @@ func ServerReadCompleteFlags(ctx command.Context, params *params.ReadServerParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -344,7 +344,7 @@ func ServerUpdateCompleteFlags(ctx command.Context, params *params.UpdateServerP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -380,7 +380,7 @@ func ServerDeleteCompleteFlags(ctx command.Context, params *params.DeleteServerP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -416,7 +416,7 @@ func ServerPlanChangeCompleteFlags(ctx command.Context, params *params.PlanChang
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -606,7 +606,7 @@ func ServerSshCompleteFlags(ctx command.Context, params *params.SshServerParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -647,7 +647,7 @@ func ServerSshExecCompleteFlags(ctx command.Context, params *params.SshExecServe
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -688,7 +688,7 @@ func ServerScpCompleteFlags(ctx command.Context, params *params.ScpServerParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -748,7 +748,7 @@ func ServerVncInfoCompleteFlags(ctx command.Context, params *params.VncInfoServe
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -799,7 +799,7 @@ func ServerVncSendCompleteFlags(ctx command.Context, params *params.VncSendServe
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -835,7 +835,7 @@ func ServerVncSnapshotCompleteFlags(ctx command.Context, params *params.VncSnaps
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -905,7 +905,7 @@ func ServerRemoteDesktopInfoCompleteFlags(ctx command.Context, params *params.Re
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -931,7 +931,7 @@ func ServerDiskInfoCompleteFlags(ctx command.Context, params *params.DiskInfoSer
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1015,7 +1015,7 @@ func ServerInterfaceInfoCompleteFlags(ctx command.Context, params *params.Interf
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1192,7 +1192,7 @@ func ServerIsoInfoCompleteFlags(ctx command.Context, params *params.IsoInfoServe
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1316,7 +1316,7 @@ func ServerMonitorCpuCompleteFlags(ctx command.Context, params *params.MonitorCp
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1362,7 +1362,7 @@ func ServerMonitorNicCompleteFlags(ctx command.Context, params *params.MonitorNi
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1408,7 +1408,7 @@ func ServerMonitorDiskCompleteFlags(ctx command.Context, params *params.MonitorD
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1424,7 +1424,7 @@ func ServerMaintenanceInfoCompleteFlags(ctx command.Context, params *params.Main
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/sim_flags_gen.go
+++ b/command/completion/sim_flags_gen.go
@@ -46,7 +46,7 @@ func SIMListCompleteFlags(ctx command.Context, params *params.ListSIMParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -107,7 +107,7 @@ func SIMCreateCompleteFlags(ctx command.Context, params *params.CreateSIMParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -133,7 +133,7 @@ func SIMReadCompleteFlags(ctx command.Context, params *params.ReadSIMParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -179,7 +179,7 @@ func SIMUpdateCompleteFlags(ctx command.Context, params *params.UpdateSIMParam, 
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -234,7 +234,7 @@ func SIMCarrierInfoCompleteFlags(ctx command.Context, params *params.CarrierInfo
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -453,7 +453,7 @@ func SIMLogsCompleteFlags(ctx command.Context, params *params.LogsSIMParam, flag
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -494,7 +494,7 @@ func SIMMonitorCompleteFlags(ctx command.Context, params *params.MonitorSIMParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/simple_monitor_flags_gen.go
+++ b/command/completion/simple_monitor_flags_gen.go
@@ -51,7 +51,7 @@ func SimpleMonitorListCompleteFlags(ctx command.Context, params *params.ListSimp
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -167,7 +167,7 @@ func SimpleMonitorCreateCompleteFlags(ctx command.Context, params *params.Create
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -193,7 +193,7 @@ func SimpleMonitorReadCompleteFlags(ctx command.Context, params *params.ReadSimp
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -314,7 +314,7 @@ func SimpleMonitorUpdateCompleteFlags(ctx command.Context, params *params.Update
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -340,7 +340,7 @@ func SimpleMonitorDeleteCompleteFlags(ctx command.Context, params *params.Delete
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -366,7 +366,7 @@ func SimpleMonitorHealthCompleteFlags(ctx command.Context, params *params.Health
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/ssh_key_flags_gen.go
+++ b/command/completion/ssh_key_flags_gen.go
@@ -41,7 +41,7 @@ func SSHKeyListCompleteFlags(ctx command.Context, params *params.ListSSHKeyParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -72,7 +72,7 @@ func SSHKeyCreateCompleteFlags(ctx command.Context, params *params.CreateSSHKeyP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -93,7 +93,7 @@ func SSHKeyReadCompleteFlags(ctx command.Context, params *params.ReadSSHKeyParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -124,7 +124,7 @@ func SSHKeyUpdateCompleteFlags(ctx command.Context, params *params.UpdateSSHKeyP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -145,7 +145,7 @@ func SSHKeyDeleteCompleteFlags(ctx command.Context, params *params.DeleteSSHKeyP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -176,7 +176,7 @@ func SSHKeyGenerateCompleteFlags(ctx command.Context, params *params.GenerateSSH
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/startup_script_flags_gen.go
+++ b/command/completion/startup_script_flags_gen.go
@@ -56,7 +56,7 @@ func StartupScriptListCompleteFlags(ctx command.Context, params *params.ListStar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -102,7 +102,7 @@ func StartupScriptCreateCompleteFlags(ctx command.Context, params *params.Create
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -128,7 +128,7 @@ func StartupScriptReadCompleteFlags(ctx command.Context, params *params.ReadStar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -184,7 +184,7 @@ func StartupScriptUpdateCompleteFlags(ctx command.Context, params *params.Update
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -210,7 +210,7 @@ func StartupScriptDeleteCompleteFlags(ctx command.Context, params *params.Delete
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/summary_flags_gen.go
+++ b/command/completion/summary_flags_gen.go
@@ -21,7 +21,7 @@ func SummaryShowCompleteFlags(ctx command.Context, params *params.ShowSummaryPar
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/switch_flags_gen.go
+++ b/command/completion/switch_flags_gen.go
@@ -46,7 +46,7 @@ func SwitchListCompleteFlags(ctx command.Context, params *params.ListSwitchParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -82,7 +82,7 @@ func SwitchCreateCompleteFlags(ctx command.Context, params *params.CreateSwitchP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -108,7 +108,7 @@ func SwitchReadCompleteFlags(ctx command.Context, params *params.ReadSwitchParam
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -154,7 +154,7 @@ func SwitchUpdateCompleteFlags(ctx command.Context, params *params.UpdateSwitchP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -180,7 +180,7 @@ func SwitchDeleteCompleteFlags(ctx command.Context, params *params.DeleteSwitchP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/vpc_router_flags_gen.go
+++ b/command/completion/vpc_router_flags_gen.go
@@ -46,7 +46,7 @@ func VPCRouterListCompleteFlags(ctx command.Context, params *params.ListVPCRoute
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -122,7 +122,7 @@ func VPCRouterCreateCompleteFlags(ctx command.Context, params *params.CreateVPCR
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -148,7 +148,7 @@ func VPCRouterReadCompleteFlags(ctx command.Context, params *params.ReadVPCRoute
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -204,7 +204,7 @@ func VPCRouterUpdateCompleteFlags(ctx command.Context, params *params.UpdateVPCR
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -235,7 +235,7 @@ func VPCRouterDeleteCompleteFlags(ctx command.Context, params *params.DeleteVPCR
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -453,7 +453,7 @@ func VPCRouterInterfaceInfoCompleteFlags(ctx command.Context, params *params.Int
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -636,7 +636,7 @@ func VPCRouterStaticNatInfoCompleteFlags(ctx command.Context, params *params.Sta
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -774,7 +774,7 @@ func VPCRouterPortForwardingInfoCompleteFlags(ctx command.Context, params *param
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -942,7 +942,7 @@ func VPCRouterFirewallInfoCompleteFlags(ctx command.Context, params *params.Fire
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1160,7 +1160,7 @@ func VPCRouterDhcpServerInfoCompleteFlags(ctx command.Context, params *params.Dh
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1303,7 +1303,7 @@ func VPCRouterDhcpStaticMappingInfoCompleteFlags(ctx command.Context, params *pa
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1431,7 +1431,7 @@ func VPCRouterPptpServerInfoCompleteFlags(ctx command.Context, params *params.Pp
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1496,7 +1496,7 @@ func VPCRouterL2tpServerInfoCompleteFlags(ctx command.Context, params *params.L2
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1566,7 +1566,7 @@ func VPCRouterUserInfoCompleteFlags(ctx command.Context, params *params.UserInfo
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1694,7 +1694,7 @@ func VPCRouterSiteToSiteVpnInfoCompleteFlags(ctx command.Context, params *params
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1852,7 +1852,7 @@ func VPCRouterSiteToSiteVpnPeersCompleteFlags(ctx command.Context, params *param
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -1878,7 +1878,7 @@ func VPCRouterStaticRouteInfoCompleteFlags(ctx command.Context, params *params.S
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -2026,7 +2026,7 @@ func VPCRouterMonitorCompleteFlags(ctx command.Context, params *params.MonitorVP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/web_accel_flags_gen.go
+++ b/command/completion/web_accel_flags_gen.go
@@ -16,7 +16,7 @@ func WebAccelListCompleteFlags(ctx command.Context, params *params.ListWebAccelP
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -42,7 +42,7 @@ func WebAccelReadCompleteFlags(ctx command.Context, params *params.ReadWebAccelP
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -68,7 +68,7 @@ func WebAccelCertificateInfoCompleteFlags(ctx command.Context, params *params.Ce
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -114,7 +114,7 @@ func WebAccelCertificateUpdateCompleteFlags(ctx command.Context, params *params.
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -130,7 +130,7 @@ func WebAccelDeleteCacheCompleteFlags(ctx command.Context, params *params.Delete
 
 	switch flagName {
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/completion/zone_flags_gen.go
+++ b/command/completion/zone_flags_gen.go
@@ -41,7 +41,7 @@ func ZoneListCompleteFlags(ctx command.Context, params *params.ListZoneParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {
@@ -62,7 +62,7 @@ func ZoneReadCompleteFlags(ctx command.Context, params *params.ReadZoneParam, fl
 			comp = param.Param.CompleteFunc
 		}
 	case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 	}
 
 	if comp != nil {

--- a/command/functions.go
+++ b/command/functions.go
@@ -130,6 +130,8 @@ func getOutputWriter(formatter output.Formatter) output.Output {
 		return output.NewRowOutput(o.Out, o.Err, '\t', formatter)
 	case "json":
 		return output.NewJSONOutput(o.Out, o.Err, formatter.GetQuery())
+	case "yaml":
+		return output.NewYAMLOutput(o.Out, o.Err)
 	default:
 		return output.NewTableOutput(o.Out, o.Err, formatter)
 	}

--- a/define/config.go
+++ b/define/config.go
@@ -74,7 +74,7 @@ func ConfigResource() *schema.Resource {
 }
 
 var AllowZones = []string{"is1a", "is1b", "tk1a", "tk1v"}
-var AllowOutputTypes = []string{"table", "json", "csv", "tsv"}
+var AllowOutputTypes = []string{"table", "json", "yaml", "csv", "tsv"}
 
 func configEditParam() map[string]*schema.Schema {
 	return map[string]*schema.Schema{

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/client9/misspell v0.3.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/golang/lint v0.0.0-20181011164241-5906bd5c48cd // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc // indirect
 	github.com/hnakamur/go-scp v0.0.0-20170731142846-05a5990ec145

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/golang/lint v0.0.0-20181011164241-5906bd5c48cd h1:2WNmitqm02ZiaCMKIFDfB9dn7A038B/AFoWT2DtgPCQ=
 github.com/golang/lint v0.0.0-20181011164241-5906bd5c48cd/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc h1:cJlkeAx1QYgO5N80aF5xRGstVsRQwgLR7uA2FnP1ZjY=
@@ -125,8 +127,11 @@ golang.org/x/tools v0.0.0-20181220024903-92cdcd90bf52 h1:oOIe9Zzq27JsS/3ACpGF1Hw
 golang.org/x/tools v0.0.0-20181220024903-92cdcd90bf52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190124215303-cc6a436ffe6b h1:QhDb4isMLF+1hiAgAqj1YPRPQh+eAqwfG6wJzp57Iuo=
 golang.org/x/tools v0.0.0-20190124215303-cc6a436ffe6b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/urfave/cli.v2 v2.0.0-20170215051800-04b2f4ff79cf h1:G7OVLwGrS4CUJzmi9HF7fMqpRRMll5jFYROQL8x3MrA=
 gopkg.in/urfave/cli.v2 v2.0.0-20170215051800-04b2f4ff79cf/go.mod h1:cKXr3E0k4aosgycml1b5z33BVV6hai1Kh7uDgFOkbcs=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3 h1:LyX67rVB0kBUFoROrQfzKwdrYLH1cRzHibxdJW85J1c=
 honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed h1:WX1yoOaKQfddO/mLzdV4wptyWgoH/6hwLs7QHTixo0I=

--- a/output/yaml_output.go
+++ b/output/yaml_output.go
@@ -1,0 +1,45 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/ghodss/yaml"
+)
+
+type yamlOutput struct {
+	out   io.Writer
+	err   io.Writer
+	query string
+}
+
+func NewYAMLOutput(out io.Writer, err io.Writer) Output {
+	return &yamlOutput{
+		out: out,
+		err: err,
+	}
+}
+
+func (o *yamlOutput) Print(targets ...interface{}) error {
+	if o.out == nil {
+		o.out = os.Stdout
+	}
+	if o.err == nil {
+		o.err = os.Stderr
+	}
+
+	if len(targets) == 0 {
+		fmt.Fprintf(o.err, "Result is empty\n")
+		return nil
+	}
+
+	b, err := yaml.Marshal(targets)
+	if err != nil {
+		return fmt.Errorf("YAMLOutput:Print: yaml.Marshal is Failed: %s", err)
+	}
+	o.out.Write(b)
+	fmt.Fprintln(o.out, "")
+	return nil
+
+}

--- a/tools/gen-command-completion/main.go
+++ b/tools/gen-command-completion/main.go
@@ -348,7 +348,7 @@ func {{.FuncName}}(ctx command.Context, params *params.{{.ParamName}} , flagName
 	 		comp = param.Param.CompleteFunc
 	 	}{{end}}{{end}}{{end}}
 	{{ if .HasOutputFlag }}case "output-type", "out", "o":
-		comp = schema.CompleteInStrValues("json", "csv", "tsv")
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
 {{ end -}}
 	}
 


### PR DESCRIPTION
To fix #392 

出力タイプ(`-o` or `--out` or `--output-type`)オプションでYAMLを指定可能にする。

```bash
$ usacloud server ls -o yaml
```