### PR TITLE
CAA Recordの作成

### DIFF
--- a/define/dns.go
+++ b/define/dns.go
@@ -206,7 +206,7 @@ func dnsRecordListParam() map[string]*schema.Schema {
 		"type": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
-			Description:  "set record type[A/AAAA/NS/CNAME/MX/TXT/SRV]",
+			Description:  "set record type[A/AAAA/NS/CNAME/MX/TXT/SRV/CAA]",
 			ValidateFunc: validateInStrValues(allowDNSTypes...),
 			CompleteFunc: completeInStrValues(allowDNSTypes...),
 			Category:     "record",
@@ -216,8 +216,8 @@ func dnsRecordListParam() map[string]*schema.Schema {
 }
 
 var allowDNSTypes = []string{
-	"a", "aaaa", "ns", "cname", "mx", "txt", "srv",
-	"A", "AAAA", "NS", "CNAME", "MX", "TXT", "SRV",
+	"a", "aaaa", "ns", "cname", "mx", "txt", "srv", "caa",
+	"A", "AAAA", "NS", "CNAME", "MX", "TXT", "SRV", "CAA",
 }
 
 func dnsRecordBulkUpdateParam() map[string]*schema.Schema {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08
-	github.com/sacloud/libsacloud v1.22.3
+	github.com/sacloud/libsacloud v1.23.0
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08 h1:hGFzyq3AgiEHgI9xYPrtbK466gP7AimFCjrn3nZktc8=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08/go.mod h1:PLy4tK2PN6G8fxd/cCWH6db2mJGmUlflYs4ASdfNulg=
-github.com/sacloud/libsacloud v1.22.3 h1:jDHY3vaQnAPWMlLwYO+YorQyDhyEq72EuskBGN4pzLM=
-github.com/sacloud/libsacloud v1.22.3/go.mod h1:79ZwATmHLIFZIMd7sxA3LwzVy/B77uj3LDoToVTxDoQ=
+github.com/sacloud/libsacloud v1.23.0 h1:8gNK/Z5xSIFh2lMVkwUdzvNuSnvh6ADhVFLaCjKOI1E=
+github.com/sacloud/libsacloud v1.23.0/go.mod h1:79ZwATmHLIFZIMd7sxA3LwzVy/B77uj3LDoToVTxDoQ=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e h1:VAzdS5Nw68fbf5RZ8RDVlUvPXNU6Z3jtPCK/qvm4FoQ=


### PR DESCRIPTION
CAAレコードを作成可能にする。

```
# Example
$ usacloud dns record-add --type CAA --ttl 10 --value '0 issue "letsencrypt.org"' --name www example.com
```