### PR TITLE
エンハンスドロードバランサでのセッション維持機能

### DIFF
--- a/command/cli/cli_proxy_lb_gen.go
+++ b/command/cli/cli_proxy_lb_gen.go
@@ -411,6 +411,10 @@ func init() {
 						Usage: "[Required] set delay-loop of healthcheck",
 						Value: 10,
 					},
+					&cli.BoolFlag{
+						Name:  "sticky-session",
+						Usage: "enable sticky-session",
+					},
 					&cli.StringFlag{
 						Name:  "sorry-server-ipaddress",
 						Usage: "set sorry-server ip address",
@@ -538,6 +542,9 @@ func init() {
 					}
 					if c.IsSet("delay-loop") {
 						createParam.DelayLoop = c.Int("delay-loop")
+					}
+					if c.IsSet("sticky-session") {
+						createParam.StickySession = c.Bool("sticky-session")
 					}
 					if c.IsSet("sorry-server-ipaddress") {
 						createParam.SorryServerIpaddress = c.String("sorry-server-ipaddress")
@@ -689,6 +696,9 @@ func init() {
 					}
 					if c.IsSet("delay-loop") {
 						createParam.DelayLoop = c.Int("delay-loop")
+					}
+					if c.IsSet("sticky-session") {
+						createParam.StickySession = c.Bool("sticky-session")
 					}
 					if c.IsSet("sorry-server-ipaddress") {
 						createParam.SorryServerIpaddress = c.String("sorry-server-ipaddress")
@@ -1185,6 +1195,10 @@ func init() {
 						Name:  "delay-loop",
 						Usage: "set delay-loop of healthcheck",
 					},
+					&cli.BoolFlag{
+						Name:  "sticky-session",
+						Usage: "enable sticky-session",
+					},
 					&cli.StringFlag{
 						Name:  "sorry-server-ipaddress",
 						Usage: "set sorry-server ip address",
@@ -1318,6 +1332,9 @@ func init() {
 					}
 					if c.IsSet("delay-loop") {
 						updateParam.DelayLoop = c.Int("delay-loop")
+					}
+					if c.IsSet("sticky-session") {
+						updateParam.StickySession = c.Bool("sticky-session")
 					}
 					if c.IsSet("sorry-server-ipaddress") {
 						updateParam.SorryServerIpaddress = c.String("sorry-server-ipaddress")
@@ -1472,6 +1489,9 @@ func init() {
 					}
 					if c.IsSet("delay-loop") {
 						updateParam.DelayLoop = c.Int("delay-loop")
+					}
+					if c.IsSet("sticky-session") {
+						updateParam.StickySession = c.Bool("sticky-session")
 					}
 					if c.IsSet("sorry-server-ipaddress") {
 						updateParam.SorryServerIpaddress = c.String("sorry-server-ipaddress")
@@ -9849,6 +9869,11 @@ func init() {
 		DisplayName: "ProxyLB options",
 		Order:       1,
 	})
+	AppendFlagCategoryMap("proxy-lb", "create", "sticky-session", &schema.Category{
+		Key:         "ProxyLB",
+		DisplayName: "ProxyLB options",
+		Order:       1,
+	})
 	AppendFlagCategoryMap("proxy-lb", "create", "tags", &schema.Category{
 		Key:         "common",
 		DisplayName: "Common options",
@@ -10605,6 +10630,11 @@ func init() {
 		Order:       1,
 	})
 	AppendFlagCategoryMap("proxy-lb", "update", "sorry-server-port", &schema.Category{
+		Key:         "ProxyLB",
+		DisplayName: "ProxyLB options",
+		Order:       1,
+	})
+	AppendFlagCategoryMap("proxy-lb", "update", "sticky-session", &schema.Category{
 		Key:         "ProxyLB",
 		DisplayName: "ProxyLB options",
 		Order:       1,

--- a/command/completion/proxy_lb_flags_gen.go
+++ b/command/completion/proxy_lb_flags_gen.go
@@ -86,6 +86,11 @@ func ProxyLBCreateCompleteFlags(ctx command.Context, params *params.CreateProxyL
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}
+	case "sticky-session":
+		param := define.Resources["ProxyLB"].Commands["create"].BuildedParams().Get("sticky-session")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
 	case "sorry-server-ipaddress":
 		param := define.Resources["ProxyLB"].Commands["create"].BuildedParams().Get("sorry-server-ipaddress")
 		if param != nil {
@@ -175,6 +180,11 @@ func ProxyLBUpdateCompleteFlags(ctx command.Context, params *params.UpdateProxyL
 		}
 	case "delay-loop":
 		param := define.Resources["ProxyLB"].Commands["update"].BuildedParams().Get("delay-loop")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "sticky-session":
+		param := define.Resources["ProxyLB"].Commands["update"].BuildedParams().Get("sticky-session")
 		if param != nil {
 			comp = param.Param.CompleteFunc
 		}

--- a/command/funcs/proxy_lb_create.go
+++ b/command/funcs/proxy_lb_create.go
@@ -37,6 +37,13 @@ func ProxyLBCreate(ctx command.Context, params *params.CreateProxyLBParam) error
 		return fmt.Errorf("invalid protocol: %s", protocol)
 	}
 
+	if params.StickySession {
+		p.Settings.ProxyLB.StickySession = sacloud.ProxyLBSessionSetting{
+			Enabled: true,
+			Method:  sacloud.ProxyLBStickySessionDefaultMethod,
+		}
+	}
+
 	p.SetSorryServer(params.SorryServerIpaddress, params.SorryServerPort)
 
 	// call Create(id)

--- a/command/funcs/proxy_lb_update.go
+++ b/command/funcs/proxy_lb_update.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"fmt"
 
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
 )
@@ -70,6 +71,19 @@ func ProxyLBUpdate(ctx command.Context, params *params.UpdateProxyLBParam) error
 		p.SetTCPHealthCheck(params.DelayLoop)
 	default:
 		return fmt.Errorf("invalid protocol: %s", protocol)
+	}
+
+	if ctx.IsSet("sticky-session") {
+		if params.StickySession {
+			p.Settings.ProxyLB.StickySession = sacloud.ProxyLBSessionSetting{
+				Enabled: true,
+				Method:  sacloud.ProxyLBStickySessionDefaultMethod,
+			}
+		} else {
+			p.Settings.ProxyLB.StickySession = sacloud.ProxyLBSessionSetting{
+				Enabled: false,
+			}
+		}
 	}
 
 	if ctx.IsSet("sorry-server-ipaddress") || ctx.IsSet("sorry-server-port") {

--- a/command/params/params_proxy_lb_gen.go
+++ b/command/params/params_proxy_lb_gen.go
@@ -289,6 +289,7 @@ type CreateProxyLBParam struct {
 	HostHeader           string   `json:"host-header"`
 	Path                 string   `json:"path"`
 	DelayLoop            int      `json:"delay-loop"`
+	StickySession        bool     `json:"sticky-session"`
 	SorryServerIpaddress string   `json:"sorry-server-ipaddress"`
 	SorryServerPort      int      `json:"sorry-server-port"`
 	Name                 string   `json:"name"`
@@ -335,6 +336,9 @@ func (p *CreateProxyLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.DelayLoop) {
 		p.DelayLoop = 0
+	}
+	if isEmpty(p.StickySession) {
+		p.StickySession = false
 	}
 	if isEmpty(p.SorryServerIpaddress) {
 		p.SorryServerIpaddress = ""
@@ -552,6 +556,13 @@ func (p *CreateProxyLBParam) SetDelayLoop(v int) {
 
 func (p *CreateProxyLBParam) GetDelayLoop() int {
 	return p.DelayLoop
+}
+func (p *CreateProxyLBParam) SetStickySession(v bool) {
+	p.StickySession = v
+}
+
+func (p *CreateProxyLBParam) GetStickySession() bool {
+	return p.StickySession
 }
 func (p *CreateProxyLBParam) SetSorryServerIpaddress(v string) {
 	p.SorryServerIpaddress = v
@@ -884,6 +895,7 @@ type UpdateProxyLBParam struct {
 	HostHeader           string   `json:"host-header"`
 	Path                 string   `json:"path"`
 	DelayLoop            int      `json:"delay-loop"`
+	StickySession        bool     `json:"sticky-session"`
 	SorryServerIpaddress string   `json:"sorry-server-ipaddress"`
 	SorryServerPort      int      `json:"sorry-server-port"`
 	Selector             []string `json:"selector"`
@@ -923,6 +935,9 @@ func (p *UpdateProxyLBParam) FillValueToSkeleton() {
 	}
 	if isEmpty(p.DelayLoop) {
 		p.DelayLoop = 0
+	}
+	if isEmpty(p.StickySession) {
+		p.StickySession = false
 	}
 	if isEmpty(p.SorryServerIpaddress) {
 		p.SorryServerIpaddress = ""
@@ -1118,6 +1133,13 @@ func (p *UpdateProxyLBParam) SetDelayLoop(v int) {
 
 func (p *UpdateProxyLBParam) GetDelayLoop() int {
 	return p.DelayLoop
+}
+func (p *UpdateProxyLBParam) SetStickySession(v bool) {
+	p.StickySession = v
+}
+
+func (p *UpdateProxyLBParam) GetStickySession() bool {
+	return p.StickySession
 }
 func (p *UpdateProxyLBParam) SetSorryServerIpaddress(v string) {
 	p.SorryServerIpaddress = v

--- a/define/proxylb.go
+++ b/define/proxylb.go
@@ -278,6 +278,14 @@ func proxyLBListColumns() []output.ColumnDef {
 			Name:    "VIP",
 			Sources: []string{"Status.VirtualIPAddress"},
 		},
+		{
+			Name:    "FQDN",
+			Sources: []string{"Status.FQDN"},
+		},
+		{
+			Name:    "StickySession",
+			Sources: []string{"Settings.ProxyLB.StickySession.Enabled"},
+		},
 	}
 }
 
@@ -379,6 +387,13 @@ func proxyLBCreateParam() map[string]*schema.Schema {
 			Category:     "ProxyLB",
 			Order:        60,
 		},
+		"sticky-session": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Description: "enable sticky-session",
+			Category:    "ProxyLB",
+			Order:       70,
+		},
 		"sorry-server-ipaddress": {
 			Type:        schema.TypeString,
 			HandlerType: schema.HandlerNoop,
@@ -392,7 +407,7 @@ func proxyLBCreateParam() map[string]*schema.Schema {
 			Description:  "set sorry-server ports",
 			ValidateFunc: validateIntRange(1, 65535),
 			Category:     "ProxyLB",
-			Order:        80,
+			Order:        85,
 		},
 		"name":        paramRequiredName,
 		"description": paramDescription,
@@ -437,6 +452,13 @@ func proxyLBUpdateParam() map[string]*schema.Schema {
 			ValidateFunc: validateIntRange(10, 60),
 			Category:     "ProxyLB",
 			Order:        60,
+		},
+		"sticky-session": {
+			Type:        schema.TypeBool,
+			HandlerType: schema.HandlerNoop,
+			Description: "enable sticky-session",
+			Category:    "ProxyLB",
+			Order:       70,
 		},
 		"sorry-server-ipaddress": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
( related: #437 )

エンハンスドロードバランサでのセッション維持機能に対応する。
https://cloud-news.sakura.ad.jp/2019/06/27/enhanced-lb-session-stickiness/

エンハンスドロードバランサの作成(create)/更新(update)に`--stick-session`というパラメータを追加して対応する。

### 利用例

```bash
# 作成時に指定
$ usacloud enhanced-load-balancer create --name example --sticky-session --plan 100
```

```bash
# 更新時に指定
$ usacloud enhanced-load-balancer update --sticky-session=false <ID or Name>
```