### PR TITLE
DNSレコードのバルク更新コマンド追加

### DIFF
--- a/command/completion/dns_args_gen.go
+++ b/command/completion/dns_args_gen.go
@@ -44,6 +44,37 @@ func DNSRecordInfoCompleteArgs(ctx command.Context, params *params.RecordInfoDNS
 
 }
 
+func DNSRecordBulkUpdateCompleteArgs(ctx command.Context, params *params.RecordBulkUpdateDNSParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetDNSAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.CommonServiceDNSItems {
+		fmt.Println(res.CommonServiceDNSItems[i].ID)
+		var target interface{} = &res.CommonServiceDNSItems[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
 func DNSCreateCompleteArgs(ctx command.Context, params *params.CreateDNSParam, cur, prev, commandName string) {
 
 }

--- a/command/completion/dns_flags_gen.go
+++ b/command/completion/dns_flags_gen.go
@@ -93,6 +93,42 @@ func DNSRecordInfoCompleteFlags(ctx command.Context, params *params.RecordInfoDN
 	}
 }
 
+func DNSRecordBulkUpdateCompleteFlags(ctx command.Context, params *params.RecordBulkUpdateDNSParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "file":
+		param := define.Resources["DNS"].Commands["record-bulk-update"].BuildedParams().Get("file")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "mode":
+		param := define.Resources["DNS"].Commands["record-bulk-update"].BuildedParams().Get("mode")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["DNS"].Commands["record-bulk-update"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["DNS"].Commands["record-bulk-update"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out", "o":
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
 func DNSCreateCompleteFlags(ctx command.Context, params *params.CreateDNSParam, flagName string, currentValue string) {
 	var comp schema.CompletionFunc
 

--- a/command/funcs/dns_record_bulk_update.go
+++ b/command/funcs/dns_record_bulk_update.go
@@ -1,0 +1,100 @@
+package funcs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"sort"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func DNSRecordBulkUpdate(ctx command.Context, params *params.RecordBulkUpdateDNSParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetDNSAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("DNSRecordBulkUpdate is failed: %s", e)
+	}
+
+	// validate
+	buf, err := ioutil.ReadFile(params.File)
+	if err != nil {
+		return fmt.Errorf("DNSRecordBulkUpdate is failed: %s", err)
+	}
+
+	var records dnsRecordsType
+	if err := json.Unmarshal(buf, &records); err != nil {
+		return fmt.Errorf("DNSRecordBulkUpdate is failed: %s", err)
+	}
+
+	if len(records) == 0 {
+		return fmt.Errorf("file %q don't have any records", params.File)
+	}
+
+	// set params
+	switch params.Mode {
+	case "upsert-only":
+		indexedRecords := map[int]*sacloud.DNSRecordSet{}
+		if p.HasDNSRecord() {
+			for i := range p.Settings.DNS.ResourceRecordSets {
+				indexedRecords[i+1] = &p.Settings.DNS.ResourceRecordSets[i]
+			}
+		}
+
+		for _, record := range records {
+			if record.Index == 0 {
+				continue
+			}
+			if dest, ok := indexedRecords[record.Index]; ok {
+				dest.Name = record.Name
+				dest.Type = record.Type
+				dest.RData = record.RData
+				dest.TTL = record.TTL
+			} else {
+				indexedRecords[record.Index] = &sacloud.DNSRecordSet{
+					Name:  record.Name,
+					Type:  record.Type,
+					RData: record.RData,
+					TTL:   record.TTL,
+				}
+			}
+		}
+
+		var keys []int
+		for k := range indexedRecords {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+		v := make([]sacloud.DNSRecordSet, 0, len(indexedRecords))
+		for _, key := range keys {
+			v = append(v, *indexedRecords[key])
+		}
+		p.Settings.DNS.ResourceRecordSets = v
+
+	case "sync":
+		p.ClearRecords()
+		sort.Slice(records, func(i, j int) bool { return records[i].Index < records[j].Index })
+		for _, record := range records {
+			p.AddRecord(&sacloud.DNSRecordSet{
+				Name:  record.Name,
+				Type:  record.Type,
+				RData: record.RData,
+				TTL:   record.TTL,
+			})
+		}
+	default:
+		return fmt.Errorf("Invalid Mode: %q", params.Mode)
+	}
+
+	// update records
+	p, e = api.Update(params.Id, p)
+	if e != nil {
+		return fmt.Errorf("DNSRecordBulkUpdate is failed: %s", e)
+	}
+
+	return nil
+}

--- a/command/funcs/dns_record_value_type.go
+++ b/command/funcs/dns_record_value_type.go
@@ -6,3 +6,5 @@ type dnsRecordValueType struct {
 	*sacloud.DNSRecordSet
 	Index int
 }
+
+type dnsRecordsType []*dnsRecordValueType

--- a/command/params/params_dns_gen.go
+++ b/command/params/params_dns_gen.go
@@ -523,6 +523,275 @@ func (p *RecordInfoDNSParam) GetId() int64 {
 	return p.Id
 }
 
+// RecordBulkUpdateDNSParam is input parameters for the sacloud API
+type RecordBulkUpdateDNSParam struct {
+	File              string   `json:"file"`
+	Mode              string   `json:"mode"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
+	Id                int64    `json:"id"`
+}
+
+// NewRecordBulkUpdateDNSParam return new RecordBulkUpdateDNSParam
+func NewRecordBulkUpdateDNSParam() *RecordBulkUpdateDNSParam {
+	return &RecordBulkUpdateDNSParam{
+
+		Mode: "upsert-only",
+	}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *RecordBulkUpdateDNSParam) FillValueToSkeleton() {
+	if isEmpty(p.File) {
+		p.File = ""
+	}
+	if isEmpty(p.Mode) {
+		p.Mode = ""
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *RecordBulkUpdateDNSParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--file", p.File)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["DNS"].Commands["record-bulk-update"].Params["file"].ValidateFunc
+		errs := validator("--file", p.File)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateRequired
+		errs := validator("--mode", p.Mode)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["DNS"].Commands["record-bulk-update"].Params["mode"].ValidateFunc
+		errs := validator("--mode", p.Mode)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *RecordBulkUpdateDNSParam) GetResourceDef() *schema.Resource {
+	return define.Resources["DNS"]
+}
+
+func (p *RecordBulkUpdateDNSParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["record-bulk-update"]
+}
+
+func (p *RecordBulkUpdateDNSParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *RecordBulkUpdateDNSParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *RecordBulkUpdateDNSParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *RecordBulkUpdateDNSParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *RecordBulkUpdateDNSParam) SetFile(v string) {
+	p.File = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetFile() string {
+	return p.File
+}
+func (p *RecordBulkUpdateDNSParam) SetMode(v string) {
+	p.Mode = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetMode() string {
+	return p.Mode
+}
+func (p *RecordBulkUpdateDNSParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *RecordBulkUpdateDNSParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *RecordBulkUpdateDNSParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *RecordBulkUpdateDNSParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *RecordBulkUpdateDNSParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *RecordBulkUpdateDNSParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *RecordBulkUpdateDNSParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetColumn() []string {
+	return p.Column
+}
+func (p *RecordBulkUpdateDNSParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *RecordBulkUpdateDNSParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetFormat() string {
+	return p.Format
+}
+func (p *RecordBulkUpdateDNSParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *RecordBulkUpdateDNSParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetQuery() string {
+	return p.Query
+}
+func (p *RecordBulkUpdateDNSParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetQueryFile() string {
+	return p.QueryFile
+}
+func (p *RecordBulkUpdateDNSParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *RecordBulkUpdateDNSParam) GetId() int64 {
+	return p.Id
+}
+
 // CreateDNSParam is input parameters for the sacloud API
 type CreateDNSParam struct {
 	Name              string   `json:"name"`

--- a/define/dns.go
+++ b/define/dns.go
@@ -63,6 +63,13 @@ func DNSResource() *schema.Resource {
 			Category:           "records",
 			Order:              10,
 		},
+		"record-bulk-update": {
+			Type:             schema.CommandManipulateSingle,
+			Params:           dnsRecordBulkUpdateParam(),
+			UseCustomCommand: true,
+			Category:         "records",
+			Order:            15,
+		},
 		"record-add": {
 			Type:               schema.CommandManipulateSingle,
 			Params:             dnsRecordAddParam(),
@@ -211,6 +218,32 @@ func dnsRecordListParam() map[string]*schema.Schema {
 var allowDNSTypes = []string{
 	"a", "aaaa", "ns", "cname", "mx", "txt", "srv",
 	"A", "AAAA", "NS", "CNAME", "MX", "TXT", "SRV",
+}
+
+func dnsRecordBulkUpdateParam() map[string]*schema.Schema {
+
+	return map[string]*schema.Schema{
+		"file": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set name",
+			Required:     true,
+			ValidateFunc: validateFileExists(),
+			Category:     "record",
+			Order:        10,
+		},
+		"mode": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set name",
+			Required:     true,
+			DefaultValue: "upsert-only",
+			ValidateFunc: validateInStrValues("upsert-only", "sync"),
+			CompleteFunc: completeInStrValues("upsert-only", "sync"),
+			Category:     "record",
+			Order:        20,
+		},
+	}
 }
 
 func dnsRecordAddParam() map[string]*schema.Schema {


### PR DESCRIPTION
(to fix #407)

DNSレコードのバルク更新用サブコマンド`record-bulk-update`を追加する。

### オプション

`--file`: レコード情報を格納したJSONファイル、`usacloud dns record-info`の出力と同じ形式のJSONである必要がある。

`--mode`: 更新モード
  - `upsert-only`(デフォルト): インデックスが一致するレコードは更新、以外のレコードは挿入、もともと存在したレコードの削除は行わない
  - `sync`: 全レコードをクリア/挿入する


### 使用例

```bash
# レコード一覧取得
$ usacloud dns record-info -o json example.com > records.json

# レコード一覧(必要に応じて編集)
$ cat records.json

[
  {
    "Index": 1,
    "Name": "www",
    "RData": "192.2.0.1",
    "Type": "A"
  },
  {
    "Index": 2,
    "Name": "www",
    "RData": "fe::1",
    "Type": "AAAA"
  }
]

# バルク更新(モード: upsert-only)
$ usacloud dns record-bulk-update --file records.json example.com

# バルク更新(モード: sync)
$ usacloud dns record-bulk-update --file records.json --mode sync example.com
```


### Note: JSONファイル中のIndexの扱い

JSONファイルの中のIndexを省略した場合はモードにより挙動が異なる。

`--mode=upsert-only`の場合: Indexを省略、またはIndexが0の場合は該当レコードの挿入/更新は行われない

`--mode=sync`の場合: Indexを省略した場合はIndex=0として扱い、Indexの昇順にソートした上で挿入される