### PR TITLE
--query-fileオプションの追加

### DIFF
--- a/command/cli/cli_archive_gen.go
+++ b/command/cli/cli_archive_gen.go
@@ -117,6 +117,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -209,6 +213,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -349,6 +356,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -469,6 +479,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -561,6 +575,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -701,6 +718,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -798,6 +818,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -871,6 +895,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -989,6 +1016,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1179,6 +1209,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1267,6 +1301,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1400,6 +1437,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1580,6 +1620,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1656,6 +1700,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1777,6 +1824,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1960,6 +2010,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2039,6 +2093,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						uploadParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						uploadParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						uploadParam.Id = c.Int64("id")
@@ -2163,6 +2220,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						uploadParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						uploadParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						uploadParam.Id = c.Int64("id")
@@ -2672,6 +2732,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2748,6 +2812,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ftpOpenParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ftpOpenParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ftpOpenParam.Id = c.Int64("id")
@@ -2869,6 +2936,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ftpOpenParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ftpOpenParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ftpOpenParam.Id = c.Int64("id")
@@ -3727,6 +3797,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("archive", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("archive", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3798,6 +3873,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("archive", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("archive", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3927,6 +4007,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("archive", "ftp-open", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("archive", "ftp-open", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3993,6 +4078,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("archive", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("archive", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4072,6 +4162,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("archive", "read", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("archive", "read", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4147,6 +4242,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("archive", "update", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("archive", "update", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4213,6 +4313,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("archive", "upload", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("archive", "upload", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_auth_status_gen.go
+++ b/command/cli/cli_auth_status_gen.go
@@ -70,6 +70,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -115,6 +119,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -181,6 +189,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						showParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						showParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -294,6 +305,9 @@ func init() {
 					if c.IsSet("query") {
 						showParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						showParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -388,6 +402,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("auth-status", "show", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("auth-status", "show", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_auto_backup_gen.go
+++ b/command/cli/cli_auto_backup_gen.go
@@ -100,6 +100,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -183,6 +187,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -314,6 +321,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -432,6 +442,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -521,6 +535,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -658,6 +675,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -755,6 +775,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -828,6 +852,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -946,6 +973,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1144,6 +1174,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1238,6 +1272,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1377,6 +1414,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1557,6 +1597,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1633,6 +1677,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1754,6 +1801,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1989,6 +2039,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("auto-backup", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("auto-backup", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2050,6 +2105,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("auto-backup", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("auto-backup", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2124,6 +2184,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("auto-backup", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("auto-backup", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2180,6 +2245,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("auto-backup", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("auto-backup", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2260,6 +2330,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("auto-backup", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("auto-backup", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_bill_gen.go
+++ b/command/cli/cli_bill_gen.go
@@ -79,6 +79,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -361,6 +365,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -432,6 +440,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -550,6 +561,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -685,6 +699,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("bill", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("bill", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_bridge_gen.go
+++ b/command/cli/cli_bridge_gen.go
@@ -95,6 +95,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -175,6 +179,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -303,6 +310,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -399,6 +409,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -473,6 +487,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -595,6 +612,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -688,6 +708,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -758,6 +782,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -873,6 +900,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1036,6 +1066,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1115,6 +1149,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1239,6 +1276,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1400,6 +1440,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1473,6 +1517,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1591,6 +1638,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1796,6 +1846,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("bridge", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("bridge", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1847,6 +1902,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("bridge", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("bridge", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -1916,6 +1976,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("bridge", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("bridge", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1967,6 +2032,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("bridge", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("bridge", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2032,6 +2102,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("bridge", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("bridge", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_coupon_gen.go
+++ b/command/cli/cli_coupon_gen.go
@@ -74,6 +74,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -124,6 +128,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -193,6 +201,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -309,6 +320,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -403,6 +417,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("coupon", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("coupon", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_database_gen.go
+++ b/command/cli/cli_database_gen.go
@@ -122,6 +122,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -205,6 +209,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -335,6 +342,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -505,6 +515,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -630,6 +644,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -803,6 +820,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -900,6 +920,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -973,6 +997,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1091,6 +1118,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1319,6 +1349,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1434,6 +1468,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1594,6 +1631,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1774,6 +1814,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.BoolFlag{
 						Name:    "force",
 						Aliases: []string{"f"},
@@ -1855,6 +1899,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("force") {
 						deleteParam.Force = c.Bool("force")
@@ -1979,6 +2026,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("force") {
 						deleteParam.Force = c.Bool("force")
@@ -3990,6 +4040,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4063,6 +4117,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupInfoParam.Id = c.Int64("id")
@@ -4181,6 +4238,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupInfoParam.Id = c.Int64("id")
@@ -4350,6 +4410,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4423,6 +4487,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupCreateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupCreateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupCreateParam.Id = c.Int64("id")
@@ -4541,6 +4608,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupCreateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupCreateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupCreateParam.Id = c.Int64("id")
@@ -4709,6 +4779,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4785,6 +4859,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupRestoreParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupRestoreParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupRestoreParam.Id = c.Int64("id")
@@ -4906,6 +4983,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupRestoreParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupRestoreParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupRestoreParam.Id = c.Int64("id")
@@ -5074,6 +5154,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -5150,6 +5234,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupLockParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupLockParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupLockParam.Id = c.Int64("id")
@@ -5271,6 +5358,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupLockParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupLockParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupLockParam.Id = c.Int64("id")
@@ -5439,6 +5529,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -5515,6 +5609,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupUnlockParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupUnlockParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupUnlockParam.Id = c.Int64("id")
@@ -5636,6 +5733,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupUnlockParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupUnlockParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupUnlockParam.Id = c.Int64("id")
@@ -5804,6 +5904,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -5880,6 +5984,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupRemoveParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupRemoveParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupRemoveParam.Id = c.Int64("id")
@@ -6001,6 +6108,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						backupRemoveParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						backupRemoveParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						backupRemoveParam.Id = c.Int64("id")
@@ -6234,6 +6344,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -6355,6 +6469,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						cloneParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						cloneParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						cloneParam.Id = c.Int64("id")
@@ -6521,6 +6638,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						cloneParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						cloneParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						cloneParam.Id = c.Int64("id")
@@ -6719,6 +6839,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -6816,6 +6940,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						replicaCreateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						replicaCreateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						replicaCreateParam.Id = c.Int64("id")
@@ -6958,6 +7085,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						replicaCreateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						replicaCreateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						replicaCreateParam.Id = c.Int64("id")
@@ -7134,6 +7264,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -7216,6 +7350,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorCpuParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorCpuParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorCpuParam.Id = c.Int64("id")
@@ -7343,6 +7480,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorCpuParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorCpuParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorCpuParam.Id = c.Int64("id")
@@ -7524,6 +7664,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -7606,6 +7750,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorMemoryParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorMemoryParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorMemoryParam.Id = c.Int64("id")
@@ -7733,6 +7880,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorMemoryParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorMemoryParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorMemoryParam.Id = c.Int64("id")
@@ -7914,6 +8064,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -7996,6 +8150,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorNicParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorNicParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorNicParam.Id = c.Int64("id")
@@ -8123,6 +8280,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorNicParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorNicParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorNicParam.Id = c.Int64("id")
@@ -8304,6 +8464,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -8386,6 +8550,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorSystemDiskParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorSystemDiskParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorSystemDiskParam.Id = c.Int64("id")
@@ -8513,6 +8680,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorSystemDiskParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorSystemDiskParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorSystemDiskParam.Id = c.Int64("id")
@@ -8694,6 +8864,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -8776,6 +8950,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorBackupDiskParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorBackupDiskParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorBackupDiskParam.Id = c.Int64("id")
@@ -8903,6 +9080,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorBackupDiskParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorBackupDiskParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorBackupDiskParam.Id = c.Int64("id")
@@ -9084,6 +9264,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -9166,6 +9350,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorSystemDiskSizeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorSystemDiskSizeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorSystemDiskSizeParam.Id = c.Int64("id")
@@ -9293,6 +9480,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorSystemDiskSizeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorSystemDiskSizeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorSystemDiskSizeParam.Id = c.Int64("id")
@@ -9474,6 +9664,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -9556,6 +9750,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorBackupDiskSizeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorBackupDiskSizeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorBackupDiskSizeParam.Id = c.Int64("id")
@@ -9683,6 +9880,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorBackupDiskSizeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorBackupDiskSizeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorBackupDiskSizeParam.Id = c.Int64("id")
@@ -10341,6 +10541,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "backup-create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "backup-create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -10387,6 +10592,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "backup-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "backup-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -10456,6 +10666,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "backup-lock", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "backup-lock", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -10512,6 +10727,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "backup-remove", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "backup-remove", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -10576,6 +10796,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "backup-restore", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "backup-restore", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -10632,6 +10857,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "backup-unlock", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "backup-unlock", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -10781,6 +11011,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "clone", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "clone", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -10921,6 +11156,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11006,6 +11246,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11072,6 +11317,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -11191,6 +11441,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "monitor-backup-disk", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "monitor-backup-disk", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11257,6 +11512,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "monitor-backup-disk-size", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "monitor-backup-disk-size", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -11331,6 +11591,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "monitor-cpu", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "monitor-cpu", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11397,6 +11662,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "monitor-memory", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "monitor-memory", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -11471,6 +11741,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "monitor-nic", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "monitor-nic", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11537,6 +11812,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "monitor-system-disk", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "monitor-system-disk", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -11611,6 +11891,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("database", "monitor-system-disk-size", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("database", "monitor-system-disk-size", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11667,6 +11952,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -11757,6 +12047,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("database", "replica-create", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "replica-create", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -11962,6 +12257,11 @@ func init() {
 		Order:       1,
 	})
 	AppendFlagCategoryMap("database", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("database", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_disk_gen.go
+++ b/command/cli/cli_disk_gen.go
@@ -124,6 +124,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -219,6 +223,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -362,6 +369,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -493,6 +503,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -591,6 +605,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -737,6 +754,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -834,6 +854,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -907,6 +931,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1025,6 +1052,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1219,6 +1249,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1310,6 +1344,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1446,6 +1483,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1626,6 +1666,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1702,6 +1746,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1823,6 +1870,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2041,6 +2091,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2141,6 +2195,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						editParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						editParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						editParam.Id = c.Int64("id")
@@ -2286,6 +2343,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						editParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						editParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						editParam.Id = c.Int64("id")
@@ -4081,6 +4141,10 @@ func init() {
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
 					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
 						Name:  "end",
 						Usage: "set end-time",
 					},
@@ -4166,6 +4230,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("end") {
 						monitorParam.End = c.String("end")
@@ -4293,6 +4360,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("end") {
 						monitorParam.End = c.String("end")
@@ -4868,6 +4938,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("disk", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("disk", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4939,6 +5014,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("disk", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("disk", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5033,6 +5113,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("disk", "edit", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("disk", "edit", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5109,6 +5194,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("disk", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("disk", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5203,6 +5293,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("disk", "monitor", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("disk", "monitor", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5259,6 +5354,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("disk", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("disk", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5519,6 +5619,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("disk", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("disk", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_dns_gen.go
+++ b/command/cli/cli_dns_gen.go
@@ -104,6 +104,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -187,6 +191,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -318,6 +325,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -414,6 +424,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -493,6 +507,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordInfoParam.Id = c.Int64("id")
@@ -617,6 +634,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordInfoParam.Id = c.Int64("id")
@@ -802,6 +822,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -882,6 +906,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1009,6 +1036,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -1153,6 +1183,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1256,6 +1290,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordAddParam.Id = c.Int64("id")
@@ -1404,6 +1441,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordAddParam.Id = c.Int64("id")
@@ -1582,6 +1622,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1655,6 +1699,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1773,6 +1820,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1986,6 +2036,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2092,6 +2146,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordUpdateParam.Id = c.Int64("id")
@@ -2243,6 +2300,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordUpdateParam.Id = c.Int64("id")
@@ -2430,6 +2490,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2509,6 +2573,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordDeleteParam.Id = c.Int64("id")
@@ -2633,6 +2700,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						recordDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						recordDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						recordDeleteParam.Id = c.Int64("id")
@@ -2829,6 +2899,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2914,6 +2988,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -3044,6 +3121,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -3224,6 +3304,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3300,6 +3384,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -3421,6 +3508,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -3666,6 +3756,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("dns", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("dns", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3722,6 +3817,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("dns", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("dns", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3796,6 +3896,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("dns", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("dns", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3852,6 +3957,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("dns", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("dns", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3922,6 +4032,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("dns", "record-add", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("dns", "record-add", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4026,6 +4141,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("dns", "record-delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("dns", "record-delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4082,6 +4202,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("dns", "record-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("dns", "record-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4162,6 +4287,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("dns", "record-update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("dns", "record-update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4267,6 +4397,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("dns", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("dns", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_gslb_gen.go
+++ b/command/cli/cli_gslb_gen.go
@@ -104,6 +104,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -187,6 +191,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -318,6 +325,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -406,6 +416,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -479,6 +493,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverInfoParam.Id = c.Int64("id")
@@ -597,6 +614,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverInfoParam.Id = c.Int64("id")
@@ -819,6 +839,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -923,6 +947,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1075,6 +1102,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1189,6 +1219,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1274,6 +1308,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverAddParam.Id = c.Int64("id")
@@ -1404,6 +1441,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverAddParam.Id = c.Int64("id")
@@ -1582,6 +1622,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1655,6 +1699,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1773,6 +1820,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1962,6 +2012,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2050,6 +2104,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverUpdateParam.Id = c.Int64("id")
@@ -2183,6 +2240,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverUpdateParam.Id = c.Int64("id")
@@ -2370,6 +2430,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2449,6 +2513,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverDeleteParam.Id = c.Int64("id")
@@ -2573,6 +2640,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverDeleteParam.Id = c.Int64("id")
@@ -2805,6 +2875,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2917,6 +2991,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -3074,6 +3151,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -3254,6 +3334,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3330,6 +3414,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -3451,6 +3538,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -3721,6 +3811,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("gslb", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("gslb", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3796,6 +3891,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("gslb", "delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("gslb", "delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3866,6 +3966,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("gslb", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("gslb", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3922,6 +4027,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("gslb", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("gslb", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3996,6 +4106,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("gslb", "server-add", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("gslb", "server-add", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4066,6 +4181,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("gslb", "server-delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("gslb", "server-delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4117,6 +4237,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("gslb", "server-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("gslb", "server-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4192,6 +4317,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("gslb", "server-update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("gslb", "server-update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4297,6 +4427,11 @@ func init() {
 		Order:       1,
 	})
 	AppendFlagCategoryMap("gslb", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("gslb", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_icon_gen.go
+++ b/command/cli/cli_icon_gen.go
@@ -104,6 +104,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -190,6 +194,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -324,6 +331,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -423,6 +433,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -500,6 +514,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -625,6 +642,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -722,6 +742,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -795,6 +819,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -913,6 +940,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1094,6 +1124,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1176,6 +1210,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1303,6 +1340,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1483,6 +1523,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1559,6 +1603,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1680,6 +1727,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1900,6 +1950,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("icon", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("icon", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1956,6 +2011,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("icon", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("icon", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2030,6 +2090,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("icon", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("icon", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2095,6 +2160,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("icon", "read", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("icon", "read", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2156,6 +2226,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("icon", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("icon", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_interface_gen.go
+++ b/command/cli/cli_interface_gen.go
@@ -97,6 +97,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -177,6 +181,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -304,6 +311,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -693,6 +703,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -764,6 +778,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -882,6 +899,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -1273,6 +1293,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1343,6 +1367,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1458,6 +1485,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1616,6 +1646,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1692,6 +1726,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1813,6 +1850,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1974,6 +2014,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2047,6 +2091,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2165,6 +2212,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2370,6 +2420,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("interface", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("interface", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2426,6 +2481,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("interface", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("interface", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2491,6 +2551,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("interface", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("interface", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2610,6 +2675,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("interface", "read", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("interface", "read", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2661,6 +2731,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("interface", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("interface", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_internet_gen.go
+++ b/command/cli/cli_internet_gen.go
@@ -109,6 +109,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -192,6 +196,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -323,6 +330,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -438,6 +448,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -524,6 +538,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -658,6 +675,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -755,6 +775,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -828,6 +852,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -946,6 +973,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1140,6 +1170,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1231,6 +1265,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1367,6 +1404,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1547,6 +1587,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1623,6 +1667,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1744,6 +1791,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1928,6 +1978,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2007,6 +2061,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateBandwidthParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateBandwidthParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateBandwidthParam.Id = c.Int64("id")
@@ -2131,6 +2188,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateBandwidthParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateBandwidthParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateBandwidthParam.Id = c.Int64("id")
@@ -2305,6 +2365,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2378,6 +2442,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						subnetInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						subnetInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						subnetInfoParam.Id = c.Int64("id")
@@ -2496,6 +2563,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						subnetInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						subnetInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						subnetInfoParam.Id = c.Int64("id")
@@ -2675,6 +2745,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2757,6 +2831,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						subnetAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						subnetAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						subnetAddParam.Id = c.Int64("id")
@@ -2884,6 +2961,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						subnetAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						subnetAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						subnetAddParam.Id = c.Int64("id")
@@ -3393,6 +3473,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3475,6 +3559,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						subnetUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						subnetUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						subnetUpdateParam.Id = c.Int64("id")
@@ -3602,6 +3689,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						subnetUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						subnetUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						subnetUpdateParam.Id = c.Int64("id")
@@ -3776,6 +3866,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3849,6 +3943,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ipv6InfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ipv6InfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ipv6InfoParam.Id = c.Int64("id")
@@ -3967,6 +4064,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ipv6InfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ipv6InfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ipv6InfoParam.Id = c.Int64("id")
@@ -4136,6 +4236,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4212,6 +4316,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ipv6EnableParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ipv6EnableParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ipv6EnableParam.Id = c.Int64("id")
@@ -4333,6 +4440,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ipv6EnableParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ipv6EnableParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ipv6EnableParam.Id = c.Int64("id")
@@ -4832,6 +4942,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4914,6 +5028,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -5041,6 +5158,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -5315,6 +5435,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("internet", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("internet", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5371,6 +5496,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("internet", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("internet", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5465,6 +5595,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("internet", "ipv6-enable", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("internet", "ipv6-enable", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5516,6 +5651,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("internet", "ipv6-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("internet", "ipv6-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5590,6 +5730,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("internet", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("internet", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5660,6 +5805,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("internet", "monitor", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("internet", "monitor", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5716,6 +5866,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("internet", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("internet", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5786,6 +5941,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("internet", "subnet-add", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("internet", "subnet-add", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5880,6 +6040,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("internet", "subnet-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("internet", "subnet-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5941,6 +6106,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("internet", "subnet-update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("internet", "subnet-update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -6030,6 +6200,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("internet", "update", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("internet", "update", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -6096,6 +6271,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("internet", "update-bandwidth", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("internet", "update-bandwidth", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_ipv4_gen.go
+++ b/command/cli/cli_ipv4_gen.go
@@ -95,6 +95,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -175,6 +179,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -303,6 +310,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -395,6 +405,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -466,6 +480,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrAddParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -585,6 +602,9 @@ func init() {
 					if c.IsSet("query") {
 						ptrAddParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						ptrAddParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -678,6 +698,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -743,6 +767,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrReadParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrReadParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -856,6 +883,9 @@ func init() {
 					if c.IsSet("query") {
 						ptrReadParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						ptrReadParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -948,6 +978,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -1019,6 +1053,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrUpdateParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1138,6 +1175,9 @@ func init() {
 					if c.IsSet("query") {
 						ptrUpdateParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						ptrUpdateParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1236,6 +1276,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -1304,6 +1348,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrDeleteParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1419,6 +1466,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrDeleteParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -1568,6 +1618,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ipv4", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ipv4", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1628,6 +1683,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ipv4", "ptr-add", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ipv4", "ptr-add", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1678,6 +1738,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ipv4", "ptr-delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ipv4", "ptr-delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1719,6 +1784,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("ipv4", "ptr-read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("ipv4", "ptr-read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -1774,6 +1844,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("ipv4", "ptr-update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("ipv4", "ptr-update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_ipv6_gen.go
+++ b/command/cli/cli_ipv6_gen.go
@@ -103,6 +103,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -189,6 +193,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -323,6 +330,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -415,6 +425,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -486,6 +500,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrAddParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -605,6 +622,9 @@ func init() {
 					if c.IsSet("query") {
 						ptrAddParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						ptrAddParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -698,6 +718,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -763,6 +787,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrReadParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrReadParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -876,6 +903,9 @@ func init() {
 					if c.IsSet("query") {
 						ptrReadParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						ptrReadParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -968,6 +998,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -1039,6 +1073,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrUpdateParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1158,6 +1195,9 @@ func init() {
 					if c.IsSet("query") {
 						ptrUpdateParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						ptrUpdateParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -1256,6 +1296,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -1324,6 +1368,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrDeleteParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1439,6 +1486,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ptrDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ptrDeleteParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -1598,6 +1648,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ipv6", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ipv6", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1658,6 +1713,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ipv6", "ptr-add", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ipv6", "ptr-add", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1708,6 +1768,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ipv6", "ptr-delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ipv6", "ptr-delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1749,6 +1814,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("ipv6", "ptr-read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("ipv6", "ptr-read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -1804,6 +1874,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("ipv6", "ptr-update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("ipv6", "ptr-update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_iso_image_gen.go
+++ b/command/cli/cli_iso_image_gen.go
@@ -108,6 +108,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -194,6 +198,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -328,6 +335,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -441,6 +451,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -527,6 +541,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -661,6 +678,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -758,6 +778,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -831,6 +855,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -949,6 +976,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1139,6 +1169,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1227,6 +1261,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1360,6 +1397,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1540,6 +1580,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1616,6 +1660,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1737,6 +1784,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1920,6 +1970,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1999,6 +2053,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						uploadParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						uploadParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						uploadParam.Id = c.Int64("id")
@@ -2123,6 +2180,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						uploadParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						uploadParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						uploadParam.Id = c.Int64("id")
@@ -2632,6 +2692,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2708,6 +2772,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ftpOpenParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ftpOpenParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ftpOpenParam.Id = c.Int64("id")
@@ -2829,6 +2896,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ftpOpenParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ftpOpenParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ftpOpenParam.Id = c.Int64("id")
@@ -3391,6 +3461,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("iso-image", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("iso-image", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3452,6 +3527,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("iso-image", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("iso-image", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3581,6 +3661,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("iso-image", "ftp-open", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("iso-image", "ftp-open", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3651,6 +3736,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("iso-image", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("iso-image", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3712,6 +3802,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("iso-image", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("iso-image", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3791,6 +3886,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("iso-image", "update", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("iso-image", "update", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3857,6 +3957,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("iso-image", "upload", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("iso-image", "upload", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_license_gen.go
+++ b/command/cli/cli_license_gen.go
@@ -95,6 +95,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -175,6 +179,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -303,6 +310,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -398,6 +408,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -472,6 +486,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -594,6 +611,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -687,6 +707,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -757,6 +781,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -872,6 +899,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1030,6 +1060,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1106,6 +1140,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1227,6 +1264,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1388,6 +1428,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1461,6 +1505,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1579,6 +1626,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1784,6 +1834,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("license", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("license", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1835,6 +1890,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("license", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("license", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -1904,6 +1964,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("license", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("license", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1955,6 +2020,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("license", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("license", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2015,6 +2085,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("license", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("license", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_load_balancer_gen.go
+++ b/command/cli/cli_load_balancer_gen.go
@@ -115,6 +115,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -198,6 +202,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -328,6 +335,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -472,6 +482,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -576,6 +590,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -728,6 +745,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -825,6 +845,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -898,6 +922,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1016,6 +1043,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1206,6 +1236,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1294,6 +1328,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1427,6 +1464,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1612,6 +1652,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1691,6 +1735,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1815,6 +1862,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -3822,6 +3872,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3895,6 +3949,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vipInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vipInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vipInfoParam.Id = c.Int64("id")
@@ -4013,6 +4070,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vipInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vipInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vipInfoParam.Id = c.Int64("id")
@@ -5265,6 +5325,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -5347,6 +5411,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverInfoParam.Id = c.Int64("id")
@@ -5474,6 +5541,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverInfoParam.Id = c.Int64("id")
@@ -6807,6 +6877,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -6889,6 +6963,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -7016,6 +7093,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -7370,6 +7450,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("load-balancer", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("load-balancer", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -7445,6 +7530,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("load-balancer", "delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("load-balancer", "delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -7511,6 +7601,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("load-balancer", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("load-balancer", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -7585,6 +7680,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("load-balancer", "monitor", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("load-balancer", "monitor", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -7641,6 +7741,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("load-balancer", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("load-balancer", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -7851,6 +7956,11 @@ func init() {
 		Order:       1,
 	})
 	AppendFlagCategoryMap("load-balancer", "server-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("load-balancer", "server-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -8070,6 +8180,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("load-balancer", "update", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("load-balancer", "update", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -8216,6 +8331,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("load-balancer", "vip-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("load-balancer", "vip-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_mobile_gateway_gen.go
+++ b/command/cli/cli_mobile_gateway_gen.go
@@ -129,6 +129,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -212,6 +216,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -343,6 +350,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -451,6 +461,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -534,6 +548,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -665,6 +682,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -762,6 +782,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -835,6 +859,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -953,6 +980,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1147,6 +1177,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1238,6 +1272,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1374,6 +1411,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1559,6 +1599,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1638,6 +1682,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1762,6 +1809,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -3770,6 +3820,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3843,6 +3897,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						interfaceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						interfaceInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						interfaceInfoParam.Id = c.Int64("id")
@@ -3961,6 +4018,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						interfaceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						interfaceInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						interfaceInfoParam.Id = c.Int64("id")
@@ -5133,6 +5193,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -5206,6 +5270,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						trafficControlInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						trafficControlInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						trafficControlInfoParam.Id = c.Int64("id")
@@ -5324,6 +5391,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						trafficControlInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						trafficControlInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						trafficControlInfoParam.Id = c.Int64("id")
@@ -6522,6 +6592,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -6595,6 +6669,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						staticRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						staticRouteInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						staticRouteInfoParam.Id = c.Int64("id")
@@ -6713,6 +6790,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						staticRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						staticRouteInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						staticRouteInfoParam.Id = c.Int64("id")
@@ -7890,6 +7970,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -7963,6 +8047,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						simInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						simInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						simInfoParam.Id = c.Int64("id")
@@ -8081,6 +8168,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						simInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						simInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						simInfoParam.Id = c.Int64("id")
@@ -9250,6 +9340,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -9323,6 +9417,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						simRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						simRouteInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						simRouteInfoParam.Id = c.Int64("id")
@@ -9441,6 +9538,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						simRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						simRouteInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						simRouteInfoParam.Id = c.Int64("id")
@@ -11496,6 +11596,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("mobile-gateway", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("mobile-gateway", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11557,6 +11662,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("mobile-gateway", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -11731,6 +11841,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("mobile-gateway", "interface-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("mobile-gateway", "interface-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11841,6 +11956,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("mobile-gateway", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("mobile-gateway", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -11932,6 +12052,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("mobile-gateway", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -12156,6 +12281,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("mobile-gateway", "sim-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("mobile-gateway", "sim-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -12282,6 +12412,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("mobile-gateway", "sim-route-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "sim-route-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -12501,6 +12636,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("mobile-gateway", "static-route-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -12686,6 +12826,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("mobile-gateway", "traffic-control-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -12817,6 +12962,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("mobile-gateway", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("mobile-gateway", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_nfs_gen.go
+++ b/command/cli/cli_nfs_gen.go
@@ -108,6 +108,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -191,6 +195,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -322,6 +329,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -448,6 +458,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -543,6 +557,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -686,6 +703,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -783,6 +803,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -856,6 +880,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -974,6 +1001,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1164,6 +1194,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1252,6 +1286,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1385,6 +1422,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1570,6 +1610,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1649,6 +1693,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1773,6 +1820,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -3793,6 +3843,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3875,6 +3929,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorNicParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorNicParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorNicParam.Id = c.Int64("id")
@@ -4002,6 +4059,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorNicParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorNicParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorNicParam.Id = c.Int64("id")
@@ -4183,6 +4243,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4265,6 +4329,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorFreeDiskSizeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorFreeDiskSizeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorFreeDiskSizeParam.Id = c.Int64("id")
@@ -4392,6 +4459,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorFreeDiskSizeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorFreeDiskSizeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorFreeDiskSizeParam.Id = c.Int64("id")
@@ -4701,6 +4771,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("nfs", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("nfs", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4767,6 +4842,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("nfs", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("nfs", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4841,6 +4921,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("nfs", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("nfs", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4907,6 +4992,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("nfs", "monitor-free-disk-size", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("nfs", "monitor-free-disk-size", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4981,6 +5071,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("nfs", "monitor-nic", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("nfs", "monitor-nic", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5037,6 +5132,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("nfs", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("nfs", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5202,6 +5302,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("nfs", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("nfs", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_object_storage_gen.go
+++ b/command/cli/cli_object_storage_gen.go
@@ -88,6 +88,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -162,6 +166,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -283,6 +290,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -1255,6 +1265,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("object-storage", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("object-storage", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_packet_filter_gen.go
+++ b/command/cli/cli_packet_filter_gen.go
@@ -101,6 +101,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -181,6 +185,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -309,6 +316,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -405,6 +415,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -479,6 +493,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -601,6 +618,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -694,6 +714,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -764,6 +788,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -879,6 +906,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1042,6 +1072,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1121,6 +1155,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1245,6 +1282,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1406,6 +1446,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1479,6 +1523,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1597,6 +1644,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1753,6 +1803,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1823,6 +1877,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleInfoParam.Id = c.Int64("id")
@@ -1938,6 +1995,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleInfoParam.Id = c.Int64("id")
@@ -2119,6 +2179,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2213,6 +2277,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleAddParam.Id = c.Int64("id")
@@ -2352,6 +2419,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleAddParam.Id = c.Int64("id")
@@ -2546,6 +2616,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2640,6 +2714,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleUpdateParam.Id = c.Int64("id")
@@ -2779,6 +2856,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleUpdateParam.Id = c.Int64("id")
@@ -2947,6 +3027,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -3023,6 +3107,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleDeleteParam.Id = c.Int64("id")
@@ -3144,6 +3231,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						ruleDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						ruleDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						ruleDeleteParam.Id = c.Int64("id")
@@ -3985,6 +4075,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("packet-filter", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4036,6 +4131,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4165,6 +4265,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("packet-filter", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4216,6 +4321,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4300,6 +4410,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "rule-add", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("packet-filter", "rule-add", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4370,6 +4485,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "rule-delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("packet-filter", "rule-delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4416,6 +4536,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "rule-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "rule-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -4500,6 +4625,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("packet-filter", "rule-update", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("packet-filter", "rule-update", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -4571,6 +4701,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("packet-filter", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("packet-filter", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_price_gen.go
+++ b/command/cli/cli_price_gen.go
@@ -93,6 +93,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -161,6 +165,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -242,6 +250,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -370,6 +381,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -484,6 +498,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("price", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("price", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_private_host_gen.go
+++ b/command/cli/cli_private_host_gen.go
@@ -103,6 +103,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -186,6 +190,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -317,6 +324,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -421,6 +431,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -501,6 +515,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -629,6 +646,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -726,6 +746,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -799,6 +823,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -917,6 +944,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1107,6 +1137,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1195,6 +1229,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1328,6 +1365,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1508,6 +1548,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1584,6 +1628,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1705,6 +1752,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1880,6 +1930,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1953,6 +2007,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverInfoParam.Id = c.Int64("id")
@@ -2071,6 +2128,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverInfoParam.Id = c.Int64("id")
@@ -2248,6 +2308,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2327,6 +2391,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverAddParam.Id = c.Int64("id")
@@ -2451,6 +2518,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverAddParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverAddParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverAddParam.Id = c.Int64("id")
@@ -2638,6 +2708,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2717,6 +2791,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverDeleteParam.Id = c.Int64("id")
@@ -2841,6 +2918,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						serverDeleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						serverDeleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						serverDeleteParam.Id = c.Int64("id")
@@ -3085,6 +3165,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("private-host", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("private-host", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3141,6 +3226,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("private-host", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("private-host", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3215,6 +3305,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("private-host", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("private-host", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3275,6 +3370,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("private-host", "read", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("private-host", "read", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3331,6 +3431,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("private-host", "server-add", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("private-host", "server-add", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3400,6 +3505,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("private-host", "server-delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("private-host", "server-delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -3456,6 +3566,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("private-host", "server-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("private-host", "server-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3531,6 +3646,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("private-host", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("private-host", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_product_disk_gen.go
+++ b/command/cli/cli_product_disk_gen.go
@@ -94,6 +94,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -162,6 +166,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -243,6 +251,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -371,6 +382,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -459,6 +473,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "[Required] set resource ID",
@@ -532,6 +550,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -650,6 +671,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -793,6 +817,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-disk", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("product-disk", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -849,6 +878,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-disk", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-disk", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_product_internet_gen.go
+++ b/command/cli/cli_product_internet_gen.go
@@ -94,6 +94,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -162,6 +166,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -243,6 +251,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -371,6 +382,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -459,6 +473,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "[Required] set resource ID",
@@ -532,6 +550,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -650,6 +671,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -793,6 +817,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-internet", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("product-internet", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -849,6 +878,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-internet", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-internet", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_product_license_gen.go
+++ b/command/cli/cli_product_license_gen.go
@@ -94,6 +94,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -162,6 +166,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -243,6 +251,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -371,6 +382,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -459,6 +473,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "[Required] set resource ID",
@@ -532,6 +550,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -650,6 +671,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -793,6 +817,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-license", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("product-license", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -849,6 +878,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-license", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-license", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_product_server_gen.go
+++ b/command/cli/cli_product_server_gen.go
@@ -94,6 +94,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -162,6 +166,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -243,6 +251,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -371,6 +382,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -459,6 +473,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "[Required] set resource ID",
@@ -532,6 +550,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -650,6 +671,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -793,6 +817,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("product-server", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("product-server", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -849,6 +878,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("product-server", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("product-server", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_region_gen.go
+++ b/command/cli/cli_region_gen.go
@@ -93,6 +93,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -161,6 +165,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -242,6 +250,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -370,6 +381,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -458,6 +472,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "[Required] set resource ID",
@@ -531,6 +549,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -649,6 +670,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -792,6 +816,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("region", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("region", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -848,6 +877,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("region", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("region", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_server_gen.go
+++ b/command/cli/cli_server_gen.go
@@ -131,6 +131,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -214,6 +218,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -344,6 +351,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -607,6 +617,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.BoolFlag{
 						Name:  "us-keyboard",
 						Usage: "use us-keyboard",
@@ -800,6 +814,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						buildParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						buildParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("us-keyboard") {
 						buildParam.UsKeyboard = c.Bool("us-keyboard")
@@ -1039,6 +1056,9 @@ func init() {
 					if c.IsSet("query") {
 						buildParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						buildParam.QueryFile = c.String("query-file")
+					}
 					if c.IsSet("us-keyboard") {
 						buildParam.UsKeyboard = c.Bool("us-keyboard")
 					}
@@ -1142,6 +1162,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1215,6 +1239,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1333,6 +1360,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1528,6 +1558,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1619,6 +1653,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1755,6 +1792,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1944,6 +1984,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2026,6 +2070,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2153,6 +2200,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2340,6 +2390,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2422,6 +2476,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						planChangeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						planChangeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						planChangeParam.Id = c.Int64("id")
@@ -2549,6 +2606,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						planChangeParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						planChangeParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						planChangeParam.Id = c.Int64("id")
@@ -5817,6 +5877,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -5893,6 +5957,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vncInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vncInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vncInfoParam.Id = c.Int64("id")
@@ -6014,6 +6081,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vncInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vncInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vncInfoParam.Id = c.Int64("id")
@@ -6210,6 +6280,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -6301,6 +6375,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vncSendParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vncSendParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vncSendParam.Id = c.Int64("id")
@@ -6437,6 +6514,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vncSendParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vncSendParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vncSendParam.Id = c.Int64("id")
@@ -6626,6 +6706,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -6708,6 +6792,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vncSnapshotParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vncSnapshotParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vncSnapshotParam.Id = c.Int64("id")
@@ -6835,6 +6922,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						vncSnapshotParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						vncSnapshotParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						vncSnapshotParam.Id = c.Int64("id")
@@ -7340,6 +7430,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -7419,6 +7513,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						remoteDesktopInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						remoteDesktopInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						remoteDesktopInfoParam.Id = c.Int64("id")
@@ -7543,6 +7640,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						remoteDesktopInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						remoteDesktopInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						remoteDesktopInfoParam.Id = c.Int64("id")
@@ -7712,6 +7812,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -7785,6 +7889,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						diskInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						diskInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						diskInfoParam.Id = c.Int64("id")
@@ -7903,6 +8010,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						diskInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						diskInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						diskInfoParam.Id = c.Int64("id")
@@ -8724,6 +8834,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -8797,6 +8911,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						interfaceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						interfaceInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						interfaceInfoParam.Id = c.Int64("id")
@@ -8915,6 +9032,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						interfaceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						interfaceInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						interfaceInfoParam.Id = c.Int64("id")
@@ -10465,6 +10585,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -10538,6 +10662,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						isoInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						isoInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						isoInfoParam.Id = c.Int64("id")
@@ -10656,6 +10783,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						isoInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						isoInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						isoInfoParam.Id = c.Int64("id")
@@ -11541,6 +11671,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -11623,6 +11757,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorCpuParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorCpuParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorCpuParam.Id = c.Int64("id")
@@ -11750,6 +11887,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorCpuParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorCpuParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorCpuParam.Id = c.Int64("id")
@@ -11935,6 +12075,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -12020,6 +12164,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorNicParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorNicParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorNicParam.Id = c.Int64("id")
@@ -12150,6 +12297,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorNicParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorNicParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorNicParam.Id = c.Int64("id")
@@ -12335,6 +12485,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -12420,6 +12574,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorDiskParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorDiskParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorDiskParam.Id = c.Int64("id")
@@ -12550,6 +12707,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorDiskParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorDiskParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorDiskParam.Id = c.Int64("id")
@@ -12713,6 +12873,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -12778,6 +12942,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						maintenanceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						maintenanceInfoParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -12890,6 +13057,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						maintenanceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						maintenanceInfoParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -13319,6 +13489,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "build", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "build", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -13464,6 +13639,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -13590,6 +13770,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("server", "disk-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "disk-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -13824,6 +14009,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "interface-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "interface-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -13905,6 +14095,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("server", "iso-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "iso-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -14044,6 +14239,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -14095,6 +14295,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("server", "maintenance-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "maintenance-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -14155,6 +14360,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("server", "monitor-cpu", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "monitor-cpu", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -14234,6 +14444,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "monitor-disk", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "monitor-disk", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -14305,6 +14520,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("server", "monitor-nic", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "monitor-nic", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -14384,6 +14604,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "plan-change", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "plan-change", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -14435,6 +14660,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("server", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -14530,6 +14760,11 @@ func init() {
 		Order:       1,
 	})
 	AppendFlagCategoryMap("server", "remote-desktop-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "remote-desktop-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -14854,6 +15089,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "update", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "update", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -14944,6 +15184,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "vnc-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "vnc-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -15024,6 +15269,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "vnc-send", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("server", "vnc-send", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -15095,6 +15345,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("server", "vnc-snapshot", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "vnc-snapshot", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_sim_gen.go
+++ b/command/cli/cli_sim_gen.go
@@ -110,6 +110,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -193,6 +197,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -324,6 +331,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -447,6 +457,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -542,6 +556,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -685,6 +702,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -782,6 +802,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -855,6 +879,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -973,6 +1000,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1163,6 +1193,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1251,6 +1285,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1384,6 +1421,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1883,6 +1923,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1956,6 +2000,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						carrierInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						carrierInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						carrierInfoParam.Id = c.Int64("id")
@@ -2074,6 +2121,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						carrierInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						carrierInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						carrierInfoParam.Id = c.Int64("id")
@@ -4475,6 +4525,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4554,6 +4608,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						logsParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						logsParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						logsParam.Id = c.Int64("id")
@@ -4678,6 +4735,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						logsParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						logsParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						logsParam.Id = c.Int64("id")
@@ -4859,6 +4919,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4941,6 +5005,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -5068,6 +5135,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -5352,6 +5422,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("sim", "carrier-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("sim", "carrier-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5478,6 +5553,11 @@ func init() {
 		Order:       1,
 	})
 	AppendFlagCategoryMap("sim", "create", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("sim", "create", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5747,6 +5827,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("sim", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("sim", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5808,6 +5893,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("sim", "logs", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("sim", "logs", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -5882,6 +5972,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("sim", "monitor", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("sim", "monitor", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -5938,6 +6033,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("sim", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("sim", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -6013,6 +6113,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("sim", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("sim", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_simple_monitor_gen.go
+++ b/command/cli/cli_simple_monitor_gen.go
@@ -105,6 +105,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -191,6 +195,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -324,6 +331,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -501,6 +511,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -629,6 +643,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -805,6 +822,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -902,6 +922,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -975,6 +999,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1093,6 +1120,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1346,6 +1376,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1479,6 +1513,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1657,6 +1694,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1837,6 +1877,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1913,6 +1957,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2034,6 +2081,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2208,6 +2258,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -2281,6 +2335,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						healthParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						healthParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						healthParam.Id = c.Int64("id")
@@ -2399,6 +2456,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						healthParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						healthParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						healthParam.Id = c.Int64("id")
@@ -2673,6 +2733,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("simple-monitor", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("simple-monitor", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2763,6 +2828,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("simple-monitor", "delete", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("simple-monitor", "delete", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2814,6 +2884,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("simple-monitor", "health", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("simple-monitor", "health", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2893,6 +2968,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("simple-monitor", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("simple-monitor", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2949,6 +3029,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("simple-monitor", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("simple-monitor", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -3074,6 +3159,11 @@ func init() {
 		Order:       20,
 	})
 	AppendFlagCategoryMap("simple-monitor", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("simple-monitor", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_ssh_key_gen.go
+++ b/command/cli/cli_ssh_key_gen.go
@@ -96,6 +96,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -176,6 +180,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -304,6 +311,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -408,6 +418,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -488,6 +502,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -616,6 +633,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -709,6 +729,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -779,6 +803,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -894,6 +921,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1057,6 +1087,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1136,6 +1170,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1260,6 +1297,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1421,6 +1461,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1494,6 +1538,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1612,6 +1659,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1790,6 +1840,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -1870,6 +1924,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						generateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						generateParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1997,6 +2054,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						generateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						generateParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -2156,6 +2216,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ssh-key", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ssh-key", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2207,6 +2272,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("ssh-key", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("ssh-key", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2281,6 +2351,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ssh-key", "generate", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ssh-key", "generate", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2346,6 +2421,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("ssh-key", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("ssh-key", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2397,6 +2477,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("ssh-key", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("ssh-key", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2462,6 +2547,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("ssh-key", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("ssh-key", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_startup_script_gen.go
+++ b/command/cli/cli_startup_script_gen.go
@@ -109,6 +109,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -198,6 +202,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -335,6 +342,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -449,6 +459,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -535,6 +549,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -669,6 +686,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -766,6 +786,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -839,6 +863,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -957,6 +984,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1156,6 +1186,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1250,6 +1284,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1389,6 +1426,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1569,6 +1609,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1645,6 +1689,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1766,6 +1813,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1991,6 +2041,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("startup-script", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("startup-script", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2057,6 +2112,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("startup-script", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("startup-script", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2136,6 +2196,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("startup-script", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("startup-script", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2197,6 +2262,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("startup-script", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("startup-script", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2272,6 +2342,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("startup-script", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("startup-script", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_summary_gen.go
+++ b/command/cli/cli_summary_gen.go
@@ -70,6 +70,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 			&cli.BoolFlag{
 				Name:    "paid-resources-only",
 				Aliases: []string{"paid"},
@@ -120,6 +124,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 					&cli.BoolFlag{
 						Name:    "paid-resources-only",
@@ -191,6 +199,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						showParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						showParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("paid-resources-only") {
 						showParam.PaidResourcesOnly = c.Bool("paid-resources-only")
@@ -307,6 +318,9 @@ func init() {
 					if c.IsSet("query") {
 						showParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						showParam.QueryFile = c.String("query-file")
+					}
 					if c.IsSet("paid-resources-only") {
 						showParam.PaidResourcesOnly = c.Bool("paid-resources-only")
 					}
@@ -409,6 +423,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("summary", "show", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("summary", "show", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_switch_gen.go
+++ b/command/cli/cli_switch_gen.go
@@ -102,6 +102,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -185,6 +189,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -316,6 +323,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -420,6 +430,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -500,6 +514,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -628,6 +645,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -725,6 +745,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -798,6 +822,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -916,6 +943,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1106,6 +1136,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1194,6 +1228,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1327,6 +1364,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1507,6 +1547,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1583,6 +1627,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1704,6 +1751,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -2638,6 +2688,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("switch", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("switch", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2694,6 +2749,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("switch", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("switch", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2768,6 +2828,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("switch", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("switch", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -2824,6 +2889,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("switch", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("switch", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2899,6 +2969,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("switch", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("switch", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_vpc_router_gen.go
+++ b/command/cli/cli_vpc_router_gen.go
@@ -151,6 +151,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -234,6 +238,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -364,6 +371,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -507,6 +517,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -611,6 +625,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -763,6 +780,9 @@ func init() {
 					if c.IsSet("query") {
 						createParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						createParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -860,6 +880,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -933,6 +957,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1051,6 +1078,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -1249,6 +1279,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1343,6 +1377,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1482,6 +1519,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						updateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						updateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						updateParam.Id = c.Int64("id")
@@ -1667,6 +1707,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1746,6 +1790,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -1870,6 +1917,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						deleteParam.Id = c.Int64("id")
@@ -4510,6 +4560,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -4583,6 +4637,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						interfaceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						interfaceInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						interfaceInfoParam.Id = c.Int64("id")
@@ -4701,6 +4758,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						interfaceInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						interfaceInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						interfaceInfoParam.Id = c.Int64("id")
@@ -5998,6 +6058,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -6071,6 +6135,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						staticNatInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						staticNatInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						staticNatInfoParam.Id = c.Int64("id")
@@ -6189,6 +6256,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						staticNatInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						staticNatInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						staticNatInfoParam.Id = c.Int64("id")
@@ -7392,6 +7462,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -7465,6 +7539,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						portForwardingInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						portForwardingInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						portForwardingInfoParam.Id = c.Int64("id")
@@ -7583,6 +7660,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						portForwardingInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						portForwardingInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						portForwardingInfoParam.Id = c.Int64("id")
@@ -8834,6 +8914,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -8913,6 +8997,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						firewallInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						firewallInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						firewallInfoParam.Id = c.Int64("id")
@@ -9037,6 +9124,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						firewallInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						firewallInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						firewallInfoParam.Id = c.Int64("id")
@@ -10408,6 +10498,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -10481,6 +10575,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						dhcpServerInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						dhcpServerInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						dhcpServerInfoParam.Id = c.Int64("id")
@@ -10599,6 +10696,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						dhcpServerInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						dhcpServerInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						dhcpServerInfoParam.Id = c.Int64("id")
@@ -11808,6 +11908,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -11881,6 +11985,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						dhcpStaticMappingInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						dhcpStaticMappingInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						dhcpStaticMappingInfoParam.Id = c.Int64("id")
@@ -11999,6 +12106,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						dhcpStaticMappingInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						dhcpStaticMappingInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						dhcpStaticMappingInfoParam.Id = c.Int64("id")
@@ -13179,6 +13289,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -13252,6 +13366,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						pptpServerInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						pptpServerInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						pptpServerInfoParam.Id = c.Int64("id")
@@ -13370,6 +13487,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						pptpServerInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						pptpServerInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						pptpServerInfoParam.Id = c.Int64("id")
@@ -13885,6 +14005,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -13958,6 +14082,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						l2tpServerInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						l2tpServerInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						l2tpServerInfoParam.Id = c.Int64("id")
@@ -14076,6 +14203,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						l2tpServerInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						l2tpServerInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						l2tpServerInfoParam.Id = c.Int64("id")
@@ -14602,6 +14732,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -14675,6 +14809,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						userInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						userInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						userInfoParam.Id = c.Int64("id")
@@ -14793,6 +14930,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						userInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						userInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						userInfoParam.Id = c.Int64("id")
@@ -15974,6 +16114,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -16047,6 +16191,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						siteToSiteVpnInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						siteToSiteVpnInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						siteToSiteVpnInfoParam.Id = c.Int64("id")
@@ -16165,6 +16312,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						siteToSiteVpnInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						siteToSiteVpnInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						siteToSiteVpnInfoParam.Id = c.Int64("id")
@@ -17401,6 +17551,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -17474,6 +17628,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						siteToSiteVpnPeersParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						siteToSiteVpnPeersParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						siteToSiteVpnPeersParam.Id = c.Int64("id")
@@ -17592,6 +17749,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						siteToSiteVpnPeersParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						siteToSiteVpnPeersParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						siteToSiteVpnPeersParam.Id = c.Int64("id")
@@ -17761,6 +17921,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -17834,6 +17998,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						staticRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						staticRouteInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						staticRouteInfoParam.Id = c.Int64("id")
@@ -17952,6 +18119,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						staticRouteInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						staticRouteInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						staticRouteInfoParam.Id = c.Int64("id")
@@ -19146,6 +19316,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -19231,6 +19405,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -19361,6 +19538,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						monitorParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						monitorParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						monitorParam.Id = c.Int64("id")
@@ -20229,6 +20409,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "create", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "create", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -20305,6 +20490,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "delete", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "delete", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -20445,6 +20635,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "dhcp-server-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "dhcp-server-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -20625,6 +20820,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "dhcp-static-mapping-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "dhcp-static-mapping-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -20924,6 +21124,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "firewall-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "firewall-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -21169,6 +21374,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "interface-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "interface-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -21294,6 +21504,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "l2tp-server-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "l2tp-server-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -21414,6 +21629,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -21530,6 +21750,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "monitor", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "monitor", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -21684,6 +21909,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "port-forwarding-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "port-forwarding-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -21799,6 +22029,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "pptp-server-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "pptp-server-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -21895,6 +22130,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -22134,6 +22374,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "site-to-site-vpn-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "site-to-site-vpn-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -22185,6 +22430,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "site-to-site-vpn-peers", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "site-to-site-vpn-peers", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -22384,6 +22634,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "static-nat-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "static-nat-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -22564,6 +22819,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("vpc-router", "static-route-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("vpc-router", "static-route-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -22685,6 +22945,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "update", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "update", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -22825,6 +23090,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("vpc-router", "user-info", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("vpc-router", "user-info", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_web_accel_gen.go
+++ b/command/cli/cli_web_accel_gen.go
@@ -73,6 +73,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -138,6 +142,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -251,6 +258,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -338,6 +348,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -411,6 +425,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -529,6 +546,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -698,6 +718,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -771,6 +795,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						certificateInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						certificateInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						certificateInfoParam.Id = c.Int64("id")
@@ -889,6 +916,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						certificateInfoParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						certificateInfoParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						certificateInfoParam.Id = c.Int64("id")
@@ -1079,6 +1109,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "Set target ID",
@@ -1167,6 +1201,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						certificateUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						certificateUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						certificateUpdateParam.Id = c.Int64("id")
@@ -1300,6 +1337,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						certificateUpdateParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						certificateUpdateParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						certificateUpdateParam.Id = c.Int64("id")
@@ -1480,6 +1520,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 				},
 				ShellComplete: func(c *cli.Context) {
 
@@ -1548,6 +1592,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteCacheParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteCacheParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -1663,6 +1710,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						deleteCacheParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						deleteCacheParam.QueryFile = c.String("query-file")
 					}
 
 					// Validate global params
@@ -1797,6 +1847,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("web-accel", "certificate-info", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("web-accel", "certificate-info", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1877,6 +1932,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("web-accel", "certificate-update", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("web-accel", "certificate-update", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1932,6 +1992,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("web-accel", "delete-cache", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("web-accel", "delete-cache", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -1973,6 +2038,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("web-accel", "list", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("web-accel", "list", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
@@ -2023,6 +2093,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("web-accel", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("web-accel", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/cli/cli_zone_gen.go
+++ b/command/cli/cli_zone_gen.go
@@ -93,6 +93,10 @@ func init() {
 				Name:  "query",
 				Usage: "JMESPath query(using when '--output-type' is json only)",
 			},
+			&cli.StringFlag{
+				Name:  "query-file",
+				Usage: "JMESPath query from file(using when '--output-type' is json only)",
+			},
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -161,6 +165,10 @@ func init() {
 					&cli.StringFlag{
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
+					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
 					},
 				},
 				ShellComplete: func(c *cli.Context) {
@@ -242,6 +250,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
 					}
 
 					if strings.HasPrefix(prev, "-") {
@@ -370,6 +381,9 @@ func init() {
 					if c.IsSet("query") {
 						listParam.Query = c.String("query")
 					}
+					if c.IsSet("query-file") {
+						listParam.QueryFile = c.String("query-file")
+					}
 
 					// Validate global params
 					if errors := command.GlobalOption.Validate(false); len(errors) > 0 {
@@ -458,6 +472,10 @@ func init() {
 						Name:  "query",
 						Usage: "JMESPath query(using when '--output-type' is json only)",
 					},
+					&cli.StringFlag{
+						Name:  "query-file",
+						Usage: "JMESPath query from file(using when '--output-type' is json only)",
+					},
 					&cli.Int64Flag{
 						Name:   "id",
 						Usage:  "[Required] set resource ID",
@@ -531,6 +549,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -649,6 +670,9 @@ func init() {
 					}
 					if c.IsSet("query") {
 						readParam.Query = c.String("query")
+					}
+					if c.IsSet("query-file") {
+						readParam.QueryFile = c.String("query-file")
 					}
 					if c.IsSet("id") {
 						readParam.Id = c.Int64("id")
@@ -792,6 +816,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("zone", "list", "query-file", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
 	AppendFlagCategoryMap("zone", "list", "quiet", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
@@ -848,6 +877,11 @@ func init() {
 		Order:       2147483627,
 	})
 	AppendFlagCategoryMap("zone", "read", "query", &schema.Category{
+		Key:         "output",
+		DisplayName: "Output options",
+		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("zone", "read", "query-file", &schema.Category{
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,

--- a/command/functions.go
+++ b/command/functions.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io/ioutil"
 	"reflect"
 	"strings"
 	"time"
@@ -129,7 +130,12 @@ func getOutputWriter(formatter output.Formatter) output.Output {
 	case "tsv":
 		return output.NewRowOutput(o.Out, o.Err, '\t', formatter)
 	case "json":
-		return output.NewJSONOutput(o.Out, o.Err, formatter.GetQuery())
+		query := formatter.GetQuery()
+		if query == "" {
+			bQuery, _ := ioutil.ReadFile(formatter.GetQueryFile()) // nolint: err was already checked
+			query = string(bQuery)
+		}
+		return output.NewJSONOutput(o.Out, o.Err, query)
 	case "yaml":
 		return output.NewYAMLOutput(o.Out, o.Err)
 	default:

--- a/command/params/params_archive_gen.go
+++ b/command/params/params_archive_gen.go
@@ -28,6 +28,7 @@ type ListArchiveParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListArchiveParam return new ListArchiveParam
@@ -90,6 +91,9 @@ func (p *ListArchiveParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -324,6 +328,13 @@ func (p *ListArchiveParam) SetQuery(v string) {
 func (p *ListArchiveParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListArchiveParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListArchiveParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateArchiveParam is input parameters for the sacloud API
 type CreateArchiveParam struct {
@@ -345,6 +356,7 @@ type CreateArchiveParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateArchiveParam return new CreateArchiveParam
@@ -407,6 +419,9 @@ func (p *CreateArchiveParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -693,6 +708,13 @@ func (p *CreateArchiveParam) SetQuery(v string) {
 func (p *CreateArchiveParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateArchiveParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateArchiveParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadArchiveParam is input parameters for the sacloud API
 type ReadArchiveParam struct {
@@ -706,6 +728,7 @@ type ReadArchiveParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -745,6 +768,9 @@ func (p *ReadArchiveParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -880,6 +906,13 @@ func (p *ReadArchiveParam) SetQuery(v string) {
 func (p *ReadArchiveParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadArchiveParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadArchiveParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadArchiveParam) SetId(v int64) {
 	p.Id = v
 }
@@ -905,6 +938,7 @@ type UpdateArchiveParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -959,6 +993,9 @@ func (p *UpdateArchiveParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1157,6 +1194,13 @@ func (p *UpdateArchiveParam) SetQuery(v string) {
 func (p *UpdateArchiveParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateArchiveParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateArchiveParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateArchiveParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1178,6 +1222,7 @@ type DeleteArchiveParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1220,6 +1265,9 @@ func (p *DeleteArchiveParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1362,6 +1410,13 @@ func (p *DeleteArchiveParam) SetQuery(v string) {
 func (p *DeleteArchiveParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeleteArchiveParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteArchiveParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeleteArchiveParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1384,6 +1439,7 @@ type UploadArchiveParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1429,6 +1485,9 @@ func (p *UploadArchiveParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1585,6 +1644,13 @@ func (p *UploadArchiveParam) SetQuery(v string) {
 func (p *UploadArchiveParam) GetQuery() string {
 	return p.Query
 }
+func (p *UploadArchiveParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UploadArchiveParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UploadArchiveParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1736,6 +1802,7 @@ type FtpOpenArchiveParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1778,6 +1845,9 @@ func (p *FtpOpenArchiveParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1919,6 +1989,13 @@ func (p *FtpOpenArchiveParam) SetQuery(v string) {
 
 func (p *FtpOpenArchiveParam) GetQuery() string {
 	return p.Query
+}
+func (p *FtpOpenArchiveParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *FtpOpenArchiveParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *FtpOpenArchiveParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_auth_status_gen.go
+++ b/command/params/params_auth_status_gen.go
@@ -19,6 +19,7 @@ type ShowAuthStatusParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewShowAuthStatusParam return new ShowAuthStatusParam
@@ -54,6 +55,9 @@ func (p *ShowAuthStatusParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -171,4 +175,11 @@ func (p *ShowAuthStatusParam) SetQuery(v string) {
 
 func (p *ShowAuthStatusParam) GetQuery() string {
 	return p.Query
+}
+func (p *ShowAuthStatusParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ShowAuthStatusParam) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_auto_backup_gen.go
+++ b/command/params/params_auto_backup_gen.go
@@ -25,6 +25,7 @@ type ListAutoBackupParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListAutoBackupParam return new ListAutoBackupParam
@@ -78,6 +79,9 @@ func (p *ListAutoBackupParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListAutoBackupParam) SetQuery(v string) {
 func (p *ListAutoBackupParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListAutoBackupParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListAutoBackupParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateAutoBackupParam is input parameters for the sacloud API
 type CreateAutoBackupParam struct {
@@ -290,6 +301,7 @@ type CreateAutoBackupParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateAutoBackupParam return new CreateAutoBackupParam
@@ -353,6 +365,9 @@ func (p *CreateAutoBackupParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -604,6 +619,13 @@ func (p *CreateAutoBackupParam) SetQuery(v string) {
 func (p *CreateAutoBackupParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateAutoBackupParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateAutoBackupParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadAutoBackupParam is input parameters for the sacloud API
 type ReadAutoBackupParam struct {
@@ -617,6 +639,7 @@ type ReadAutoBackupParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -656,6 +679,9 @@ func (p *ReadAutoBackupParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -791,6 +817,13 @@ func (p *ReadAutoBackupParam) SetQuery(v string) {
 func (p *ReadAutoBackupParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadAutoBackupParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadAutoBackupParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadAutoBackupParam) SetId(v int64) {
 	p.Id = v
 }
@@ -818,6 +851,7 @@ type UpdateAutoBackupParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -878,6 +912,9 @@ func (p *UpdateAutoBackupParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1104,6 +1141,13 @@ func (p *UpdateAutoBackupParam) SetQuery(v string) {
 func (p *UpdateAutoBackupParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateAutoBackupParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateAutoBackupParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateAutoBackupParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1125,6 +1169,7 @@ type DeleteAutoBackupParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1167,6 +1212,9 @@ func (p *DeleteAutoBackupParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1308,6 +1356,13 @@ func (p *DeleteAutoBackupParam) SetQuery(v string) {
 
 func (p *DeleteAutoBackupParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteAutoBackupParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteAutoBackupParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteAutoBackupParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_bill_gen.go
+++ b/command/params/params_bill_gen.go
@@ -140,6 +140,7 @@ type ListBillParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListBillParam return new ListBillParam
@@ -181,6 +182,9 @@ func (p *ListBillParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -326,4 +330,11 @@ func (p *ListBillParam) SetQuery(v string) {
 
 func (p *ListBillParam) GetQuery() string {
 	return p.Query
+}
+func (p *ListBillParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListBillParam) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_bridge_gen.go
+++ b/command/params/params_bridge_gen.go
@@ -24,6 +24,7 @@ type ListBridgeParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListBridgeParam return new ListBridgeParam
@@ -74,6 +75,9 @@ func (p *ListBridgeParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListBridgeParam) SetQuery(v string) {
 func (p *ListBridgeParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListBridgeParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListBridgeParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateBridgeParam is input parameters for the sacloud API
 type CreateBridgeParam struct {
@@ -267,6 +278,7 @@ type CreateBridgeParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateBridgeParam return new CreateBridgeParam
@@ -311,6 +323,9 @@ func (p *CreateBridgeParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -471,6 +486,13 @@ func (p *CreateBridgeParam) SetQuery(v string) {
 func (p *CreateBridgeParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateBridgeParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateBridgeParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadBridgeParam is input parameters for the sacloud API
 type ReadBridgeParam struct {
@@ -483,6 +505,7 @@ type ReadBridgeParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -519,6 +542,9 @@ func (p *ReadBridgeParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -647,6 +673,13 @@ func (p *ReadBridgeParam) SetQuery(v string) {
 func (p *ReadBridgeParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadBridgeParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadBridgeParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadBridgeParam) SetId(v int64) {
 	p.Id = v
 }
@@ -669,6 +702,7 @@ type UpdateBridgeParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -714,6 +748,9 @@ func (p *UpdateBridgeParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -877,6 +914,13 @@ func (p *UpdateBridgeParam) SetQuery(v string) {
 func (p *UpdateBridgeParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateBridgeParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateBridgeParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateBridgeParam) SetId(v int64) {
 	p.Id = v
 }
@@ -897,6 +941,7 @@ type DeleteBridgeParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -936,6 +981,9 @@ func (p *DeleteBridgeParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1070,6 +1118,13 @@ func (p *DeleteBridgeParam) SetQuery(v string) {
 
 func (p *DeleteBridgeParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteBridgeParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteBridgeParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteBridgeParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_coupon_gen.go
+++ b/command/params/params_coupon_gen.go
@@ -20,6 +20,7 @@ type ListCouponParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListCouponParam return new ListCouponParam
@@ -58,6 +59,9 @@ func (p *ListCouponParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -182,4 +186,11 @@ func (p *ListCouponParam) SetQuery(v string) {
 
 func (p *ListCouponParam) GetQuery() string {
 	return p.Query
+}
+func (p *ListCouponParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListCouponParam) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_database_gen.go
+++ b/command/params/params_database_gen.go
@@ -25,6 +25,7 @@ type ListDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListDatabaseParam return new ListDatabaseParam
@@ -78,6 +79,9 @@ func (p *ListDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListDatabaseParam) SetQuery(v string) {
 func (p *ListDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateDatabaseParam is input parameters for the sacloud API
 type CreateDatabaseParam struct {
@@ -302,6 +313,7 @@ type CreateDatabaseParam struct {
 	Format              string   `json:"format"`
 	FormatFile          string   `json:"format-file"`
 	Query               string   `json:"query"`
+	QueryFile           string   `json:"query-file"`
 }
 
 // NewCreateDatabaseParam return new CreateDatabaseParam
@@ -401,6 +413,9 @@ func (p *CreateDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -841,6 +856,13 @@ func (p *CreateDatabaseParam) SetQuery(v string) {
 func (p *CreateDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadDatabaseParam is input parameters for the sacloud API
 type ReadDatabaseParam struct {
@@ -854,6 +876,7 @@ type ReadDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -893,6 +916,9 @@ func (p *ReadDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1028,6 +1054,13 @@ func (p *ReadDatabaseParam) SetQuery(v string) {
 func (p *ReadDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1062,6 +1095,7 @@ type UpdateDatabaseParam struct {
 	Format              string   `json:"format"`
 	FormatFile          string   `json:"format-file"`
 	Query               string   `json:"query"`
+	QueryFile           string   `json:"query-file"`
 	Id                  int64    `json:"id"`
 }
 
@@ -1146,6 +1180,9 @@ func (p *UpdateDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1449,6 +1486,13 @@ func (p *UpdateDatabaseParam) SetQuery(v string) {
 func (p *UpdateDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1470,6 +1514,7 @@ type DeleteDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Force             bool     `json:"force"`
 	Id                int64    `json:"id"`
 }
@@ -1513,6 +1558,9 @@ func (p *DeleteDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Force) {
 		p.Force = false
@@ -1657,6 +1705,13 @@ func (p *DeleteDatabaseParam) SetQuery(v string) {
 
 func (p *DeleteDatabaseParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteDatabaseParam) SetForce(v bool) {
 	p.Force = v
@@ -2377,6 +2432,7 @@ type BackupInfoDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2416,6 +2472,9 @@ func (p *BackupInfoDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2551,6 +2610,13 @@ func (p *BackupInfoDatabaseParam) SetQuery(v string) {
 func (p *BackupInfoDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *BackupInfoDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *BackupInfoDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *BackupInfoDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2571,6 +2637,7 @@ type BackupCreateDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2610,6 +2677,9 @@ func (p *BackupCreateDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2745,6 +2815,13 @@ func (p *BackupCreateDatabaseParam) SetQuery(v string) {
 func (p *BackupCreateDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *BackupCreateDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *BackupCreateDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *BackupCreateDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2766,6 +2843,7 @@ type BackupRestoreDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2808,6 +2886,9 @@ func (p *BackupRestoreDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2964,6 +3045,13 @@ func (p *BackupRestoreDatabaseParam) SetQuery(v string) {
 func (p *BackupRestoreDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *BackupRestoreDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *BackupRestoreDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *BackupRestoreDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2985,6 +3073,7 @@ type BackupLockDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3027,6 +3116,9 @@ func (p *BackupLockDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3183,6 +3275,13 @@ func (p *BackupLockDatabaseParam) SetQuery(v string) {
 func (p *BackupLockDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *BackupLockDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *BackupLockDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *BackupLockDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3204,6 +3303,7 @@ type BackupUnlockDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3246,6 +3346,9 @@ func (p *BackupUnlockDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3402,6 +3505,13 @@ func (p *BackupUnlockDatabaseParam) SetQuery(v string) {
 func (p *BackupUnlockDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *BackupUnlockDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *BackupUnlockDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *BackupUnlockDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3423,6 +3533,7 @@ type BackupRemoveDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3465,6 +3576,9 @@ func (p *BackupRemoveDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3621,6 +3735,13 @@ func (p *BackupRemoveDatabaseParam) SetQuery(v string) {
 func (p *BackupRemoveDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *BackupRemoveDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *BackupRemoveDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *BackupRemoveDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3657,6 +3778,7 @@ type CloneDatabaseParam struct {
 	Format              string   `json:"format"`
 	FormatFile          string   `json:"format-file"`
 	Query               string   `json:"query"`
+	QueryFile           string   `json:"query-file"`
 	Id                  int64    `json:"id"`
 }
 
@@ -3748,6 +3870,9 @@ func (p *CloneDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4114,6 +4239,13 @@ func (p *CloneDatabaseParam) SetQuery(v string) {
 func (p *CloneDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *CloneDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CloneDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *CloneDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4142,6 +4274,7 @@ type ReplicaCreateDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4205,6 +4338,9 @@ func (p *ReplicaCreateDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4466,6 +4602,13 @@ func (p *ReplicaCreateDatabaseParam) SetQuery(v string) {
 func (p *ReplicaCreateDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReplicaCreateDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReplicaCreateDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReplicaCreateDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4489,6 +4632,7 @@ type MonitorCpuDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4540,6 +4684,9 @@ func (p *MonitorCpuDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4717,6 +4864,13 @@ func (p *MonitorCpuDatabaseParam) SetQuery(v string) {
 func (p *MonitorCpuDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorCpuDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorCpuDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorCpuDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4740,6 +4894,7 @@ type MonitorMemoryDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4791,6 +4946,9 @@ func (p *MonitorMemoryDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4968,6 +5126,13 @@ func (p *MonitorMemoryDatabaseParam) SetQuery(v string) {
 func (p *MonitorMemoryDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorMemoryDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorMemoryDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorMemoryDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4991,6 +5156,7 @@ type MonitorNicDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -5042,6 +5208,9 @@ func (p *MonitorNicDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -5219,6 +5388,13 @@ func (p *MonitorNicDatabaseParam) SetQuery(v string) {
 func (p *MonitorNicDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorNicDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorNicDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorNicDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5242,6 +5418,7 @@ type MonitorSystemDiskDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -5293,6 +5470,9 @@ func (p *MonitorSystemDiskDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -5470,6 +5650,13 @@ func (p *MonitorSystemDiskDatabaseParam) SetQuery(v string) {
 func (p *MonitorSystemDiskDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorSystemDiskDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorSystemDiskDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorSystemDiskDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5493,6 +5680,7 @@ type MonitorBackupDiskDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -5544,6 +5732,9 @@ func (p *MonitorBackupDiskDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -5721,6 +5912,13 @@ func (p *MonitorBackupDiskDatabaseParam) SetQuery(v string) {
 func (p *MonitorBackupDiskDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorBackupDiskDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorBackupDiskDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorBackupDiskDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5744,6 +5942,7 @@ type MonitorSystemDiskSizeDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -5795,6 +5994,9 @@ func (p *MonitorSystemDiskSizeDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -5972,6 +6174,13 @@ func (p *MonitorSystemDiskSizeDatabaseParam) SetQuery(v string) {
 func (p *MonitorSystemDiskSizeDatabaseParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorSystemDiskSizeDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorSystemDiskSizeDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorSystemDiskSizeDatabaseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -5995,6 +6204,7 @@ type MonitorBackupDiskSizeDatabaseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -6046,6 +6256,9 @@ func (p *MonitorBackupDiskSizeDatabaseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -6222,6 +6435,13 @@ func (p *MonitorBackupDiskSizeDatabaseParam) SetQuery(v string) {
 
 func (p *MonitorBackupDiskSizeDatabaseParam) GetQuery() string {
 	return p.Query
+}
+func (p *MonitorBackupDiskSizeDatabaseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorBackupDiskSizeDatabaseParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *MonitorBackupDiskSizeDatabaseParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_disk_gen.go
+++ b/command/params/params_disk_gen.go
@@ -29,6 +29,7 @@ type ListDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListDiskParam return new ListDiskParam
@@ -94,6 +95,9 @@ func (p *ListDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -335,6 +339,13 @@ func (p *ListDiskParam) SetQuery(v string) {
 func (p *ListDiskParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListDiskParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateDiskParam is input parameters for the sacloud API
 type CreateDiskParam struct {
@@ -358,6 +369,7 @@ type CreateDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateDiskParam return new CreateDiskParam
@@ -431,6 +443,9 @@ func (p *CreateDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -742,6 +757,13 @@ func (p *CreateDiskParam) SetQuery(v string) {
 func (p *CreateDiskParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateDiskParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadDiskParam is input parameters for the sacloud API
 type ReadDiskParam struct {
@@ -755,6 +777,7 @@ type ReadDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -794,6 +817,9 @@ func (p *ReadDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -929,6 +955,13 @@ func (p *ReadDiskParam) SetQuery(v string) {
 func (p *ReadDiskParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadDiskParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -955,6 +988,7 @@ type UpdateDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1012,6 +1046,9 @@ func (p *UpdateDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1224,6 +1261,13 @@ func (p *UpdateDiskParam) SetQuery(v string) {
 func (p *UpdateDiskParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateDiskParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1245,6 +1289,7 @@ type DeleteDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1287,6 +1332,9 @@ func (p *DeleteDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1429,6 +1477,13 @@ func (p *DeleteDiskParam) SetQuery(v string) {
 func (p *DeleteDiskParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeleteDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteDiskParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeleteDiskParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1458,6 +1513,7 @@ type EditDiskParam struct {
 	Format              string   `json:"format"`
 	FormatFile          string   `json:"format-file"`
 	Query               string   `json:"query"`
+	QueryFile           string   `json:"query-file"`
 	Id                  int64    `json:"id"`
 }
 
@@ -1527,6 +1583,9 @@ func (p *EditDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1745,6 +1804,13 @@ func (p *EditDiskParam) SetQuery(v string) {
 
 func (p *EditDiskParam) GetQuery() string {
 	return p.Query
+}
+func (p *EditDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *EditDiskParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *EditDiskParam) SetId(v int64) {
 	p.Id = v
@@ -2490,6 +2556,7 @@ type MonitorDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	End               string   `json:"end"`
 	Id                int64    `json:"id"`
 	KeyFormat         string   `json:"key-format"`
@@ -2535,6 +2602,9 @@ func (p *MonitorDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.End) {
 		p.End = ""
@@ -2699,6 +2769,13 @@ func (p *MonitorDiskParam) SetQuery(v string) {
 
 func (p *MonitorDiskParam) GetQuery() string {
 	return p.Query
+}
+func (p *MonitorDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorDiskParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *MonitorDiskParam) SetEnd(v string) {
 	p.End = v

--- a/command/params/params_dns_gen.go
+++ b/command/params/params_dns_gen.go
@@ -25,6 +25,7 @@ type ListDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListDNSParam return new ListDNSParam
@@ -78,6 +79,9 @@ func (p *ListDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListDNSParam) SetQuery(v string) {
 func (p *ListDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // RecordInfoDNSParam is input parameters for the sacloud API
 type RecordInfoDNSParam struct {
@@ -285,6 +296,7 @@ type RecordInfoDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -330,6 +342,9 @@ func (p *RecordInfoDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -493,6 +508,13 @@ func (p *RecordInfoDNSParam) SetQuery(v string) {
 func (p *RecordInfoDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *RecordInfoDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RecordInfoDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RecordInfoDNSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -517,6 +539,7 @@ type CreateDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateDNSParam return new CreateDNSParam
@@ -567,6 +590,9 @@ func (p *CreateDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -755,6 +781,13 @@ func (p *CreateDNSParam) SetQuery(v string) {
 func (p *CreateDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // RecordAddDNSParam is input parameters for the sacloud API
 type RecordAddDNSParam struct {
@@ -778,6 +811,7 @@ type RecordAddDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -851,6 +885,9 @@ func (p *RecordAddDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1126,6 +1163,13 @@ func (p *RecordAddDNSParam) SetQuery(v string) {
 func (p *RecordAddDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *RecordAddDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RecordAddDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RecordAddDNSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1146,6 +1190,7 @@ type ReadDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1185,6 +1230,9 @@ func (p *ReadDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1320,6 +1368,13 @@ func (p *ReadDNSParam) SetQuery(v string) {
 func (p *ReadDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadDNSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1351,6 +1406,7 @@ type RecordUpdateDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1423,6 +1479,9 @@ func (p *RecordUpdateDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1698,6 +1757,13 @@ func (p *RecordUpdateDNSParam) SetQuery(v string) {
 func (p *RecordUpdateDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *RecordUpdateDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RecordUpdateDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RecordUpdateDNSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1720,6 +1786,7 @@ type RecordDeleteDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1765,6 +1832,9 @@ func (p *RecordDeleteDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1921,6 +1991,13 @@ func (p *RecordDeleteDNSParam) SetQuery(v string) {
 func (p *RecordDeleteDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *RecordDeleteDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RecordDeleteDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RecordDeleteDNSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1945,6 +2022,7 @@ type UpdateDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1996,6 +2074,9 @@ func (p *UpdateDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2180,6 +2261,13 @@ func (p *UpdateDNSParam) SetQuery(v string) {
 func (p *UpdateDNSParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateDNSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2201,6 +2289,7 @@ type DeleteDNSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2243,6 +2332,9 @@ func (p *DeleteDNSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2384,6 +2476,13 @@ func (p *DeleteDNSParam) SetQuery(v string) {
 
 func (p *DeleteDNSParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteDNSParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteDNSParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_gslb_gen.go
+++ b/command/params/params_gslb_gen.go
@@ -25,6 +25,7 @@ type ListGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListGSLBParam return new ListGSLBParam
@@ -78,6 +79,9 @@ func (p *ListGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListGSLBParam) SetQuery(v string) {
 func (p *ListGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ServerInfoGSLBParam is input parameters for the sacloud API
 type ServerInfoGSLBParam struct {
@@ -283,6 +294,7 @@ type ServerInfoGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -322,6 +334,9 @@ func (p *ServerInfoGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -457,6 +472,13 @@ func (p *ServerInfoGSLBParam) SetQuery(v string) {
 func (p *ServerInfoGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *ServerInfoGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerInfoGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ServerInfoGSLBParam) SetId(v int64) {
 	p.Id = v
 }
@@ -489,6 +511,7 @@ type CreateGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateGSLBParam return new CreateGSLBParam
@@ -570,6 +593,9 @@ func (p *CreateGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -849,6 +875,13 @@ func (p *CreateGSLBParam) SetQuery(v string) {
 func (p *CreateGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ServerAddGSLBParam is input parameters for the sacloud API
 type ServerAddGSLBParam struct {
@@ -866,6 +899,7 @@ type ServerAddGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -917,6 +951,9 @@ func (p *ServerAddGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1094,6 +1131,13 @@ func (p *ServerAddGSLBParam) SetQuery(v string) {
 func (p *ServerAddGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *ServerAddGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerAddGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ServerAddGSLBParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1114,6 +1158,7 @@ type ReadGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1153,6 +1198,9 @@ func (p *ReadGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1288,6 +1336,13 @@ func (p *ReadGSLBParam) SetQuery(v string) {
 func (p *ReadGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadGSLBParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1313,6 +1368,7 @@ type ServerUpdateGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1367,6 +1423,9 @@ func (p *ServerUpdateGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1558,6 +1617,13 @@ func (p *ServerUpdateGSLBParam) SetQuery(v string) {
 func (p *ServerUpdateGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *ServerUpdateGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerUpdateGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ServerUpdateGSLBParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1580,6 +1646,7 @@ type ServerDeleteGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1625,6 +1692,9 @@ func (p *ServerDeleteGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1781,6 +1851,13 @@ func (p *ServerDeleteGSLBParam) SetQuery(v string) {
 func (p *ServerDeleteGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *ServerDeleteGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerDeleteGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ServerDeleteGSLBParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1814,6 +1891,7 @@ type UpdateGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1892,6 +1970,9 @@ func (p *UpdateGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2167,6 +2248,13 @@ func (p *UpdateGSLBParam) SetQuery(v string) {
 func (p *UpdateGSLBParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateGSLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateGSLBParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2188,6 +2276,7 @@ type DeleteGSLBParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2230,6 +2319,9 @@ func (p *DeleteGSLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2371,6 +2463,13 @@ func (p *DeleteGSLBParam) SetQuery(v string) {
 
 func (p *DeleteGSLBParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteGSLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteGSLBParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteGSLBParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_icon_gen.go
+++ b/command/params/params_icon_gen.go
@@ -26,6 +26,7 @@ type ListIconParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListIconParam return new ListIconParam
@@ -82,6 +83,9 @@ func (p *ListIconParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -288,6 +292,13 @@ func (p *ListIconParam) SetQuery(v string) {
 func (p *ListIconParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListIconParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListIconParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateIconParam is input parameters for the sacloud API
 type CreateIconParam struct {
@@ -304,6 +315,7 @@ type CreateIconParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateIconParam return new CreateIconParam
@@ -351,6 +363,9 @@ func (p *CreateIconParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -532,6 +547,13 @@ func (p *CreateIconParam) SetQuery(v string) {
 func (p *CreateIconParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateIconParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateIconParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadIconParam is input parameters for the sacloud API
 type ReadIconParam struct {
@@ -545,6 +567,7 @@ type ReadIconParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -584,6 +607,9 @@ func (p *ReadIconParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -719,6 +745,13 @@ func (p *ReadIconParam) SetQuery(v string) {
 func (p *ReadIconParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadIconParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadIconParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadIconParam) SetId(v int64) {
 	p.Id = v
 }
@@ -742,6 +775,7 @@ type UpdateIconParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -790,6 +824,9 @@ func (p *UpdateIconParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -960,6 +997,13 @@ func (p *UpdateIconParam) SetQuery(v string) {
 func (p *UpdateIconParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateIconParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateIconParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateIconParam) SetId(v int64) {
 	p.Id = v
 }
@@ -981,6 +1025,7 @@ type DeleteIconParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1023,6 +1068,9 @@ func (p *DeleteIconParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1164,6 +1212,13 @@ func (p *DeleteIconParam) SetQuery(v string) {
 
 func (p *DeleteIconParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteIconParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteIconParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteIconParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_interface_gen.go
+++ b/command/params/params_interface_gen.go
@@ -24,6 +24,7 @@ type ListInterfaceParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListInterfaceParam return new ListInterfaceParam
@@ -74,6 +75,9 @@ func (p *ListInterfaceParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListInterfaceParam) SetQuery(v string) {
 func (p *ListInterfaceParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListInterfaceParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListInterfaceParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PacketFilterConnectInterfaceParam is input parameters for the sacloud API
 type PacketFilterConnectInterfaceParam struct {
@@ -399,6 +410,7 @@ type CreateInterfaceParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateInterfaceParam return new CreateInterfaceParam
@@ -440,6 +452,9 @@ func (p *CreateInterfaceParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -586,6 +601,13 @@ func (p *CreateInterfaceParam) SetQuery(v string) {
 func (p *CreateInterfaceParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateInterfaceParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateInterfaceParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PacketFilterDisconnectInterfaceParam is input parameters for the sacloud API
 type PacketFilterDisconnectInterfaceParam struct {
@@ -731,6 +753,7 @@ type ReadInterfaceParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -767,6 +790,9 @@ func (p *ReadInterfaceParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -895,6 +921,13 @@ func (p *ReadInterfaceParam) SetQuery(v string) {
 func (p *ReadInterfaceParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadInterfaceParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadInterfaceParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadInterfaceParam) SetId(v int64) {
 	p.Id = v
 }
@@ -916,6 +949,7 @@ type UpdateInterfaceParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -958,6 +992,9 @@ func (p *UpdateInterfaceParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1107,6 +1144,13 @@ func (p *UpdateInterfaceParam) SetQuery(v string) {
 func (p *UpdateInterfaceParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateInterfaceParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateInterfaceParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateInterfaceParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1127,6 +1171,7 @@ type DeleteInterfaceParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1166,6 +1211,9 @@ func (p *DeleteInterfaceParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1300,6 +1348,13 @@ func (p *DeleteInterfaceParam) SetQuery(v string) {
 
 func (p *DeleteInterfaceParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteInterfaceParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteInterfaceParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteInterfaceParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_internet_gen.go
+++ b/command/params/params_internet_gen.go
@@ -25,6 +25,7 @@ type ListInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListInternetParam return new ListInternetParam
@@ -78,6 +79,9 @@ func (p *ListInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListInternetParam) SetQuery(v string) {
 func (p *ListInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateInternetParam is input parameters for the sacloud API
 type CreateInternetParam struct {
@@ -289,6 +300,7 @@ type CreateInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateInternetParam return new CreateInternetParam
@@ -349,6 +361,9 @@ func (p *CreateInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -579,6 +594,13 @@ func (p *CreateInternetParam) SetQuery(v string) {
 func (p *CreateInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadInternetParam is input parameters for the sacloud API
 type ReadInternetParam struct {
@@ -592,6 +614,7 @@ type ReadInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -631,6 +654,9 @@ func (p *ReadInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -766,6 +792,13 @@ func (p *ReadInternetParam) SetQuery(v string) {
 func (p *ReadInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -792,6 +825,7 @@ type UpdateInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -849,6 +883,9 @@ func (p *UpdateInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1061,6 +1098,13 @@ func (p *UpdateInternetParam) SetQuery(v string) {
 func (p *UpdateInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1082,6 +1126,7 @@ type DeleteInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1124,6 +1169,9 @@ func (p *DeleteInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1266,6 +1314,13 @@ func (p *DeleteInternetParam) SetQuery(v string) {
 func (p *DeleteInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeleteInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeleteInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1288,6 +1343,7 @@ type UpdateBandwidthInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1336,6 +1392,9 @@ func (p *UpdateBandwidthInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1499,6 +1558,13 @@ func (p *UpdateBandwidthInternetParam) SetQuery(v string) {
 func (p *UpdateBandwidthInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateBandwidthInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateBandwidthInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateBandwidthInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1519,6 +1585,7 @@ type SubnetInfoInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1558,6 +1625,9 @@ func (p *SubnetInfoInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1693,6 +1763,13 @@ func (p *SubnetInfoInternetParam) SetQuery(v string) {
 func (p *SubnetInfoInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *SubnetInfoInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *SubnetInfoInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *SubnetInfoInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1716,6 +1793,7 @@ type SubnetAddInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1767,6 +1845,9 @@ func (p *SubnetAddInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1951,6 +2032,13 @@ func (p *SubnetAddInternetParam) SetQuery(v string) {
 func (p *SubnetAddInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *SubnetAddInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *SubnetAddInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *SubnetAddInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2111,6 +2199,7 @@ type SubnetUpdateInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2159,6 +2248,9 @@ func (p *SubnetUpdateInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2336,6 +2428,13 @@ func (p *SubnetUpdateInternetParam) SetQuery(v string) {
 func (p *SubnetUpdateInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *SubnetUpdateInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *SubnetUpdateInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *SubnetUpdateInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2356,6 +2455,7 @@ type Ipv6InfoInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2395,6 +2495,9 @@ func (p *Ipv6InfoInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2530,6 +2633,13 @@ func (p *Ipv6InfoInternetParam) SetQuery(v string) {
 func (p *Ipv6InfoInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *Ipv6InfoInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *Ipv6InfoInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *Ipv6InfoInternetParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2551,6 +2661,7 @@ type Ipv6EnableInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2593,6 +2704,9 @@ func (p *Ipv6EnableInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2734,6 +2848,13 @@ func (p *Ipv6EnableInternetParam) SetQuery(v string) {
 
 func (p *Ipv6EnableInternetParam) GetQuery() string {
 	return p.Query
+}
+func (p *Ipv6EnableInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *Ipv6EnableInternetParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *Ipv6EnableInternetParam) SetId(v int64) {
 	p.Id = v
@@ -2877,6 +2998,7 @@ type MonitorInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2928,6 +3050,9 @@ func (p *MonitorInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3104,6 +3229,13 @@ func (p *MonitorInternetParam) SetQuery(v string) {
 
 func (p *MonitorInternetParam) GetQuery() string {
 	return p.Query
+}
+func (p *MonitorInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorInternetParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *MonitorInternetParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_ipv4_gen.go
+++ b/command/params/params_ipv4_gen.go
@@ -24,6 +24,7 @@ type ListIpv4Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListIpv4Param return new ListIpv4Param
@@ -74,6 +75,9 @@ func (p *ListIpv4Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListIpv4Param) SetQuery(v string) {
 func (p *ListIpv4Param) GetQuery() string {
 	return p.Query
 }
+func (p *ListIpv4Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListIpv4Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrAddIpv4Param is input parameters for the sacloud API
 type PtrAddIpv4Param struct {
@@ -266,6 +277,7 @@ type PtrAddIpv4Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrAddIpv4Param return new PtrAddIpv4Param
@@ -307,6 +319,9 @@ func (p *PtrAddIpv4Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -446,6 +461,13 @@ func (p *PtrAddIpv4Param) SetQuery(v string) {
 func (p *PtrAddIpv4Param) GetQuery() string {
 	return p.Query
 }
+func (p *PtrAddIpv4Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrAddIpv4Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrReadIpv4Param is input parameters for the sacloud API
 type PtrReadIpv4Param struct {
@@ -458,6 +480,7 @@ type PtrReadIpv4Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrReadIpv4Param return new PtrReadIpv4Param
@@ -493,6 +516,9 @@ func (p *PtrReadIpv4Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -611,6 +637,13 @@ func (p *PtrReadIpv4Param) SetQuery(v string) {
 func (p *PtrReadIpv4Param) GetQuery() string {
 	return p.Query
 }
+func (p *PtrReadIpv4Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrReadIpv4Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrUpdateIpv4Param is input parameters for the sacloud API
 type PtrUpdateIpv4Param struct {
@@ -625,6 +658,7 @@ type PtrUpdateIpv4Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrUpdateIpv4Param return new PtrUpdateIpv4Param
@@ -666,6 +700,9 @@ func (p *PtrUpdateIpv4Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -805,6 +842,13 @@ func (p *PtrUpdateIpv4Param) SetQuery(v string) {
 func (p *PtrUpdateIpv4Param) GetQuery() string {
 	return p.Query
 }
+func (p *PtrUpdateIpv4Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrUpdateIpv4Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrDeleteIpv4Param is input parameters for the sacloud API
 type PtrDeleteIpv4Param struct {
@@ -818,6 +862,7 @@ type PtrDeleteIpv4Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrDeleteIpv4Param return new PtrDeleteIpv4Param
@@ -856,6 +901,9 @@ func (p *PtrDeleteIpv4Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -980,4 +1028,11 @@ func (p *PtrDeleteIpv4Param) SetQuery(v string) {
 
 func (p *PtrDeleteIpv4Param) GetQuery() string {
 	return p.Query
+}
+func (p *PtrDeleteIpv4Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrDeleteIpv4Param) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_ipv6_gen.go
+++ b/command/params/params_ipv6_gen.go
@@ -26,6 +26,7 @@ type ListIpv6Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListIpv6Param return new ListIpv6Param
@@ -82,6 +83,9 @@ func (p *ListIpv6Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -288,6 +292,13 @@ func (p *ListIpv6Param) SetQuery(v string) {
 func (p *ListIpv6Param) GetQuery() string {
 	return p.Query
 }
+func (p *ListIpv6Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListIpv6Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrAddIpv6Param is input parameters for the sacloud API
 type PtrAddIpv6Param struct {
@@ -302,6 +313,7 @@ type PtrAddIpv6Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrAddIpv6Param return new PtrAddIpv6Param
@@ -343,6 +355,9 @@ func (p *PtrAddIpv6Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -482,6 +497,13 @@ func (p *PtrAddIpv6Param) SetQuery(v string) {
 func (p *PtrAddIpv6Param) GetQuery() string {
 	return p.Query
 }
+func (p *PtrAddIpv6Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrAddIpv6Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrReadIpv6Param is input parameters for the sacloud API
 type PtrReadIpv6Param struct {
@@ -494,6 +516,7 @@ type PtrReadIpv6Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrReadIpv6Param return new PtrReadIpv6Param
@@ -529,6 +552,9 @@ func (p *PtrReadIpv6Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -647,6 +673,13 @@ func (p *PtrReadIpv6Param) SetQuery(v string) {
 func (p *PtrReadIpv6Param) GetQuery() string {
 	return p.Query
 }
+func (p *PtrReadIpv6Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrReadIpv6Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrUpdateIpv6Param is input parameters for the sacloud API
 type PtrUpdateIpv6Param struct {
@@ -661,6 +694,7 @@ type PtrUpdateIpv6Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrUpdateIpv6Param return new PtrUpdateIpv6Param
@@ -702,6 +736,9 @@ func (p *PtrUpdateIpv6Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -841,6 +878,13 @@ func (p *PtrUpdateIpv6Param) SetQuery(v string) {
 func (p *PtrUpdateIpv6Param) GetQuery() string {
 	return p.Query
 }
+func (p *PtrUpdateIpv6Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrUpdateIpv6Param) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // PtrDeleteIpv6Param is input parameters for the sacloud API
 type PtrDeleteIpv6Param struct {
@@ -854,6 +898,7 @@ type PtrDeleteIpv6Param struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewPtrDeleteIpv6Param return new PtrDeleteIpv6Param
@@ -892,6 +937,9 @@ func (p *PtrDeleteIpv6Param) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -1016,4 +1064,11 @@ func (p *PtrDeleteIpv6Param) SetQuery(v string) {
 
 func (p *PtrDeleteIpv6Param) GetQuery() string {
 	return p.Query
+}
+func (p *PtrDeleteIpv6Param) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PtrDeleteIpv6Param) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_iso_image_gen.go
+++ b/command/params/params_iso_image_gen.go
@@ -26,6 +26,7 @@ type ListISOImageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListISOImageParam return new ListISOImageParam
@@ -82,6 +83,9 @@ func (p *ListISOImageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -288,6 +292,13 @@ func (p *ListISOImageParam) SetQuery(v string) {
 func (p *ListISOImageParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListISOImageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListISOImageParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateISOImageParam is input parameters for the sacloud API
 type CreateISOImageParam struct {
@@ -307,6 +318,7 @@ type CreateISOImageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateISOImageParam return new CreateISOImageParam
@@ -366,6 +378,9 @@ func (p *CreateISOImageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -589,6 +604,13 @@ func (p *CreateISOImageParam) SetQuery(v string) {
 func (p *CreateISOImageParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateISOImageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateISOImageParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadISOImageParam is input parameters for the sacloud API
 type ReadISOImageParam struct {
@@ -602,6 +624,7 @@ type ReadISOImageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -641,6 +664,9 @@ func (p *ReadISOImageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -776,6 +802,13 @@ func (p *ReadISOImageParam) SetQuery(v string) {
 func (p *ReadISOImageParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadISOImageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadISOImageParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadISOImageParam) SetId(v int64) {
 	p.Id = v
 }
@@ -801,6 +834,7 @@ type UpdateISOImageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -855,6 +889,9 @@ func (p *UpdateISOImageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1053,6 +1090,13 @@ func (p *UpdateISOImageParam) SetQuery(v string) {
 func (p *UpdateISOImageParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateISOImageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateISOImageParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateISOImageParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1074,6 +1118,7 @@ type DeleteISOImageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1116,6 +1161,9 @@ func (p *DeleteISOImageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1258,6 +1306,13 @@ func (p *DeleteISOImageParam) SetQuery(v string) {
 func (p *DeleteISOImageParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeleteISOImageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteISOImageParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeleteISOImageParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1280,6 +1335,7 @@ type UploadISOImageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1325,6 +1381,9 @@ func (p *UploadISOImageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1481,6 +1540,13 @@ func (p *UploadISOImageParam) SetQuery(v string) {
 func (p *UploadISOImageParam) GetQuery() string {
 	return p.Query
 }
+func (p *UploadISOImageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UploadISOImageParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UploadISOImageParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1632,6 +1698,7 @@ type FtpOpenISOImageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1674,6 +1741,9 @@ func (p *FtpOpenISOImageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1815,6 +1885,13 @@ func (p *FtpOpenISOImageParam) SetQuery(v string) {
 
 func (p *FtpOpenISOImageParam) GetQuery() string {
 	return p.Query
+}
+func (p *FtpOpenISOImageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *FtpOpenISOImageParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *FtpOpenISOImageParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_license_gen.go
+++ b/command/params/params_license_gen.go
@@ -24,6 +24,7 @@ type ListLicenseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListLicenseParam return new ListLicenseParam
@@ -74,6 +75,9 @@ func (p *ListLicenseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListLicenseParam) SetQuery(v string) {
 func (p *ListLicenseParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListLicenseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListLicenseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateLicenseParam is input parameters for the sacloud API
 type CreateLicenseParam struct {
@@ -267,6 +278,7 @@ type CreateLicenseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateLicenseParam return new CreateLicenseParam
@@ -311,6 +323,9 @@ func (p *CreateLicenseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -464,6 +479,13 @@ func (p *CreateLicenseParam) SetQuery(v string) {
 func (p *CreateLicenseParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateLicenseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateLicenseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadLicenseParam is input parameters for the sacloud API
 type ReadLicenseParam struct {
@@ -476,6 +498,7 @@ type ReadLicenseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -512,6 +535,9 @@ func (p *ReadLicenseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -640,6 +666,13 @@ func (p *ReadLicenseParam) SetQuery(v string) {
 func (p *ReadLicenseParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadLicenseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadLicenseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadLicenseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -661,6 +694,7 @@ type UpdateLicenseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -703,6 +737,9 @@ func (p *UpdateLicenseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -852,6 +889,13 @@ func (p *UpdateLicenseParam) SetQuery(v string) {
 func (p *UpdateLicenseParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateLicenseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateLicenseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateLicenseParam) SetId(v int64) {
 	p.Id = v
 }
@@ -872,6 +916,7 @@ type DeleteLicenseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -911,6 +956,9 @@ func (p *DeleteLicenseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1045,6 +1093,13 @@ func (p *DeleteLicenseParam) SetQuery(v string) {
 
 func (p *DeleteLicenseParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteLicenseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteLicenseParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteLicenseParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_load_balancer_gen.go
+++ b/command/params/params_load_balancer_gen.go
@@ -25,6 +25,7 @@ type ListLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListLoadBalancerParam return new ListLoadBalancerParam
@@ -78,6 +79,9 @@ func (p *ListLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListLoadBalancerParam) SetQuery(v string) {
 func (p *ListLoadBalancerParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateLoadBalancerParam is input parameters for the sacloud API
 type CreateLoadBalancerParam struct {
@@ -295,6 +306,7 @@ type CreateLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateLoadBalancerParam return new CreateLoadBalancerParam
@@ -373,6 +385,9 @@ func (p *CreateLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -687,6 +702,13 @@ func (p *CreateLoadBalancerParam) SetQuery(v string) {
 func (p *CreateLoadBalancerParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadLoadBalancerParam is input parameters for the sacloud API
 type ReadLoadBalancerParam struct {
@@ -700,6 +722,7 @@ type ReadLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -739,6 +762,9 @@ func (p *ReadLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -874,6 +900,13 @@ func (p *ReadLoadBalancerParam) SetQuery(v string) {
 func (p *ReadLoadBalancerParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -899,6 +932,7 @@ type UpdateLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -953,6 +987,9 @@ func (p *UpdateLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1151,6 +1188,13 @@ func (p *UpdateLoadBalancerParam) SetQuery(v string) {
 func (p *UpdateLoadBalancerParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateLoadBalancerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1173,6 +1217,7 @@ type DeleteLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1218,6 +1263,9 @@ func (p *DeleteLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1366,6 +1414,13 @@ func (p *DeleteLoadBalancerParam) SetQuery(v string) {
 
 func (p *DeleteLoadBalancerParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteLoadBalancerParam) SetId(v int64) {
 	p.Id = v
@@ -2079,6 +2134,7 @@ type VipInfoLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2118,6 +2174,9 @@ func (p *VipInfoLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2252,6 +2311,13 @@ func (p *VipInfoLoadBalancerParam) SetQuery(v string) {
 
 func (p *VipInfoLoadBalancerParam) GetQuery() string {
 	return p.Query
+}
+func (p *VipInfoLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *VipInfoLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *VipInfoLoadBalancerParam) SetId(v int64) {
 	p.Id = v
@@ -2855,6 +2921,7 @@ type ServerInfoLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2903,6 +2970,9 @@ func (p *ServerInfoLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3100,6 +3170,13 @@ func (p *ServerInfoLoadBalancerParam) SetQuery(v string) {
 
 func (p *ServerInfoLoadBalancerParam) GetQuery() string {
 	return p.Query
+}
+func (p *ServerInfoLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerInfoLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ServerInfoLoadBalancerParam) SetId(v int64) {
 	p.Id = v
@@ -3893,6 +3970,7 @@ type MonitorLoadBalancerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3944,6 +4022,9 @@ func (p *MonitorLoadBalancerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4120,6 +4201,13 @@ func (p *MonitorLoadBalancerParam) SetQuery(v string) {
 
 func (p *MonitorLoadBalancerParam) GetQuery() string {
 	return p.Query
+}
+func (p *MonitorLoadBalancerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorLoadBalancerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *MonitorLoadBalancerParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_mobile_gateway_gen.go
+++ b/command/params/params_mobile_gateway_gen.go
@@ -25,6 +25,7 @@ type ListMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListMobileGatewayParam return new ListMobileGatewayParam
@@ -78,6 +79,9 @@ func (p *ListMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListMobileGatewayParam) SetQuery(v string) {
 func (p *ListMobileGatewayParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateMobileGatewayParam is input parameters for the sacloud API
 type CreateMobileGatewayParam struct {
@@ -288,6 +299,7 @@ type CreateMobileGatewayParam struct {
 	Format             string   `json:"format"`
 	FormatFile         string   `json:"format-file"`
 	Query              string   `json:"query"`
+	QueryFile          string   `json:"query-file"`
 }
 
 // NewCreateMobileGatewayParam return new CreateMobileGatewayParam
@@ -341,6 +353,9 @@ func (p *CreateMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -536,6 +551,13 @@ func (p *CreateMobileGatewayParam) SetQuery(v string) {
 func (p *CreateMobileGatewayParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadMobileGatewayParam is input parameters for the sacloud API
 type ReadMobileGatewayParam struct {
@@ -549,6 +571,7 @@ type ReadMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -588,6 +611,9 @@ func (p *ReadMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -723,6 +749,13 @@ func (p *ReadMobileGatewayParam) SetQuery(v string) {
 func (p *ReadMobileGatewayParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadMobileGatewayParam) SetId(v int64) {
 	p.Id = v
 }
@@ -749,6 +782,7 @@ type UpdateMobileGatewayParam struct {
 	Format             string   `json:"format"`
 	FormatFile         string   `json:"format-file"`
 	Query              string   `json:"query"`
+	QueryFile          string   `json:"query-file"`
 	Id                 int64    `json:"id"`
 }
 
@@ -806,6 +840,9 @@ func (p *UpdateMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1011,6 +1048,13 @@ func (p *UpdateMobileGatewayParam) SetQuery(v string) {
 func (p *UpdateMobileGatewayParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateMobileGatewayParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1033,6 +1077,7 @@ type DeleteMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1078,6 +1123,9 @@ func (p *DeleteMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1226,6 +1274,13 @@ func (p *DeleteMobileGatewayParam) SetQuery(v string) {
 
 func (p *DeleteMobileGatewayParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteMobileGatewayParam) SetId(v int64) {
 	p.Id = v
@@ -1939,6 +1994,7 @@ type InterfaceInfoMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1978,6 +2034,9 @@ func (p *InterfaceInfoMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2112,6 +2171,13 @@ func (p *InterfaceInfoMobileGatewayParam) SetQuery(v string) {
 
 func (p *InterfaceInfoMobileGatewayParam) GetQuery() string {
 	return p.Query
+}
+func (p *InterfaceInfoMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *InterfaceInfoMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *InterfaceInfoMobileGatewayParam) SetId(v int64) {
 	p.Id = v
@@ -2600,6 +2666,7 @@ type TrafficControlInfoMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2639,6 +2706,9 @@ func (p *TrafficControlInfoMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2773,6 +2843,13 @@ func (p *TrafficControlInfoMobileGatewayParam) SetQuery(v string) {
 
 func (p *TrafficControlInfoMobileGatewayParam) GetQuery() string {
 	return p.Query
+}
+func (p *TrafficControlInfoMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *TrafficControlInfoMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *TrafficControlInfoMobileGatewayParam) SetId(v int64) {
 	p.Id = v
@@ -3313,6 +3390,7 @@ type StaticRouteInfoMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3352,6 +3430,9 @@ func (p *StaticRouteInfoMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3486,6 +3567,13 @@ func (p *StaticRouteInfoMobileGatewayParam) SetQuery(v string) {
 
 func (p *StaticRouteInfoMobileGatewayParam) GetQuery() string {
 	return p.Query
+}
+func (p *StaticRouteInfoMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *StaticRouteInfoMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *StaticRouteInfoMobileGatewayParam) SetId(v int64) {
 	p.Id = v
@@ -3986,6 +4074,7 @@ type SimInfoMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4025,6 +4114,9 @@ func (p *SimInfoMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4159,6 +4251,13 @@ func (p *SimInfoMobileGatewayParam) SetQuery(v string) {
 
 func (p *SimInfoMobileGatewayParam) GetQuery() string {
 	return p.Query
+}
+func (p *SimInfoMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *SimInfoMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *SimInfoMobileGatewayParam) SetId(v int64) {
 	p.Id = v
@@ -4655,6 +4754,7 @@ type SimRouteInfoMobileGatewayParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4694,6 +4794,9 @@ func (p *SimRouteInfoMobileGatewayParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4828,6 +4931,13 @@ func (p *SimRouteInfoMobileGatewayParam) SetQuery(v string) {
 
 func (p *SimRouteInfoMobileGatewayParam) GetQuery() string {
 	return p.Query
+}
+func (p *SimRouteInfoMobileGatewayParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *SimRouteInfoMobileGatewayParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *SimRouteInfoMobileGatewayParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_nfs_gen.go
+++ b/command/params/params_nfs_gen.go
@@ -25,6 +25,7 @@ type ListNFSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListNFSParam return new ListNFSParam
@@ -78,6 +79,9 @@ func (p *ListNFSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListNFSParam) SetQuery(v string) {
 func (p *ListNFSParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListNFSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListNFSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateNFSParam is input parameters for the sacloud API
 type CreateNFSParam struct {
@@ -292,6 +303,7 @@ type CreateNFSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateNFSParam return new CreateNFSParam
@@ -360,6 +372,9 @@ func (p *CreateNFSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -646,6 +661,13 @@ func (p *CreateNFSParam) SetQuery(v string) {
 func (p *CreateNFSParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateNFSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateNFSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadNFSParam is input parameters for the sacloud API
 type ReadNFSParam struct {
@@ -659,6 +681,7 @@ type ReadNFSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -698,6 +721,9 @@ func (p *ReadNFSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -833,6 +859,13 @@ func (p *ReadNFSParam) SetQuery(v string) {
 func (p *ReadNFSParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadNFSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadNFSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadNFSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -858,6 +891,7 @@ type UpdateNFSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -912,6 +946,9 @@ func (p *UpdateNFSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1110,6 +1147,13 @@ func (p *UpdateNFSParam) SetQuery(v string) {
 func (p *UpdateNFSParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateNFSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateNFSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateNFSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1132,6 +1176,7 @@ type DeleteNFSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1177,6 +1222,9 @@ func (p *DeleteNFSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1325,6 +1373,13 @@ func (p *DeleteNFSParam) SetQuery(v string) {
 
 func (p *DeleteNFSParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteNFSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteNFSParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteNFSParam) SetId(v int64) {
 	p.Id = v
@@ -2041,6 +2096,7 @@ type MonitorNicNFSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2092,6 +2148,9 @@ func (p *MonitorNicNFSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2269,6 +2328,13 @@ func (p *MonitorNicNFSParam) SetQuery(v string) {
 func (p *MonitorNicNFSParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorNicNFSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorNicNFSParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorNicNFSParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2292,6 +2358,7 @@ type MonitorFreeDiskSizeNFSParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2343,6 +2410,9 @@ func (p *MonitorFreeDiskSizeNFSParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2519,6 +2589,13 @@ func (p *MonitorFreeDiskSizeNFSParam) SetQuery(v string) {
 
 func (p *MonitorFreeDiskSizeNFSParam) GetQuery() string {
 	return p.Query
+}
+func (p *MonitorFreeDiskSizeNFSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorFreeDiskSizeNFSParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *MonitorFreeDiskSizeNFSParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_object_storage_gen.go
+++ b/command/params/params_object_storage_gen.go
@@ -22,6 +22,7 @@ type ListObjectStorageParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListObjectStorageParam return new ListObjectStorageParam
@@ -66,6 +67,9 @@ func (p *ListObjectStorageParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -218,6 +222,13 @@ func (p *ListObjectStorageParam) SetQuery(v string) {
 
 func (p *ListObjectStorageParam) GetQuery() string {
 	return p.Query
+}
+func (p *ListObjectStorageParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListObjectStorageParam) GetQueryFile() string {
+	return p.QueryFile
 }
 
 // PutObjectStorageParam is input parameters for the sacloud API

--- a/command/params/params_packet_filter_gen.go
+++ b/command/params/params_packet_filter_gen.go
@@ -24,6 +24,7 @@ type ListPacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListPacketFilterParam return new ListPacketFilterParam
@@ -74,6 +75,9 @@ func (p *ListPacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListPacketFilterParam) SetQuery(v string) {
 func (p *ListPacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListPacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListPacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreatePacketFilterParam is input parameters for the sacloud API
 type CreatePacketFilterParam struct {
@@ -267,6 +278,7 @@ type CreatePacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreatePacketFilterParam return new CreatePacketFilterParam
@@ -311,6 +323,9 @@ func (p *CreatePacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -471,6 +486,13 @@ func (p *CreatePacketFilterParam) SetQuery(v string) {
 func (p *CreatePacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreatePacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreatePacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadPacketFilterParam is input parameters for the sacloud API
 type ReadPacketFilterParam struct {
@@ -483,6 +505,7 @@ type ReadPacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -519,6 +542,9 @@ func (p *ReadPacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -647,6 +673,13 @@ func (p *ReadPacketFilterParam) SetQuery(v string) {
 func (p *ReadPacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadPacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadPacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadPacketFilterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -669,6 +702,7 @@ type UpdatePacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -714,6 +748,9 @@ func (p *UpdatePacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -877,6 +914,13 @@ func (p *UpdatePacketFilterParam) SetQuery(v string) {
 func (p *UpdatePacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdatePacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdatePacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdatePacketFilterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -897,6 +941,7 @@ type DeletePacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -936,6 +981,9 @@ func (p *DeletePacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1071,6 +1119,13 @@ func (p *DeletePacketFilterParam) SetQuery(v string) {
 func (p *DeletePacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeletePacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeletePacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeletePacketFilterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1090,6 +1145,7 @@ type RuleInfoPacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1126,6 +1182,9 @@ func (p *RuleInfoPacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1254,6 +1313,13 @@ func (p *RuleInfoPacketFilterParam) SetQuery(v string) {
 func (p *RuleInfoPacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *RuleInfoPacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RuleInfoPacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RuleInfoPacketFilterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1281,6 +1347,7 @@ type RuleAddPacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1344,6 +1411,9 @@ func (p *RuleAddPacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1570,6 +1640,13 @@ func (p *RuleAddPacketFilterParam) SetQuery(v string) {
 func (p *RuleAddPacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *RuleAddPacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RuleAddPacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RuleAddPacketFilterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1597,6 +1674,7 @@ type RuleUpdatePacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1657,6 +1735,9 @@ func (p *RuleUpdatePacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1890,6 +1971,13 @@ func (p *RuleUpdatePacketFilterParam) SetQuery(v string) {
 func (p *RuleUpdatePacketFilterParam) GetQuery() string {
 	return p.Query
 }
+func (p *RuleUpdatePacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RuleUpdatePacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RuleUpdatePacketFilterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1911,6 +1999,7 @@ type RuleDeletePacketFilterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1953,6 +2042,9 @@ func (p *RuleDeletePacketFilterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2101,6 +2193,13 @@ func (p *RuleDeletePacketFilterParam) SetQuery(v string) {
 
 func (p *RuleDeletePacketFilterParam) GetQuery() string {
 	return p.Query
+}
+func (p *RuleDeletePacketFilterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RuleDeletePacketFilterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *RuleDeletePacketFilterParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_price_gen.go
+++ b/command/params/params_price_gen.go
@@ -24,6 +24,7 @@ type ListPriceParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListPriceParam return new ListPriceParam
@@ -74,6 +75,9 @@ func (p *ListPriceParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -251,4 +255,11 @@ func (p *ListPriceParam) SetQuery(v string) {
 
 func (p *ListPriceParam) GetQuery() string {
 	return p.Query
+}
+func (p *ListPriceParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListPriceParam) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_private_host_gen.go
+++ b/command/params/params_private_host_gen.go
@@ -25,6 +25,7 @@ type ListPrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListPrivateHostParam return new ListPrivateHostParam
@@ -78,6 +79,9 @@ func (p *ListPrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListPrivateHostParam) SetQuery(v string) {
 func (p *ListPrivateHostParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListPrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListPrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreatePrivateHostParam is input parameters for the sacloud API
 type CreatePrivateHostParam struct {
@@ -287,6 +298,7 @@ type CreatePrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreatePrivateHostParam return new CreatePrivateHostParam
@@ -337,6 +349,9 @@ func (p *CreatePrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -525,6 +540,13 @@ func (p *CreatePrivateHostParam) SetQuery(v string) {
 func (p *CreatePrivateHostParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreatePrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreatePrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadPrivateHostParam is input parameters for the sacloud API
 type ReadPrivateHostParam struct {
@@ -538,6 +560,7 @@ type ReadPrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -577,6 +600,9 @@ func (p *ReadPrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -712,6 +738,13 @@ func (p *ReadPrivateHostParam) SetQuery(v string) {
 func (p *ReadPrivateHostParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadPrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadPrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadPrivateHostParam) SetId(v int64) {
 	p.Id = v
 }
@@ -737,6 +770,7 @@ type UpdatePrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -791,6 +825,9 @@ func (p *UpdatePrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -989,6 +1026,13 @@ func (p *UpdatePrivateHostParam) SetQuery(v string) {
 func (p *UpdatePrivateHostParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdatePrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdatePrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdatePrivateHostParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1010,6 +1054,7 @@ type DeletePrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1052,6 +1097,9 @@ func (p *DeletePrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1194,6 +1242,13 @@ func (p *DeletePrivateHostParam) SetQuery(v string) {
 func (p *DeletePrivateHostParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeletePrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeletePrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeletePrivateHostParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1214,6 +1269,7 @@ type ServerInfoPrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1253,6 +1309,9 @@ func (p *ServerInfoPrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1388,6 +1447,13 @@ func (p *ServerInfoPrivateHostParam) SetQuery(v string) {
 func (p *ServerInfoPrivateHostParam) GetQuery() string {
 	return p.Query
 }
+func (p *ServerInfoPrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerInfoPrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ServerInfoPrivateHostParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1410,6 +1476,7 @@ type ServerAddPrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1455,6 +1522,9 @@ func (p *ServerAddPrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1618,6 +1688,13 @@ func (p *ServerAddPrivateHostParam) SetQuery(v string) {
 func (p *ServerAddPrivateHostParam) GetQuery() string {
 	return p.Query
 }
+func (p *ServerAddPrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerAddPrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ServerAddPrivateHostParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1640,6 +1717,7 @@ type ServerDeletePrivateHostParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1685,6 +1763,9 @@ func (p *ServerDeletePrivateHostParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1847,6 +1928,13 @@ func (p *ServerDeletePrivateHostParam) SetQuery(v string) {
 
 func (p *ServerDeletePrivateHostParam) GetQuery() string {
 	return p.Query
+}
+func (p *ServerDeletePrivateHostParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ServerDeletePrivateHostParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ServerDeletePrivateHostParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_product_disk_gen.go
+++ b/command/params/params_product_disk_gen.go
@@ -24,6 +24,7 @@ type ListProductDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListProductDiskParam return new ListProductDiskParam
@@ -74,6 +75,9 @@ func (p *ListProductDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListProductDiskParam) SetQuery(v string) {
 func (p *ListProductDiskParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListProductDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListProductDiskParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadProductDiskParam is input parameters for the sacloud API
 type ReadProductDiskParam struct {
@@ -265,6 +276,7 @@ type ReadProductDiskParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -304,6 +316,9 @@ func (p *ReadProductDiskParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -445,6 +460,13 @@ func (p *ReadProductDiskParam) SetQuery(v string) {
 
 func (p *ReadProductDiskParam) GetQuery() string {
 	return p.Query
+}
+func (p *ReadProductDiskParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadProductDiskParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ReadProductDiskParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_product_internet_gen.go
+++ b/command/params/params_product_internet_gen.go
@@ -24,6 +24,7 @@ type ListProductInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListProductInternetParam return new ListProductInternetParam
@@ -74,6 +75,9 @@ func (p *ListProductInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListProductInternetParam) SetQuery(v string) {
 func (p *ListProductInternetParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListProductInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListProductInternetParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadProductInternetParam is input parameters for the sacloud API
 type ReadProductInternetParam struct {
@@ -265,6 +276,7 @@ type ReadProductInternetParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -304,6 +316,9 @@ func (p *ReadProductInternetParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -445,6 +460,13 @@ func (p *ReadProductInternetParam) SetQuery(v string) {
 
 func (p *ReadProductInternetParam) GetQuery() string {
 	return p.Query
+}
+func (p *ReadProductInternetParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadProductInternetParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ReadProductInternetParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_product_license_gen.go
+++ b/command/params/params_product_license_gen.go
@@ -24,6 +24,7 @@ type ListProductLicenseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListProductLicenseParam return new ListProductLicenseParam
@@ -74,6 +75,9 @@ func (p *ListProductLicenseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListProductLicenseParam) SetQuery(v string) {
 func (p *ListProductLicenseParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListProductLicenseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListProductLicenseParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadProductLicenseParam is input parameters for the sacloud API
 type ReadProductLicenseParam struct {
@@ -265,6 +276,7 @@ type ReadProductLicenseParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -304,6 +316,9 @@ func (p *ReadProductLicenseParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -445,6 +460,13 @@ func (p *ReadProductLicenseParam) SetQuery(v string) {
 
 func (p *ReadProductLicenseParam) GetQuery() string {
 	return p.Query
+}
+func (p *ReadProductLicenseParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadProductLicenseParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ReadProductLicenseParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_product_server_gen.go
+++ b/command/params/params_product_server_gen.go
@@ -24,6 +24,7 @@ type ListProductServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListProductServerParam return new ListProductServerParam
@@ -74,6 +75,9 @@ func (p *ListProductServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListProductServerParam) SetQuery(v string) {
 func (p *ListProductServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListProductServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListProductServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadProductServerParam is input parameters for the sacloud API
 type ReadProductServerParam struct {
@@ -265,6 +276,7 @@ type ReadProductServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -304,6 +316,9 @@ func (p *ReadProductServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -445,6 +460,13 @@ func (p *ReadProductServerParam) SetQuery(v string) {
 
 func (p *ReadProductServerParam) GetQuery() string {
 	return p.Query
+}
+func (p *ReadProductServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadProductServerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ReadProductServerParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_region_gen.go
+++ b/command/params/params_region_gen.go
@@ -24,6 +24,7 @@ type ListRegionParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListRegionParam return new ListRegionParam
@@ -74,6 +75,9 @@ func (p *ListRegionParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListRegionParam) SetQuery(v string) {
 func (p *ListRegionParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListRegionParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListRegionParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadRegionParam is input parameters for the sacloud API
 type ReadRegionParam struct {
@@ -265,6 +276,7 @@ type ReadRegionParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -304,6 +316,9 @@ func (p *ReadRegionParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -445,6 +460,13 @@ func (p *ReadRegionParam) SetQuery(v string) {
 
 func (p *ReadRegionParam) GetQuery() string {
 	return p.Query
+}
+func (p *ReadRegionParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadRegionParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ReadRegionParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_server_gen.go
+++ b/command/params/params_server_gen.go
@@ -25,6 +25,7 @@ type ListServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListServerParam return new ListServerParam
@@ -78,6 +79,9 @@ func (p *ListServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListServerParam) SetQuery(v string) {
 func (p *ListServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // BuildServerParam is input parameters for the sacloud API
 type BuildServerParam struct {
@@ -322,6 +333,7 @@ type BuildServerParam struct {
 	Format                  string   `json:"format"`
 	FormatFile              string   `json:"format-file"`
 	Query                   string   `json:"query"`
+	QueryFile               string   `json:"query-file"`
 	UsKeyboard              bool     `json:"us-keyboard"`
 	DisableBootAfterCreate  bool     `json:"disable-boot-after-create"`
 }
@@ -492,6 +504,9 @@ func (p *BuildServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.UsKeyboard) {
 		p.UsKeyboard = false
@@ -1120,6 +1135,13 @@ func (p *BuildServerParam) SetQuery(v string) {
 func (p *BuildServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *BuildServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *BuildServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *BuildServerParam) SetUsKeyboard(v bool) {
 	p.UsKeyboard = v
 }
@@ -1147,6 +1169,7 @@ type ReadServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1186,6 +1209,9 @@ func (p *ReadServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1321,6 +1347,13 @@ func (p *ReadServerParam) SetQuery(v string) {
 func (p *ReadServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1347,6 +1380,7 @@ type UpdateServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1407,6 +1441,9 @@ func (p *UpdateServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1619,6 +1656,13 @@ func (p *UpdateServerParam) SetQuery(v string) {
 func (p *UpdateServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1642,6 +1686,7 @@ type DeleteServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1690,6 +1735,9 @@ func (p *DeleteServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1846,6 +1894,13 @@ func (p *DeleteServerParam) SetQuery(v string) {
 func (p *DeleteServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeleteServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeleteServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1869,6 +1924,7 @@ type PlanChangeServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1917,6 +1973,9 @@ func (p *PlanChangeServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2086,6 +2145,13 @@ func (p *PlanChangeServerParam) SetQuery(v string) {
 
 func (p *PlanChangeServerParam) GetQuery() string {
 	return p.Query
+}
+func (p *PlanChangeServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PlanChangeServerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *PlanChangeServerParam) SetId(v int64) {
 	p.Id = v
@@ -3441,6 +3507,7 @@ type VncInfoServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3483,6 +3550,9 @@ func (p *VncInfoServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3625,6 +3695,13 @@ func (p *VncInfoServerParam) SetQuery(v string) {
 func (p *VncInfoServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *VncInfoServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *VncInfoServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *VncInfoServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3651,6 +3728,7 @@ type VncSendServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3708,6 +3786,9 @@ func (p *VncSendServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3901,6 +3982,13 @@ func (p *VncSendServerParam) SetQuery(v string) {
 func (p *VncSendServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *VncSendServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *VncSendServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *VncSendServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -3924,6 +4012,7 @@ type VncSnapshotServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3972,6 +4061,9 @@ func (p *VncSnapshotServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4127,6 +4219,13 @@ func (p *VncSnapshotServerParam) SetQuery(v string) {
 
 func (p *VncSnapshotServerParam) GetQuery() string {
 	return p.Query
+}
+func (p *VncSnapshotServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *VncSnapshotServerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *VncSnapshotServerParam) SetId(v int64) {
 	p.Id = v
@@ -4298,6 +4397,7 @@ type RemoteDesktopInfoServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4347,6 +4447,9 @@ func (p *RemoteDesktopInfoServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4510,6 +4613,13 @@ func (p *RemoteDesktopInfoServerParam) SetQuery(v string) {
 func (p *RemoteDesktopInfoServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *RemoteDesktopInfoServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RemoteDesktopInfoServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *RemoteDesktopInfoServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -4530,6 +4640,7 @@ type DiskInfoServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4569,6 +4680,9 @@ func (p *DiskInfoServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4703,6 +4817,13 @@ func (p *DiskInfoServerParam) SetQuery(v string) {
 
 func (p *DiskInfoServerParam) GetQuery() string {
 	return p.Query
+}
+func (p *DiskInfoServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DiskInfoServerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DiskInfoServerParam) SetId(v int64) {
 	p.Id = v
@@ -5012,6 +5133,7 @@ type InterfaceInfoServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -5051,6 +5173,9 @@ func (p *InterfaceInfoServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -5185,6 +5310,13 @@ func (p *InterfaceInfoServerParam) SetQuery(v string) {
 
 func (p *InterfaceInfoServerParam) GetQuery() string {
 	return p.Query
+}
+func (p *InterfaceInfoServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *InterfaceInfoServerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *InterfaceInfoServerParam) SetId(v int64) {
 	p.Id = v
@@ -5879,6 +6011,7 @@ type IsoInfoServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -5918,6 +6051,9 @@ func (p *IsoInfoServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -6052,6 +6188,13 @@ func (p *IsoInfoServerParam) SetQuery(v string) {
 
 func (p *IsoInfoServerParam) GetQuery() string {
 	return p.Query
+}
+func (p *IsoInfoServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *IsoInfoServerParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *IsoInfoServerParam) SetId(v int64) {
 	p.Id = v
@@ -6436,6 +6579,7 @@ type MonitorCpuServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -6487,6 +6631,9 @@ func (p *MonitorCpuServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -6664,6 +6811,13 @@ func (p *MonitorCpuServerParam) SetQuery(v string) {
 func (p *MonitorCpuServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorCpuServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorCpuServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorCpuServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -6688,6 +6842,7 @@ type MonitorNicServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -6742,6 +6897,9 @@ func (p *MonitorNicServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -6926,6 +7084,13 @@ func (p *MonitorNicServerParam) SetQuery(v string) {
 func (p *MonitorNicServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorNicServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorNicServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorNicServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -6950,6 +7115,7 @@ type MonitorDiskServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -7004,6 +7170,9 @@ func (p *MonitorDiskServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -7188,6 +7357,13 @@ func (p *MonitorDiskServerParam) SetQuery(v string) {
 func (p *MonitorDiskServerParam) GetQuery() string {
 	return p.Query
 }
+func (p *MonitorDiskServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorDiskServerParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *MonitorDiskServerParam) SetId(v int64) {
 	p.Id = v
 }
@@ -7207,6 +7383,7 @@ type MaintenanceInfoServerParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewMaintenanceInfoServerParam return new MaintenanceInfoServerParam
@@ -7242,6 +7419,9 @@ func (p *MaintenanceInfoServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -7359,4 +7539,11 @@ func (p *MaintenanceInfoServerParam) SetQuery(v string) {
 
 func (p *MaintenanceInfoServerParam) GetQuery() string {
 	return p.Query
+}
+func (p *MaintenanceInfoServerParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MaintenanceInfoServerParam) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_sim_gen.go
+++ b/command/params/params_sim_gen.go
@@ -25,6 +25,7 @@ type ListSIMParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListSIMParam return new ListSIMParam
@@ -78,6 +79,9 @@ func (p *ListSIMParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListSIMParam) SetQuery(v string) {
 func (p *ListSIMParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListSIMParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListSIMParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateSIMParam is input parameters for the sacloud API
 type CreateSIMParam struct {
@@ -292,6 +303,7 @@ type CreateSIMParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateSIMParam return new CreateSIMParam
@@ -357,6 +369,9 @@ func (p *CreateSIMParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -614,6 +629,13 @@ func (p *CreateSIMParam) SetQuery(v string) {
 func (p *CreateSIMParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateSIMParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateSIMParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadSIMParam is input parameters for the sacloud API
 type ReadSIMParam struct {
@@ -627,6 +649,7 @@ type ReadSIMParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -666,6 +689,9 @@ func (p *ReadSIMParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -801,6 +827,13 @@ func (p *ReadSIMParam) SetQuery(v string) {
 func (p *ReadSIMParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadSIMParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadSIMParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadSIMParam) SetId(v int64) {
 	p.Id = v
 }
@@ -826,6 +859,7 @@ type UpdateSIMParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -880,6 +914,9 @@ func (p *UpdateSIMParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1078,6 +1115,13 @@ func (p *UpdateSIMParam) SetQuery(v string) {
 func (p *UpdateSIMParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateSIMParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateSIMParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateSIMParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1228,6 +1272,7 @@ type CarrierInfoSIMParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1267,6 +1312,9 @@ func (p *CarrierInfoSIMParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1401,6 +1449,13 @@ func (p *CarrierInfoSIMParam) SetQuery(v string) {
 
 func (p *CarrierInfoSIMParam) GetQuery() string {
 	return p.Query
+}
+func (p *CarrierInfoSIMParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CarrierInfoSIMParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *CarrierInfoSIMParam) SetId(v int64) {
 	p.Id = v
@@ -2331,6 +2386,7 @@ type LogsSIMParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2379,6 +2435,9 @@ func (p *LogsSIMParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2535,6 +2594,13 @@ func (p *LogsSIMParam) SetQuery(v string) {
 func (p *LogsSIMParam) GetQuery() string {
 	return p.Query
 }
+func (p *LogsSIMParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *LogsSIMParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *LogsSIMParam) SetId(v int64) {
 	p.Id = v
 }
@@ -2558,6 +2624,7 @@ type MonitorSIMParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2609,6 +2676,9 @@ func (p *MonitorSIMParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2785,6 +2855,13 @@ func (p *MonitorSIMParam) SetQuery(v string) {
 
 func (p *MonitorSIMParam) GetQuery() string {
 	return p.Query
+}
+func (p *MonitorSIMParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorSIMParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *MonitorSIMParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_simple_monitor_gen.go
+++ b/command/params/params_simple_monitor_gen.go
@@ -26,6 +26,7 @@ type ListSimpleMonitorParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListSimpleMonitorParam return new ListSimpleMonitorParam
@@ -82,6 +83,9 @@ func (p *ListSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -288,6 +292,13 @@ func (p *ListSimpleMonitorParam) SetQuery(v string) {
 func (p *ListSimpleMonitorParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListSimpleMonitorParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListSimpleMonitorParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateSimpleMonitorParam is input parameters for the sacloud API
 type CreateSimpleMonitorParam struct {
@@ -321,6 +332,7 @@ type CreateSimpleMonitorParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateSimpleMonitorParam return new CreateSimpleMonitorParam
@@ -426,6 +438,9 @@ func (p *CreateSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -768,6 +783,13 @@ func (p *CreateSimpleMonitorParam) SetQuery(v string) {
 func (p *CreateSimpleMonitorParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateSimpleMonitorParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateSimpleMonitorParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadSimpleMonitorParam is input parameters for the sacloud API
 type ReadSimpleMonitorParam struct {
@@ -781,6 +803,7 @@ type ReadSimpleMonitorParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -820,6 +843,9 @@ func (p *ReadSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -955,6 +981,13 @@ func (p *ReadSimpleMonitorParam) SetQuery(v string) {
 func (p *ReadSimpleMonitorParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadSimpleMonitorParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadSimpleMonitorParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadSimpleMonitorParam) SetId(v int64) {
 	p.Id = v
 }
@@ -995,6 +1028,7 @@ type UpdateSimpleMonitorParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1094,6 +1128,9 @@ func (p *UpdateSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1425,6 +1462,13 @@ func (p *UpdateSimpleMonitorParam) SetQuery(v string) {
 func (p *UpdateSimpleMonitorParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateSimpleMonitorParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateSimpleMonitorParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateSimpleMonitorParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1446,6 +1490,7 @@ type DeleteSimpleMonitorParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1488,6 +1533,9 @@ func (p *DeleteSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1630,6 +1678,13 @@ func (p *DeleteSimpleMonitorParam) SetQuery(v string) {
 func (p *DeleteSimpleMonitorParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeleteSimpleMonitorParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteSimpleMonitorParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeleteSimpleMonitorParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1650,6 +1705,7 @@ type HealthSimpleMonitorParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1689,6 +1745,9 @@ func (p *HealthSimpleMonitorParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1823,6 +1882,13 @@ func (p *HealthSimpleMonitorParam) SetQuery(v string) {
 
 func (p *HealthSimpleMonitorParam) GetQuery() string {
 	return p.Query
+}
+func (p *HealthSimpleMonitorParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *HealthSimpleMonitorParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *HealthSimpleMonitorParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_ssh_key_gen.go
+++ b/command/params/params_ssh_key_gen.go
@@ -24,6 +24,7 @@ type ListSSHKeyParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListSSHKeyParam return new ListSSHKeyParam
@@ -74,6 +75,9 @@ func (p *ListSSHKeyParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListSSHKeyParam) SetQuery(v string) {
 func (p *ListSSHKeyParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListSSHKeyParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListSSHKeyParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateSSHKeyParam is input parameters for the sacloud API
 type CreateSSHKeyParam struct {
@@ -269,6 +280,7 @@ type CreateSSHKeyParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateSSHKeyParam return new CreateSSHKeyParam
@@ -319,6 +331,9 @@ func (p *CreateSSHKeyParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -509,6 +524,13 @@ func (p *CreateSSHKeyParam) SetQuery(v string) {
 func (p *CreateSSHKeyParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateSSHKeyParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateSSHKeyParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadSSHKeyParam is input parameters for the sacloud API
 type ReadSSHKeyParam struct {
@@ -521,6 +543,7 @@ type ReadSSHKeyParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -557,6 +580,9 @@ func (p *ReadSSHKeyParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -685,6 +711,13 @@ func (p *ReadSSHKeyParam) SetQuery(v string) {
 func (p *ReadSSHKeyParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadSSHKeyParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadSSHKeyParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadSSHKeyParam) SetId(v int64) {
 	p.Id = v
 }
@@ -707,6 +740,7 @@ type UpdateSSHKeyParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -752,6 +786,9 @@ func (p *UpdateSSHKeyParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -915,6 +952,13 @@ func (p *UpdateSSHKeyParam) SetQuery(v string) {
 func (p *UpdateSSHKeyParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateSSHKeyParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateSSHKeyParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateSSHKeyParam) SetId(v int64) {
 	p.Id = v
 }
@@ -935,6 +979,7 @@ type DeleteSSHKeyParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -974,6 +1019,9 @@ func (p *DeleteSSHKeyParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1109,6 +1157,13 @@ func (p *DeleteSSHKeyParam) SetQuery(v string) {
 func (p *DeleteSSHKeyParam) GetQuery() string {
 	return p.Query
 }
+func (p *DeleteSSHKeyParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteSSHKeyParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *DeleteSSHKeyParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1133,6 +1188,7 @@ type GenerateSSHKeyParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewGenerateSSHKeyParam return new GenerateSSHKeyParam
@@ -1183,6 +1239,9 @@ func (p *GenerateSSHKeyParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -1363,4 +1422,11 @@ func (p *GenerateSSHKeyParam) SetQuery(v string) {
 
 func (p *GenerateSSHKeyParam) GetQuery() string {
 	return p.Query
+}
+func (p *GenerateSSHKeyParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *GenerateSSHKeyParam) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_startup_script_gen.go
+++ b/command/params/params_startup_script_gen.go
@@ -27,6 +27,7 @@ type ListStartupScriptParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListStartupScriptParam return new ListStartupScriptParam
@@ -86,6 +87,9 @@ func (p *ListStartupScriptParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -299,6 +303,13 @@ func (p *ListStartupScriptParam) SetQuery(v string) {
 func (p *ListStartupScriptParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListStartupScriptParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListStartupScriptParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateStartupScriptParam is input parameters for the sacloud API
 type CreateStartupScriptParam struct {
@@ -318,6 +329,7 @@ type CreateStartupScriptParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateStartupScriptParam return new CreateStartupScriptParam
@@ -377,6 +389,9 @@ func (p *CreateStartupScriptParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -602,6 +617,13 @@ func (p *CreateStartupScriptParam) SetQuery(v string) {
 func (p *CreateStartupScriptParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateStartupScriptParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateStartupScriptParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadStartupScriptParam is input parameters for the sacloud API
 type ReadStartupScriptParam struct {
@@ -615,6 +637,7 @@ type ReadStartupScriptParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -654,6 +677,9 @@ func (p *ReadStartupScriptParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -789,6 +815,13 @@ func (p *ReadStartupScriptParam) SetQuery(v string) {
 func (p *ReadStartupScriptParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadStartupScriptParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadStartupScriptParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadStartupScriptParam) SetId(v int64) {
 	p.Id = v
 }
@@ -816,6 +849,7 @@ type UpdateStartupScriptParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -876,6 +910,9 @@ func (p *UpdateStartupScriptParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1104,6 +1141,13 @@ func (p *UpdateStartupScriptParam) SetQuery(v string) {
 func (p *UpdateStartupScriptParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateStartupScriptParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateStartupScriptParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateStartupScriptParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1125,6 +1169,7 @@ type DeleteStartupScriptParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1167,6 +1212,9 @@ func (p *DeleteStartupScriptParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1308,6 +1356,13 @@ func (p *DeleteStartupScriptParam) SetQuery(v string) {
 
 func (p *DeleteStartupScriptParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteStartupScriptParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteStartupScriptParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteStartupScriptParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_summary_gen.go
+++ b/command/params/params_summary_gen.go
@@ -19,6 +19,7 @@ type ShowSummaryParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	PaidResourcesOnly bool     `json:"paid-resources-only"`
 }
 
@@ -55,6 +56,9 @@ func (p *ShowSummaryParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.PaidResourcesOnly) {
 		p.PaidResourcesOnly = false
@@ -175,6 +179,13 @@ func (p *ShowSummaryParam) SetQuery(v string) {
 
 func (p *ShowSummaryParam) GetQuery() string {
 	return p.Query
+}
+func (p *ShowSummaryParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ShowSummaryParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ShowSummaryParam) SetPaidResourcesOnly(v bool) {
 	p.PaidResourcesOnly = v

--- a/command/params/params_switch_gen.go
+++ b/command/params/params_switch_gen.go
@@ -25,6 +25,7 @@ type ListSwitchParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListSwitchParam return new ListSwitchParam
@@ -78,6 +79,9 @@ func (p *ListSwitchParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListSwitchParam) SetQuery(v string) {
 func (p *ListSwitchParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListSwitchParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListSwitchParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateSwitchParam is input parameters for the sacloud API
 type CreateSwitchParam struct {
@@ -287,6 +298,7 @@ type CreateSwitchParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewCreateSwitchParam return new CreateSwitchParam
@@ -337,6 +349,9 @@ func (p *CreateSwitchParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -525,6 +540,13 @@ func (p *CreateSwitchParam) SetQuery(v string) {
 func (p *CreateSwitchParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateSwitchParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateSwitchParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadSwitchParam is input parameters for the sacloud API
 type ReadSwitchParam struct {
@@ -538,6 +560,7 @@ type ReadSwitchParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -577,6 +600,9 @@ func (p *ReadSwitchParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -712,6 +738,13 @@ func (p *ReadSwitchParam) SetQuery(v string) {
 func (p *ReadSwitchParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadSwitchParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadSwitchParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadSwitchParam) SetId(v int64) {
 	p.Id = v
 }
@@ -737,6 +770,7 @@ type UpdateSwitchParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -791,6 +825,9 @@ func (p *UpdateSwitchParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -989,6 +1026,13 @@ func (p *UpdateSwitchParam) SetQuery(v string) {
 func (p *UpdateSwitchParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateSwitchParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateSwitchParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateSwitchParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1010,6 +1054,7 @@ type DeleteSwitchParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1052,6 +1097,9 @@ func (p *DeleteSwitchParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1193,6 +1241,13 @@ func (p *DeleteSwitchParam) SetQuery(v string) {
 
 func (p *DeleteSwitchParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteSwitchParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteSwitchParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteSwitchParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_vpc_router_gen.go
+++ b/command/params/params_vpc_router_gen.go
@@ -25,6 +25,7 @@ type ListVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListVPCRouterParam return new ListVPCRouterParam
@@ -78,6 +79,9 @@ func (p *ListVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -270,6 +274,13 @@ func (p *ListVPCRouterParam) SetQuery(v string) {
 func (p *ListVPCRouterParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // CreateVPCRouterParam is input parameters for the sacloud API
 type CreateVPCRouterParam struct {
@@ -295,6 +306,7 @@ type CreateVPCRouterParam struct {
 	Format                    string   `json:"format"`
 	FormatFile                string   `json:"format-file"`
 	Query                     string   `json:"query"`
+	QueryFile                 string   `json:"query-file"`
 }
 
 // NewCreateVPCRouterParam return new CreateVPCRouterParam
@@ -373,6 +385,9 @@ func (p *CreateVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -666,6 +681,13 @@ func (p *CreateVPCRouterParam) SetQuery(v string) {
 func (p *CreateVPCRouterParam) GetQuery() string {
 	return p.Query
 }
+func (p *CreateVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CreateVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadVPCRouterParam is input parameters for the sacloud API
 type ReadVPCRouterParam struct {
@@ -679,6 +701,7 @@ type ReadVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -718,6 +741,9 @@ func (p *ReadVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -853,6 +879,13 @@ func (p *ReadVPCRouterParam) SetQuery(v string) {
 func (p *ReadVPCRouterParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -880,6 +913,7 @@ type UpdateVPCRouterParam struct {
 	Format             string   `json:"format"`
 	FormatFile         string   `json:"format-file"`
 	Query              string   `json:"query"`
+	QueryFile          string   `json:"query-file"`
 	Id                 int64    `json:"id"`
 }
 
@@ -940,6 +974,9 @@ func (p *UpdateVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1159,6 +1196,13 @@ func (p *UpdateVPCRouterParam) SetQuery(v string) {
 func (p *UpdateVPCRouterParam) GetQuery() string {
 	return p.Query
 }
+func (p *UpdateVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UpdateVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *UpdateVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -1181,6 +1225,7 @@ type DeleteVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -1226,6 +1271,9 @@ func (p *DeleteVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -1374,6 +1422,13 @@ func (p *DeleteVPCRouterParam) SetQuery(v string) {
 
 func (p *DeleteVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DeleteVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -2325,6 +2380,7 @@ type InterfaceInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -2364,6 +2420,9 @@ func (p *InterfaceInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -2498,6 +2557,13 @@ func (p *InterfaceInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *InterfaceInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *InterfaceInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *InterfaceInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *InterfaceInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -3202,6 +3268,7 @@ type StaticNatInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3241,6 +3308,9 @@ func (p *StaticNatInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -3375,6 +3445,13 @@ func (p *StaticNatInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *StaticNatInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *StaticNatInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *StaticNatInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *StaticNatInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -3911,6 +3988,7 @@ type PortForwardingInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -3950,6 +4028,9 @@ func (p *PortForwardingInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4084,6 +4165,13 @@ func (p *PortForwardingInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *PortForwardingInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *PortForwardingInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PortForwardingInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *PortForwardingInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -4708,6 +4796,7 @@ type FirewallInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -4756,6 +4845,9 @@ func (p *FirewallInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -4925,6 +5017,13 @@ func (p *FirewallInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *FirewallInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *FirewallInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *FirewallInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *FirewallInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -5767,6 +5866,7 @@ type DhcpServerInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -5806,6 +5906,9 @@ func (p *DhcpServerInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -5940,6 +6043,13 @@ func (p *DhcpServerInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *DhcpServerInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *DhcpServerInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DhcpServerInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DhcpServerInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -6515,6 +6625,7 @@ type DhcpStaticMappingInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -6554,6 +6665,9 @@ func (p *DhcpStaticMappingInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -6688,6 +6802,13 @@ func (p *DhcpStaticMappingInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *DhcpStaticMappingInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *DhcpStaticMappingInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DhcpStaticMappingInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *DhcpStaticMappingInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -7188,6 +7309,7 @@ type PptpServerInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -7227,6 +7349,9 @@ func (p *PptpServerInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -7361,6 +7486,13 @@ func (p *PptpServerInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *PptpServerInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *PptpServerInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *PptpServerInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *PptpServerInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -7548,6 +7680,7 @@ type L2tpServerInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -7587,6 +7720,9 @@ func (p *L2tpServerInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -7721,6 +7857,13 @@ func (p *L2tpServerInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *L2tpServerInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *L2tpServerInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *L2tpServerInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *L2tpServerInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -7926,6 +8069,7 @@ type UserInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -7965,6 +8109,9 @@ func (p *UserInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -8099,6 +8246,13 @@ func (p *UserInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *UserInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *UserInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *UserInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *UserInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -8599,6 +8753,7 @@ type SiteToSiteVpnInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -8638,6 +8793,9 @@ func (p *SiteToSiteVpnInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -8772,6 +8930,13 @@ func (p *SiteToSiteVpnInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *SiteToSiteVpnInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *SiteToSiteVpnInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *SiteToSiteVpnInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *SiteToSiteVpnInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -9387,6 +9552,7 @@ type SiteToSiteVpnPeersVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -9426,6 +9592,9 @@ func (p *SiteToSiteVpnPeersVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -9561,6 +9730,13 @@ func (p *SiteToSiteVpnPeersVPCRouterParam) SetQuery(v string) {
 func (p *SiteToSiteVpnPeersVPCRouterParam) GetQuery() string {
 	return p.Query
 }
+func (p *SiteToSiteVpnPeersVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *SiteToSiteVpnPeersVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *SiteToSiteVpnPeersVPCRouterParam) SetId(v int64) {
 	p.Id = v
 }
@@ -9581,6 +9757,7 @@ type StaticRouteInfoVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -9620,6 +9797,9 @@ func (p *StaticRouteInfoVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -9754,6 +9934,13 @@ func (p *StaticRouteInfoVPCRouterParam) SetQuery(v string) {
 
 func (p *StaticRouteInfoVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *StaticRouteInfoVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *StaticRouteInfoVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *StaticRouteInfoVPCRouterParam) SetId(v int64) {
 	p.Id = v
@@ -10258,6 +10445,7 @@ type MonitorVPCRouterParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -10313,6 +10501,9 @@ func (p *MonitorVPCRouterParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -10510,6 +10701,13 @@ func (p *MonitorVPCRouterParam) SetQuery(v string) {
 
 func (p *MonitorVPCRouterParam) GetQuery() string {
 	return p.Query
+}
+func (p *MonitorVPCRouterParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *MonitorVPCRouterParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *MonitorVPCRouterParam) SetId(v int64) {
 	p.Id = v

--- a/command/params/params_web_accel_gen.go
+++ b/command/params/params_web_accel_gen.go
@@ -19,6 +19,7 @@ type ListWebAccelParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListWebAccelParam return new ListWebAccelParam
@@ -54,6 +55,9 @@ func (p *ListWebAccelParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -172,6 +176,13 @@ func (p *ListWebAccelParam) SetQuery(v string) {
 func (p *ListWebAccelParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListWebAccelParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListWebAccelParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadWebAccelParam is input parameters for the sacloud API
 type ReadWebAccelParam struct {
@@ -185,6 +196,7 @@ type ReadWebAccelParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -224,6 +236,9 @@ func (p *ReadWebAccelParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -359,6 +374,13 @@ func (p *ReadWebAccelParam) SetQuery(v string) {
 func (p *ReadWebAccelParam) GetQuery() string {
 	return p.Query
 }
+func (p *ReadWebAccelParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadWebAccelParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *ReadWebAccelParam) SetId(v int64) {
 	p.Id = v
 }
@@ -379,6 +401,7 @@ type CertificateInfoWebAccelParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -418,6 +441,9 @@ func (p *CertificateInfoWebAccelParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -553,6 +579,13 @@ func (p *CertificateInfoWebAccelParam) SetQuery(v string) {
 func (p *CertificateInfoWebAccelParam) GetQuery() string {
 	return p.Query
 }
+func (p *CertificateInfoWebAccelParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CertificateInfoWebAccelParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *CertificateInfoWebAccelParam) SetId(v int64) {
 	p.Id = v
 }
@@ -578,6 +611,7 @@ type CertificateUpdateWebAccelParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -632,6 +666,9 @@ func (p *CertificateUpdateWebAccelParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -834,6 +871,13 @@ func (p *CertificateUpdateWebAccelParam) SetQuery(v string) {
 func (p *CertificateUpdateWebAccelParam) GetQuery() string {
 	return p.Query
 }
+func (p *CertificateUpdateWebAccelParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *CertificateUpdateWebAccelParam) GetQueryFile() string {
+	return p.QueryFile
+}
 func (p *CertificateUpdateWebAccelParam) SetId(v int64) {
 	p.Id = v
 }
@@ -854,6 +898,7 @@ type DeleteCacheWebAccelParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewDeleteCacheWebAccelParam return new DeleteCacheWebAccelParam
@@ -892,6 +937,9 @@ func (p *DeleteCacheWebAccelParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -1016,4 +1064,11 @@ func (p *DeleteCacheWebAccelParam) SetQuery(v string) {
 
 func (p *DeleteCacheWebAccelParam) GetQuery() string {
 	return p.Query
+}
+func (p *DeleteCacheWebAccelParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *DeleteCacheWebAccelParam) GetQueryFile() string {
+	return p.QueryFile
 }

--- a/command/params/params_zone_gen.go
+++ b/command/params/params_zone_gen.go
@@ -24,6 +24,7 @@ type ListZoneParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 }
 
 // NewListZoneParam return new ListZoneParam
@@ -74,6 +75,9 @@ func (p *ListZoneParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 
 }
@@ -252,6 +256,13 @@ func (p *ListZoneParam) SetQuery(v string) {
 func (p *ListZoneParam) GetQuery() string {
 	return p.Query
 }
+func (p *ListZoneParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ListZoneParam) GetQueryFile() string {
+	return p.QueryFile
+}
 
 // ReadZoneParam is input parameters for the sacloud API
 type ReadZoneParam struct {
@@ -265,6 +276,7 @@ type ReadZoneParam struct {
 	Format            string   `json:"format"`
 	FormatFile        string   `json:"format-file"`
 	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
 	Id                int64    `json:"id"`
 }
 
@@ -304,6 +316,9 @@ func (p *ReadZoneParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Query) {
 		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
 	}
 	if isEmpty(p.Id) {
 		p.Id = 0
@@ -445,6 +460,13 @@ func (p *ReadZoneParam) SetQuery(v string) {
 
 func (p *ReadZoneParam) GetQuery() string {
 	return p.Query
+}
+func (p *ReadZoneParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ReadZoneParam) GetQueryFile() string {
+	return p.QueryFile
 }
 func (p *ReadZoneParam) SetId(v int64) {
 	p.Id = v

--- a/command/validators_test.go
+++ b/command/validators_test.go
@@ -15,6 +15,7 @@ type dummyOption struct {
 	formatFile        string
 	quiet             bool
 	query             string
+	queryFile         string
 	defaultOutputType string
 }
 
@@ -24,6 +25,7 @@ func (o *dummyOption) GetFormat() string     { return o.format }
 func (o *dummyOption) GetFormatFile() string { return o.formatFile }
 func (o *dummyOption) GetQuiet() bool        { return o.quiet }
 func (o dummyOption) GetQuery() string       { return o.query }
+func (o dummyOption) GetQueryFile() string   { return o.queryFile }
 
 func TestValidateOutputOption(t *testing.T) {
 

--- a/output/free_output_test.go
+++ b/output/free_output_test.go
@@ -16,6 +16,7 @@ func (o dummyOption) GetFormat() string     { return "test ID:{{.ID}}" }
 func (o dummyOption) GetFormatFile() string { return "" }
 func (o dummyOption) GetQuiet() bool        { return false }
 func (o dummyOption) GetQuery() string      { return "" }
+func (o dummyOption) GetQueryFile() string  { return "" }
 
 func TestFreeOutput_Print(t *testing.T) {
 	buf := bytes.NewBufferString("")

--- a/output/output.go
+++ b/output/output.go
@@ -18,6 +18,7 @@ type Option interface {
 	GetFormatFile() string
 	GetQuiet() bool
 	GetQuery() string
+	GetQueryFile() string
 }
 
 type TableType int //go:generate stringer -type=OutputTableType :: manual

--- a/output/yaml_output.go
+++ b/output/yaml_output.go
@@ -9,9 +9,8 @@ import (
 )
 
 type yamlOutput struct {
-	out   io.Writer
-	err   io.Writer
-	query string
+	out io.Writer
+	err io.Writer
 }
 
 func NewYAMLOutput(out io.Writer, err io.Writer) Output {

--- a/schema/command.go
+++ b/schema/command.go
@@ -206,6 +206,15 @@ func (c *Command) BuildedParams() SortableParams {
 				Order:       60,
 			}
 		}
+		if _, ok := c.Params["query-file"]; !ok {
+			c.Params["query-file"] = &Schema{
+				Type:        TypeString,
+				HandlerType: HandlerNoop,
+				Description: "JMESPath query from file(using when '--output-type' is json only)",
+				Category:    "output",
+				Order:       65,
+			}
+		}
 	}
 
 	params := SortableParams{}


### PR DESCRIPTION
to fix #404 

JMESPathのクエリを指定するオプション`--query`をファイルから指定するためのパラメータ`--query-option`を指定可能にする。

```bash
$ cat test-query.txt

[].Name

$ usacloud server ls -o json --query-file test-query.txt

[
  "example-01",
  "example-02"
]
```