### PR TITLE
コア専有プラン

### DIFF
--- a/command/cli/cli_server_gen.go
+++ b/command/cli/cli_server_gen.go
@@ -410,6 +410,11 @@ func init() {
 						Usage: "[Required] set memory size(GB)",
 						Value: 1,
 					},
+					&cli.StringFlag{
+						Name:  "commitment",
+						Usage: "set plan of core assignment",
+						Value: "standard",
+					},
 					&cli.Int64Flag{
 						Name:  "private-host-id",
 						Usage: "set private-host-id",
@@ -677,6 +682,9 @@ func init() {
 					if c.IsSet("memory") {
 						buildParam.Memory = c.Int("memory")
 					}
+					if c.IsSet("commitment") {
+						buildParam.Commitment = c.String("commitment")
+					}
 					if c.IsSet("private-host-id") {
 						buildParam.PrivateHostId = c.Int64("private-host-id")
 					}
@@ -917,6 +925,9 @@ func init() {
 					}
 					if c.IsSet("memory") {
 						buildParam.Memory = c.Int("memory")
+					}
+					if c.IsSet("commitment") {
+						buildParam.Commitment = c.String("commitment")
 					}
 					if c.IsSet("private-host-id") {
 						buildParam.PrivateHostId = c.Int64("private-host-id")
@@ -2356,6 +2367,11 @@ func init() {
 						Name:  "memory",
 						Usage: "[Required] set memory size(GB)",
 					},
+					&cli.StringFlag{
+						Name:  "commitment",
+						Usage: "set plan of core assignment",
+						Value: "standard",
+					},
 					&cli.StringSliceFlag{
 						Name:  "selector",
 						Usage: "Set target filter by tag",
@@ -2458,6 +2474,9 @@ func init() {
 					}
 					if c.IsSet("memory") {
 						planChangeParam.Memory = c.Int("memory")
+					}
+					if c.IsSet("commitment") {
+						planChangeParam.Commitment = c.String("commitment")
 					}
 					if c.IsSet("selector") {
 						planChangeParam.Selector = c.StringSlice("selector")
@@ -2588,6 +2607,9 @@ func init() {
 					}
 					if c.IsSet("memory") {
 						planChangeParam.Memory = c.Int("memory")
+					}
+					if c.IsSet("commitment") {
+						planChangeParam.Commitment = c.String("commitment")
 					}
 					if c.IsSet("selector") {
 						planChangeParam.Selector = c.StringSlice("selector")
@@ -13442,6 +13464,11 @@ func init() {
 		DisplayName: "Output options",
 		Order:       2147483637,
 	})
+	AppendFlagCategoryMap("server", "build", "commitment", &schema.Category{
+		Key:         "server-plan",
+		DisplayName: "For server-plan options",
+		Order:       10,
+	})
 	AppendFlagCategoryMap("server", "build", "core", &schema.Category{
 		Key:         "server-plan",
 		DisplayName: "For server-plan options",
@@ -14661,6 +14688,11 @@ func init() {
 		Key:         "output",
 		DisplayName: "Output options",
 		Order:       2147483637,
+	})
+	AppendFlagCategoryMap("server", "plan-change", "commitment", &schema.Category{
+		Key:         "server-plan",
+		DisplayName: "Server-Plan options",
+		Order:       1,
 	})
 	AppendFlagCategoryMap("server", "plan-change", "core", &schema.Category{
 		Key:         "plan",

--- a/command/completion/server_flags_gen.go
+++ b/command/completion/server_flags_gen.go
@@ -71,6 +71,11 @@ func ServerBuildCompleteFlags(ctx command.Context, params *params.BuildServerPar
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
+	case "commitment":
+		param := define.Resources["Server"].Commands["build"].BuildedParams().Get("commitment")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "private-host-id":
 		param := define.Resources["Server"].Commands["build"].BuildedParams().Get("private-host-id")
 		if param != nil {
@@ -402,6 +407,11 @@ func ServerPlanChangeCompleteFlags(ctx command.Context, params *params.PlanChang
 		}
 	case "memory":
 		param := define.Resources["Server"].Commands["plan-change"].BuildedParams().Get("memory")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "commitment":
+		param := define.Resources["Server"].Commands["plan-change"].BuildedParams().Get("commitment")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}

--- a/command/funcs/server_build.go
+++ b/command/funcs/server_build.go
@@ -228,6 +228,7 @@ func handleServerCommonParams(sb serverBuilder, ctx command.Context, params *par
 
 	sb.SetCore(params.GetCore())
 	sb.SetMemory(params.GetMemory())
+	sb.SetCommitment(sacloud.ECommitment(params.Commitment))
 	sb.SetPrivateHostID(params.PrivateHostId)
 	sb.SetServerName(params.GetName())
 	sb.SetDescription(params.GetDescription())

--- a/command/funcs/server_plan_change.go
+++ b/command/funcs/server_plan_change.go
@@ -22,7 +22,9 @@ func ServerPlanChange(ctx command.Context, params *params.PlanChangeServerParam)
 		return fmt.Errorf("ServerPlanChange is failed: %s", "server is running")
 	}
 
-	plan, err := client.GetProductServerAPI().GetBySpec(params.Core, params.Memory, sacloud.PlanDefault)
+	plan, err := client.GetProductServerAPI().GetBySpecCommitment(
+		params.Core, params.Memory, sacloud.PlanDefault, sacloud.ECommitment(params.Commitment),
+	)
 	if err != nil {
 		return fmt.Errorf("ServerPlanChange is failed: plan is invalid: %s", err)
 	}

--- a/command/params/params_server_gen.go
+++ b/command/params/params_server_gen.go
@@ -286,6 +286,7 @@ func (p *ListServerParam) GetQueryFile() string {
 type BuildServerParam struct {
 	Core                    int      `json:"core"`
 	Memory                  int      `json:"memory"`
+	Commitment              string   `json:"commitment"`
 	PrivateHostId           int64    `json:"private-host-id"`
 	DiskMode                string   `json:"disk-mode"`
 	OsType                  string   `json:"os-type"`
@@ -344,6 +345,7 @@ func NewBuildServerParam() *BuildServerParam {
 
 		Core:                    1,
 		Memory:                  1,
+		Commitment:              "standard",
 		DiskMode:                "create",
 		DiskPlan:                "ssd",
 		DiskConnection:          "virtio",
@@ -363,6 +365,9 @@ func (p *BuildServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Memory) {
 		p.Memory = 0
+	}
+	if isEmpty(p.Commitment) {
+		p.Commitment = ""
 	}
 	if isEmpty(p.PrivateHostId) {
 		p.PrivateHostId = 0
@@ -530,6 +535,13 @@ func (p *BuildServerParam) Validate() []error {
 	{
 		validator := validateRequired
 		errs := validator("--memory", p.Memory)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["Server"].Commands["build"].Params["commitment"].ValidateFunc
+		errs := validator("--commitment", p.Commitment)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -805,6 +817,13 @@ func (p *BuildServerParam) SetMemory(v int) {
 
 func (p *BuildServerParam) GetMemory() int {
 	return p.Memory
+}
+func (p *BuildServerParam) SetCommitment(v string) {
+	p.Commitment = v
+}
+
+func (p *BuildServerParam) GetCommitment() string {
+	return p.Commitment
 }
 func (p *BuildServerParam) SetPrivateHostId(v int64) {
 	p.PrivateHostId = v
@@ -1913,6 +1932,7 @@ func (p *DeleteServerParam) GetId() int64 {
 type PlanChangeServerParam struct {
 	Core              int      `json:"core"`
 	Memory            int      `json:"memory"`
+	Commitment        string   `json:"commitment"`
 	Selector          []string `json:"selector"`
 	Assumeyes         bool     `json:"assumeyes"`
 	ParamTemplate     string   `json:"param-template"`
@@ -1930,7 +1950,10 @@ type PlanChangeServerParam struct {
 
 // NewPlanChangeServerParam return new PlanChangeServerParam
 func NewPlanChangeServerParam() *PlanChangeServerParam {
-	return &PlanChangeServerParam{}
+	return &PlanChangeServerParam{
+
+		Commitment: "standard",
+	}
 }
 
 // FillValueToSkeleton fill values to empty fields
@@ -1940,6 +1963,9 @@ func (p *PlanChangeServerParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.Memory) {
 		p.Memory = 0
+	}
+	if isEmpty(p.Commitment) {
+		p.Commitment = ""
 	}
 	if isEmpty(p.Selector) {
 		p.Selector = []string{""}
@@ -1996,6 +2022,13 @@ func (p *PlanChangeServerParam) Validate() []error {
 	{
 		validator := validateRequired
 		errs := validator("--memory", p.Memory)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := define.Resources["Server"].Commands["plan-change"].Params["commitment"].ValidateFunc
+		errs := validator("--commitment", p.Commitment)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2068,6 +2101,13 @@ func (p *PlanChangeServerParam) SetMemory(v int) {
 
 func (p *PlanChangeServerParam) GetMemory() int {
 	return p.Memory
+}
+func (p *PlanChangeServerParam) SetCommitment(v string) {
+	p.Commitment = v
+}
+
+func (p *PlanChangeServerParam) GetCommitment() string {
+	return p.Commitment
 }
 func (p *PlanChangeServerParam) SetSelector(v []string) {
 	p.Selector = v

--- a/define/server.go
+++ b/define/server.go
@@ -396,6 +396,10 @@ func serverListColumns() []output.ColumnDef {
 			Format:  "%sMB",
 		},
 		{
+			Name:    "Commitment",
+			Sources: []string{"ServerPlan.Commitment"},
+		},
+		{
 			Name: "IPAddress",
 			FormatFunc: func(values map[string]string) string {
 				if scope, ok := values["Interfaces.0.Switch.Scope"]; ok {
@@ -646,6 +650,16 @@ func serverBuildParam() map[string]*schema.Schema {
 			Category:     "server-plan",
 			Order:        20,
 		},
+		"commitment": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set plan of core assignment",
+			DefaultValue: "standard",
+			ValidateFunc: validateInStrValues("standard", "dedicatedcpu"),
+			CompleteFunc: completeInStrValues("standard", "dedicatedcpu"),
+			Category:     "server-plan",
+			Order:        30,
+		},
 		"private-host-id": {
 			Type:         schema.TypeInt64,
 			HandlerType:  schema.HandlerNoop,
@@ -653,7 +667,7 @@ func serverBuildParam() map[string]*schema.Schema {
 			ValidateFunc: validateSakuraID(),
 			CompleteFunc: completePrivateHostID(),
 			Category:     "server-plan",
-			Order:        30,
+			Order:        40,
 		},
 		/*
 		 === disk ===
@@ -1298,6 +1312,16 @@ func serverPlanChangeParam() map[string]*schema.Schema {
 			Required:     true,
 			Category:     "plan",
 			Order:        20,
+		},
+		"commitment": {
+			Type:         schema.TypeString,
+			HandlerType:  schema.HandlerNoop,
+			Description:  "set plan of core assignment",
+			DefaultValue: "standard",
+			ValidateFunc: validateInStrValues("standard", "dedicatedcpu"),
+			CompleteFunc: completeInStrValues("standard", "dedicatedcpu"),
+			Category:     "server-plan",
+			Order:        30,
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08
-	github.com/sacloud/libsacloud v1.20.0
+	github.com/sacloud/libsacloud v1.22.3
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08 h1:hGFzyq3AgiEHgI9xYPrtbK466gP7AimFCjrn3nZktc8=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08/go.mod h1:PLy4tK2PN6G8fxd/cCWH6db2mJGmUlflYs4ASdfNulg=
-github.com/sacloud/libsacloud v1.20.0 h1:esY0BK73cvQdrZdOJe1vxJO99WnlgCWf5REBu5oTa28=
-github.com/sacloud/libsacloud v1.20.0/go.mod h1:ukUUnigTFBzC2x/JTPpCmBjWTMOJ7yaPSF/Z0+eXnQg=
+github.com/sacloud/libsacloud v1.22.3 h1:jDHY3vaQnAPWMlLwYO+YorQyDhyEq72EuskBGN4pzLM=
+github.com/sacloud/libsacloud v1.22.3/go.mod h1:79ZwATmHLIFZIMd7sxA3LwzVy/B77uj3LDoToVTxDoQ=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e h1:VAzdS5Nw68fbf5RZ8RDVlUvPXNU6Z3jtPCK/qvm4FoQ=
@@ -66,8 +66,14 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/uber-go/atomic v1.3.2 h1:Azu9lPBWRNKzYXSIwRfgRuDuS0YKsK4NFhiQv98gkxo=
+github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec h1:DGmKwyZwEB8dI7tbLt/I/gQuP559o/0FrAkHKlQM/Ks=
 github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec/go.mod h1:owBmyHYMLkxyrugmfwE/DLJyW8Ro9mkphwuVErQ0iUw=
+go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
+go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277 h1:d9qaMM+ODpCq+9We41//fu/sHsTnXcrqd1en3x+GKy4=
+go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277/go.mod h1:2X8KaoNd1J0lZV+PxJk/5+DGbO/tpwLR1m++a7FnB/Y=
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190417174047-f416ebab96af h1:6qGQw30u837TXZbCmLFR9AVA+RjJU1LIbvk0oIkDZGY=
 golang.org/x/crypto v0.0.0-20190417174047-f416ebab96af/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=


### PR DESCRIPTION
コア専有プランに対応する。

#### 対応内容

- サーバ作成(`server build`)とプラン変更(`server plan-change`)に`--commitment`オプションを追加
- `--commitment`には`standard`(通常)と`dedicadedcpu`(コア専有)を指定可能
- `--commitment`省略時のデフォルトは`standard`
- サーバ一覧(`server ls`)にcommitment列を追加

#### サーバ作成の例

    usacloud server build --name example --cpu 2 --memory 4 --commitment dedicatedcpu ...

#### プラン変更の例

    usacloud server plan-change --cpu 2 --memory 4 --commitment dedicadedcpu <対象のID or 名前>

