### PR TITLE
APIリクエスト時の*http.Clientタイムアウト指定機能

### DIFF
--- a/command/cli/functions.go
+++ b/command/cli/functions.go
@@ -73,6 +73,10 @@ func applyConfigFromFile(c FlagHandler) error {
 		c.Set("retry-interval", fmt.Sprintf("%d", v.RetryIntervalSec))
 		command.GlobalOption.RetryIntervalSec = v.RetryIntervalSec
 	}
+	if !c.IsSet("api-request-timeout") && v.APIRequestTimeout > 0 {
+		c.Set("api-request-timeout", fmt.Sprintf("%d", v.APIRequestTimeout))
+		command.GlobalOption.APIRequestTimeout = v.APIRequestTimeout
+	}
 	if !c.IsSet("no-color") && v.NoColor {
 		c.Set("no-color", "true")
 		command.GlobalOption.NoColor = v.NoColor

--- a/command/functions.go
+++ b/command/functions.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -111,6 +112,11 @@ func createAPIClient() *api.Client {
 	}
 	if GlobalOption.RetryIntervalSec >= 0 {
 		c.RetryInterval = time.Duration(GlobalOption.RetryIntervalSec) * time.Second
+	}
+	if GlobalOption.APIRequestTimeout > 0 {
+		c.HTTPClient = &http.Client{
+			Timeout: time.Duration(GlobalOption.APIRequestTimeout) * time.Second,
+		}
 	}
 
 	return c

--- a/command/global_option.go
+++ b/command/global_option.go
@@ -20,6 +20,7 @@ type Option struct {
 	AcceptLanguage    string
 	RetryMax          int
 	RetryIntervalSec  int64
+	APIRequestTimeout int
 	Zones             []string
 	APIRootURL        string
 	TraceMode         bool
@@ -107,6 +108,12 @@ var GlobalFlags = []cli.Flag{
 		Usage:       "API client retry interval seconds",
 		EnvVars:     []string{"SAKURACLOUD_RETRY_INTERVAL"},
 		Destination: &GlobalOption.RetryIntervalSec,
+	},
+	&cli.IntFlag{
+		Name:        "api-request-timeout",
+		Usage:       "Maximum wait time(seconds) for calling SakuraCloud API",
+		EnvVars:     []string{"SAKURACLOUD_API_REQUEST_TIMEOUT"},
+		Destination: &GlobalOption.APIRequestTimeout,
 	},
 	&cli.BoolFlag{
 		Name:        "no-color",

--- a/command/profile/profile.go
+++ b/command/profile/profile.go
@@ -77,6 +77,7 @@ type ConfigFileValue struct {
 	AcceptLanguage    string   `json:",omitempty"`
 	RetryMax          int      `json:",omitempty"`
 	RetryIntervalSec  int64    `json:",omitempty"`
+	APIRequestTimeout int      `json:",omitempty"`
 	NoColor           bool     `json:",omitempty"`
 	DefaultOutputType string   `json:",omitempty"`
 	Zones             []string `json:",omitempty"`

--- a/contrib/completion/bash/usacloud
+++ b/contrib/completion/bash/usacloud
@@ -4,7 +4,7 @@ _usacloud() {
     local commands=(archive auth-status auto-backup bill bridge config profile coupon dns database disk gslb ipv4 ipv6 iso-image icon interface internet license load-balancer mobile-gateway mgw nfs object-storage ojs packet-filter price public-price private-host product-disk disk-plan product-internet internet-plan product-license license-info product-server server-plan proxy-lb enhanced-load-balancer proxylb region sim ssh-key self server simple-monitor startup-script note summary switch vpc-router web-accel zone )
 
     local flags=(--no-color --trace --help --version)
-    local wants_value=(--token --secret --zone --config --profile --timeout --accept-language --retry-max --retry-interval --default-output-type )
+    local wants_value=(--token --secret --zone --config --profile --timeout --accept-language --retry-max --retry-interval --api-request-timeout --default-output-type )
     local configflags=(--help --token --secret --zone --config --profile --show)
     local zones=(is1a is1b tk1a tk1v)
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08
-	github.com/sacloud/libsacloud v1.17.3
+	github.com/sacloud/libsacloud v1.19.1
 	github.com/stretchr/testify v1.2.2
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect
 	golang.org/x/crypto v0.0.0-20181015023909-0c41d7ab0a0e // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08 h1:hGFzyq3AgiEHgI9xYPrtbK466gP7AimFCjrn3nZktc8=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08/go.mod h1:PLy4tK2PN6G8fxd/cCWH6db2mJGmUlflYs4ASdfNulg=
-github.com/sacloud/libsacloud v1.17.3 h1:j0wexmlI1mixJ6STNp5gOxhggJAjfX0l3HNL/W6U108=
-github.com/sacloud/libsacloud v1.17.3/go.mod h1:ukUUnigTFBzC2x/JTPpCmBjWTMOJ7yaPSF/Z0+eXnQg=
+github.com/sacloud/libsacloud v1.19.1 h1:dXUykXCRKIWYjuDTPAmfHpsGCY6zMMSNHmh1r0UZWdM=
+github.com/sacloud/libsacloud v1.19.1/go.mod h1:ukUUnigTFBzC2x/JTPpCmBjWTMOJ7yaPSF/Z0+eXnQg=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=


### PR DESCRIPTION
APIリクエスト時に利用する*http.Clientにタイムアウトを指定できるようにする。
環境変数`SAKURACLOUD_API_REQUEST_TIMEOUT`でも指定可能。

#### 利用例

```bash
# オプションで指定
$ usacloud --api-request-timeout 1 server ls

# 環境変数で指定
$ export SAKURACLOUD_API_REQUEST_TIMEOUT=1
$ usacloud server ls
```

