### PR TITLE
エンハンスドロードバランサでのカスタムレスポンスヘッダ設定

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,8 +37,6 @@ tools:
 	GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
 	GO111MODULE=off go get -u github.com/motemen/gobump/cmd/gobump
 	GO111MODULE=off go get -u golang.org/x/lint/golint
-	#curl https://git.io/vp6lP | sh
-	#gometalinter --install
 
 contrib/completion/bash/usacloud: define/*.go
 	go run tools/gen-bash-completion/main.go

--- a/README.md
+++ b/README.md
@@ -113,54 +113,65 @@ VERSION:
    NN.NN.NN, build xxxxxx
 
 COMMANDS:
-   config, profile                  A manage command of APIKey settings
-   auth-status                      A manage commands of AuthStatus
-   private-host                     A manage commands of PrivateHost
-   server                           A manage commands of Server
-   archive                          A manage commands of Archive
-   auto-backup                      A manage commands of AutoBackup
-   disk                             A manage commands of Disk
-   iso-image                        A manage commands of ISOImage
-   bridge                           A manage commands of Bridge
-   interface                        A manage commands of Interface
-   internet                         A manage commands of Internet
-   ipv4                             A manage commands of IPv4
-   ipv6                             A manage commands of IPv6
-   packet-filter                    A manage commands of PacketFilter
-   switch                           A manage commands of Switch
-   database                         A manage commands of Database
-   load-balancer                    A manage commands of LoadBalancer
-   nfs                              A manage commands of NFS
-   vpc-router                       A manage commands of VPCRouter
-   dns                              A manage commands of DNS
-   gslb                             A manage commands of GSLB
-   simple-monitor                   A manage commands of SimpleMonitor
-   icon                             A manage commands of Icon
-   license                          A manage commands of License
-   ssh-key                          A manage commands of SSHKey
-   startup-script, note             A manage commands of StartupScript
-   bill                             A manage commands of Bill
-   object-storage, ojs              A manage commands of ObjectStorage
-   web-accel                        A manage commands of WebAccel
-   price, public-price              A manage commands of Price
-   product-disk, disk-plan          A manage commands of ProductDisk
-   product-internet, internet-plan  A manage commands of ProductInternet
-   product-license, license-info    A manage commands of ProductLicense
-   product-server, server-plan      A manage commands of ProductServer
-   region                           A manage commands of Region
-   zone                             A manage commands of Zone
-   summary                          Show summary of resource usage
+   config, profile                            A manage command of APIKey settings
+   auth-status                                A manage commands of AuthStatus
+   private-host                               A manage commands of PrivateHost
+   server                                     A manage commands of Server
+   archive                                    A manage commands of Archive
+   auto-backup                                A manage commands of AutoBackup
+   disk                                       A manage commands of Disk
+   iso-image                                  A manage commands of ISOImage
+   bridge                                     A manage commands of Bridge
+   interface                                  A manage commands of Interface
+   internet                                   A manage commands of Internet
+   ipv4                                       A manage commands of IPv4
+   ipv6                                       A manage commands of IPv6
+   packet-filter                              A manage commands of PacketFilter
+   switch                                     A manage commands of Switch
+   database                                   A manage commands of Database
+   load-balancer                              A manage commands of LoadBalancer
+   mobile-gateway, mgw                        A manage commands of MobileGateway
+   nfs                                        A manage commands of NFS
+   vpc-router                                 A manage commands of VPCRouter
+   dns                                        A manage commands of DNS
+   gslb                                       A manage commands of GSLB
+   proxy-lb, enhanced-load-balancer, proxylb  A manage commands of ProxyLB
+   sim                                        A manage commands of SIM
+   simple-monitor                             A manage commands of SimpleMonitor
+   icon                                       A manage commands of Icon
+   license                                    A manage commands of License
+   ssh-key                                    A manage commands of SSHKey
+   startup-script, note                       A manage commands of StartupScript
+   bill                                       A manage commands of Bill
+   coupon                                     A manage commands of Coupon
+   object-storage, ojs                        A manage commands of ObjectStorage
+   self                                       Show self info
+   web-accel                                  A manage commands of WebAccel
+   price, public-price                        A manage commands of Price
+   product-disk, disk-plan                    A manage commands of ProductDisk
+   product-internet, internet-plan            A manage commands of ProductInternet
+   product-license, license-info              A manage commands of ProductLicense
+   product-server, server-plan                A manage commands of ProductServer
+   region                                     A manage commands of Region
+   zone                                       A manage commands of Zone
+   summary                                    Show summary of resource usage
 
 GLOBAL OPTIONS:
    --token value                    API Token of SakuraCloud (default: none) [$SAKURACLOUD_ACCESS_TOKEN]
    --secret value                   API Secret of SakuraCloud (default: none) [$SAKURACLOUD_ACCESS_TOKEN_SECRET]
    --zone value                     Target zone of SakuraCloud (default: tk1a) [$SAKURACLOUD_ZONE]
    --config value, --profile value  Config(Profile) name [$USACLOUD_PROFILE]
+   --timeout value                  Number of timeout minutes for polling functions (default: 20) [$SAKURACLOUD_TIMEOUT]
+   --accept-language value          Accept-Language Header [$SAKURACLOUD_ACCEPT_LANGUAGE]
+   --retry-max value                Number of API-Client retries (default: 0) [$SAKURACLOUD_RETRY_MAX]
+   --retry-interval value           API client retry interval seconds (default: 0) [$SAKURACLOUD_RETRY_INTERVAL]
+   --api-request-timeout value      Maximum wait time(seconds) for calling SakuraCloud API (default: 0) [$SAKURACLOUD_API_REQUEST_TIMEOUT]
+   --no-color                       Flag of not using ANSI color output (default: false) [$NO_COLOR]
    --help, -h                       show help (default: false)
    --version, -v                    print the version (default: false)
 
 COPYRIGHT:
-   Copyright (C) 2017 Kazumichi Yamamoto.
+   Copyright (C) 2017-2019 Kazumichi Yamamoto.
 ```   
 
 

--- a/command/completion/proxy_lb_args_gen.go
+++ b/command/completion/proxy_lb_args_gen.go
@@ -265,6 +265,130 @@ func ProxyLBBindPortDeleteCompleteArgs(ctx command.Context, params *params.BindP
 
 }
 
+func ProxyLBResponseHeaderInfoCompleteArgs(ctx command.Context, params *params.ResponseHeaderInfoProxyLBParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetProxyLBAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.CommonServiceProxyLBItems {
+		fmt.Println(res.CommonServiceProxyLBItems[i].ID)
+		var target interface{} = &res.CommonServiceProxyLBItems[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func ProxyLBResponseHeaderAddCompleteArgs(ctx command.Context, params *params.ResponseHeaderAddProxyLBParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetProxyLBAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.CommonServiceProxyLBItems {
+		fmt.Println(res.CommonServiceProxyLBItems[i].ID)
+		var target interface{} = &res.CommonServiceProxyLBItems[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func ProxyLBResponseHeaderUpdateCompleteArgs(ctx command.Context, params *params.ResponseHeaderUpdateProxyLBParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetProxyLBAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.CommonServiceProxyLBItems {
+		fmt.Println(res.CommonServiceProxyLBItems[i].ID)
+		var target interface{} = &res.CommonServiceProxyLBItems[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
+func ProxyLBResponseHeaderDeleteCompleteArgs(ctx command.Context, params *params.ResponseHeaderDeleteProxyLBParam, cur, prev, commandName string) {
+
+	if !command.GlobalOption.Valid {
+		return
+	}
+
+	client := ctx.GetAPIClient()
+	finder := client.GetProxyLBAPI()
+	finder.SetEmpty()
+
+	// call Find()
+	res, err := finder.Find()
+	if err != nil {
+		return
+	}
+
+	type nameHolder interface {
+		GetName() string
+	}
+
+	for i := range res.CommonServiceProxyLBItems {
+		fmt.Println(res.CommonServiceProxyLBItems[i].ID)
+		var target interface{} = &res.CommonServiceProxyLBItems[i]
+		if v, ok := target.(nameHolder); ok {
+			fmt.Println(v.GetName())
+		}
+
+	}
+
+}
+
 func ProxyLBAcmeInfoCompleteArgs(ctx command.Context, params *params.AcmeInfoProxyLBParam, cur, prev, commandName string) {
 
 	if !command.GlobalOption.Valid {

--- a/command/completion/proxy_lb_flags_gen.go
+++ b/command/completion/proxy_lb_flags_gen.go
@@ -451,6 +451,160 @@ func ProxyLBBindPortDeleteCompleteFlags(ctx command.Context, params *params.Bind
 	}
 }
 
+func ProxyLBResponseHeaderInfoCompleteFlags(ctx command.Context, params *params.ResponseHeaderInfoProxyLBParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "port-index":
+		param := define.Resources["ProxyLB"].Commands["response-header-info"].BuildedParams().Get("port-index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["ProxyLB"].Commands["response-header-info"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["ProxyLB"].Commands["response-header-info"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out", "o":
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func ProxyLBResponseHeaderAddCompleteFlags(ctx command.Context, params *params.ResponseHeaderAddProxyLBParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "port-index":
+		param := define.Resources["ProxyLB"].Commands["response-header-add"].BuildedParams().Get("port-index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "header":
+		param := define.Resources["ProxyLB"].Commands["response-header-add"].BuildedParams().Get("header")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "value":
+		param := define.Resources["ProxyLB"].Commands["response-header-add"].BuildedParams().Get("value")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["ProxyLB"].Commands["response-header-add"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["ProxyLB"].Commands["response-header-add"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out", "o":
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func ProxyLBResponseHeaderUpdateCompleteFlags(ctx command.Context, params *params.ResponseHeaderUpdateProxyLBParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "index":
+		param := define.Resources["ProxyLB"].Commands["response-header-update"].BuildedParams().Get("index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "port-index":
+		param := define.Resources["ProxyLB"].Commands["response-header-update"].BuildedParams().Get("port-index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "header":
+		param := define.Resources["ProxyLB"].Commands["response-header-update"].BuildedParams().Get("header")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "value":
+		param := define.Resources["ProxyLB"].Commands["response-header-update"].BuildedParams().Get("value")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["ProxyLB"].Commands["response-header-update"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["ProxyLB"].Commands["response-header-update"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out", "o":
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
+func ProxyLBResponseHeaderDeleteCompleteFlags(ctx command.Context, params *params.ResponseHeaderDeleteProxyLBParam, flagName string, currentValue string) {
+	var comp schema.CompletionFunc
+
+	switch flagName {
+	case "index":
+		param := define.Resources["ProxyLB"].Commands["response-header-delete"].BuildedParams().Get("index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "port-index":
+		param := define.Resources["ProxyLB"].Commands["response-header-delete"].BuildedParams().Get("port-index")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "selector":
+		param := define.Resources["ProxyLB"].Commands["response-header-delete"].BuildedParams().Get("selector")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "id":
+		param := define.Resources["ProxyLB"].Commands["response-header-delete"].BuildedParams().Get("id")
+		if param != nil {
+			comp = param.Param.CompleteFunc
+		}
+	case "output-type", "out", "o":
+		comp = schema.CompleteInStrValues("json", "yaml", "csv", "tsv")
+	}
+
+	if comp != nil {
+		words := comp(ctx, currentValue)
+		for _, w := range words {
+			fmt.Println(w)
+		}
+	}
+}
+
 func ProxyLBAcmeInfoCompleteFlags(ctx command.Context, params *params.AcmeInfoProxyLBParam, flagName string, currentValue string) {
 	var comp schema.CompletionFunc
 

--- a/command/funcs/proxy_lb_bind_port_add.go
+++ b/command/funcs/proxy_lb_bind_port_add.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"fmt"
 
+	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/command"
 	"github.com/sacloud/usacloud/command/params"
 )
@@ -23,7 +24,7 @@ func ProxyLBBindPortAdd(ctx command.Context, params *params.BindPortAddProxyLBPa
 		}
 	}
 
-	p.AddBindPort(params.Mode, params.Port, params.RedirectToHttps, params.SupportHttp2)
+	p.AddBindPort(params.Mode, params.Port, params.RedirectToHttps, params.SupportHttp2, []*sacloud.ProxyLBResponseHeader{})
 	p, e = api.UpdateSetting(params.Id, p)
 	if e != nil {
 		return fmt.Errorf("ProxyLBBindPortAdd is failed: %s", e)

--- a/command/funcs/proxy_lb_response_header_add.go
+++ b/command/funcs/proxy_lb_response_header_add.go
@@ -1,0 +1,52 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func ProxyLBResponseHeaderAdd(ctx command.Context, params *params.ResponseHeaderAddProxyLBParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetProxyLBAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("ProxyLBResponseHeaderAdd is failed: %s", e)
+	}
+	if len(p.Settings.ProxyLB.BindPorts) == 0 {
+		return fmt.Errorf("ProxyLB don't have any bind-ports")
+	}
+
+	// validate index
+	if params.PortIndex <= 0 || params.PortIndex-1 >= len(p.Settings.ProxyLB.BindPorts) {
+		return fmt.Errorf("port-index(%d) is out of range", params.PortIndex)
+	}
+
+	bindPort := p.Settings.ProxyLB.BindPorts[params.PortIndex-1]
+
+	// validate duplicate
+	for _, header := range bindPort.AddResponseHeader {
+		if header.Header == params.Header {
+			return fmt.Errorf("Header %q already exists", params.Header)
+		}
+	}
+
+	bindPort.AddResponseHeader = append(bindPort.AddResponseHeader, &sacloud.ProxyLBResponseHeader{
+		Header: params.Header,
+		Value:  params.Value,
+	})
+
+	p, e = api.UpdateSetting(params.Id, p)
+	if e != nil {
+		return fmt.Errorf("ProxyLBResponseHeaderAdd is failed: %s", e)
+	}
+
+	var list []interface{}
+	for i := range bindPort.AddResponseHeader {
+		list = append(list, &bindPort.AddResponseHeader[i])
+	}
+	return ctx.GetOutput().Print(list...)
+}

--- a/command/funcs/proxy_lb_response_header_delete.go
+++ b/command/funcs/proxy_lb_response_header_delete.go
@@ -1,0 +1,54 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func ProxyLBResponseHeaderDelete(ctx command.Context, params *params.ResponseHeaderDeleteProxyLBParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetProxyLBAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("ProxyLBResponseHeaderDelete is failed: %s", e)
+	}
+	if len(p.Settings.ProxyLB.BindPorts) == 0 {
+		return fmt.Errorf("ProxyLB don't have any bind-ports")
+	}
+
+	// validate index
+	if params.PortIndex <= 0 || params.PortIndex-1 >= len(p.Settings.ProxyLB.BindPorts) {
+		return fmt.Errorf("port-index(%d) is out of range", params.PortIndex)
+	}
+
+	bindPort := p.Settings.ProxyLB.BindPorts[params.PortIndex-1]
+
+	// validate header index
+	if params.Index <= 0 || params.Index-1 >= len(bindPort.AddResponseHeader) {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
+	}
+
+	newHeaders := []*sacloud.ProxyLBResponseHeader{}
+	for i, header := range bindPort.AddResponseHeader {
+		if i != params.Index-1 {
+			newHeaders = append(newHeaders, header)
+		}
+	}
+	bindPort.AddResponseHeader = newHeaders
+
+	p, e = api.UpdateSetting(params.Id, p)
+	if e != nil {
+		return fmt.Errorf("ProxyLBResponseHeaderDelete is failed: %s", e)
+	}
+
+	var list []interface{}
+	for i := range bindPort.AddResponseHeader {
+		list = append(list, &bindPort.AddResponseHeader[i])
+	}
+	return ctx.GetOutput().Print(list...)
+
+}

--- a/command/funcs/proxy_lb_response_header_info.go
+++ b/command/funcs/proxy_lb_response_header_info.go
@@ -1,0 +1,39 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func ProxyLBResponseHeaderInfo(ctx command.Context, params *params.ResponseHeaderInfoProxyLBParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetProxyLBAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("ProxyLBResponseHeaderInfo is failed: %s", e)
+	}
+	if len(p.Settings.ProxyLB.BindPorts) == 0 {
+		return fmt.Errorf("ProxyLB don't have any bind-ports")
+	}
+
+	// validate index
+	if params.PortIndex <= 0 || params.PortIndex-1 >= len(p.Settings.ProxyLB.BindPorts) {
+		return fmt.Errorf("port-index(%d) is out of range", params.PortIndex)
+	}
+
+	bindPort := p.Settings.ProxyLB.BindPorts[params.PortIndex-1]
+
+	if len(bindPort.AddResponseHeader) == 0 {
+		return fmt.Errorf("Port %s:%d don't have any additional response headers", bindPort.ProxyMode, bindPort.Port)
+	}
+
+	var list []interface{}
+	for i := range bindPort.AddResponseHeader {
+		list = append(list, &bindPort.AddResponseHeader[i])
+	}
+	return ctx.GetOutput().Print(list...)
+
+}

--- a/command/funcs/proxy_lb_response_header_update.go
+++ b/command/funcs/proxy_lb_response_header_update.go
@@ -1,0 +1,53 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/sacloud/usacloud/command"
+	"github.com/sacloud/usacloud/command/params"
+)
+
+func ProxyLBResponseHeaderUpdate(ctx command.Context, params *params.ResponseHeaderUpdateProxyLBParam) error {
+
+	client := ctx.GetAPIClient()
+	api := client.GetProxyLBAPI()
+	p, e := api.Read(params.Id)
+	if e != nil {
+		return fmt.Errorf("ProxyLBResponseHeaderUpdate is failed: %s", e)
+	}
+	if len(p.Settings.ProxyLB.BindPorts) == 0 {
+		return fmt.Errorf("ProxyLB don't have any bind-ports")
+	}
+
+	// validate index
+	if params.PortIndex <= 0 || params.PortIndex-1 >= len(p.Settings.ProxyLB.BindPorts) {
+		return fmt.Errorf("port-index(%d) is out of range", params.PortIndex)
+	}
+
+	bindPort := p.Settings.ProxyLB.BindPorts[params.PortIndex-1]
+
+	// validate header index
+	if params.Index <= 0 || params.Index-1 >= len(bindPort.AddResponseHeader) {
+		return fmt.Errorf("index(%d) is out of range", params.Index)
+	}
+
+	header := bindPort.AddResponseHeader[params.Index-1]
+	if ctx.IsSet("header") {
+		header.Header = params.Header
+	}
+	if ctx.IsSet("value") {
+		header.Value = params.Value
+	}
+
+	p, e = api.UpdateSetting(params.Id, p)
+	if e != nil {
+		return fmt.Errorf("ProxyLBResponseHeaderUpdate is failed: %s", e)
+	}
+
+	var list []interface{}
+	for i := range bindPort.AddResponseHeader {
+		list = append(list, &bindPort.AddResponseHeader[i])
+	}
+	return ctx.GetOutput().Print(list...)
+
+}

--- a/command/params/params_proxy_lb_gen.go
+++ b/command/params/params_proxy_lb_gen.go
@@ -2751,6 +2751,1025 @@ func (p *BindPortDeleteProxyLBParam) GetId() int64 {
 	return p.Id
 }
 
+// ResponseHeaderInfoProxyLBParam is input parameters for the sacloud API
+type ResponseHeaderInfoProxyLBParam struct {
+	PortIndex         int      `json:"port-index"`
+	Selector          []string `json:"selector"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
+	Id                int64    `json:"id"`
+}
+
+// NewResponseHeaderInfoProxyLBParam return new ResponseHeaderInfoProxyLBParam
+func NewResponseHeaderInfoProxyLBParam() *ResponseHeaderInfoProxyLBParam {
+	return &ResponseHeaderInfoProxyLBParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *ResponseHeaderInfoProxyLBParam) FillValueToSkeleton() {
+	if isEmpty(p.PortIndex) {
+		p.PortIndex = 0
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *ResponseHeaderInfoProxyLBParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--port-index", p.PortIndex)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetResourceDef() *schema.Resource {
+	return define.Resources["ProxyLB"]
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["response-header-info"]
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) SetPortIndex(v int) {
+	p.PortIndex = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetPortIndex() int {
+	return p.PortIndex
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetColumn() []string {
+	return p.Column
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetFormat() string {
+	return p.Format
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetQuery() string {
+	return p.Query
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
+func (p *ResponseHeaderInfoProxyLBParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *ResponseHeaderInfoProxyLBParam) GetId() int64 {
+	return p.Id
+}
+
+// ResponseHeaderAddProxyLBParam is input parameters for the sacloud API
+type ResponseHeaderAddProxyLBParam struct {
+	PortIndex         int      `json:"port-index"`
+	Header            string   `json:"header"`
+	Value             string   `json:"value"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
+	Id                int64    `json:"id"`
+}
+
+// NewResponseHeaderAddProxyLBParam return new ResponseHeaderAddProxyLBParam
+func NewResponseHeaderAddProxyLBParam() *ResponseHeaderAddProxyLBParam {
+	return &ResponseHeaderAddProxyLBParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *ResponseHeaderAddProxyLBParam) FillValueToSkeleton() {
+	if isEmpty(p.PortIndex) {
+		p.PortIndex = 0
+	}
+	if isEmpty(p.Header) {
+		p.Header = ""
+	}
+	if isEmpty(p.Value) {
+		p.Value = ""
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *ResponseHeaderAddProxyLBParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--port-index", p.PortIndex)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateRequired
+		errs := validator("--header", p.Header)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateRequired
+		errs := validator("--value", p.Value)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetResourceDef() *schema.Resource {
+	return define.Resources["ProxyLB"]
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["response-header-add"]
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *ResponseHeaderAddProxyLBParam) SetPortIndex(v int) {
+	p.PortIndex = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetPortIndex() int {
+	return p.PortIndex
+}
+func (p *ResponseHeaderAddProxyLBParam) SetHeader(v string) {
+	p.Header = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetHeader() string {
+	return p.Header
+}
+func (p *ResponseHeaderAddProxyLBParam) SetValue(v string) {
+	p.Value = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetValue() string {
+	return p.Value
+}
+func (p *ResponseHeaderAddProxyLBParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *ResponseHeaderAddProxyLBParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *ResponseHeaderAddProxyLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResponseHeaderAddProxyLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *ResponseHeaderAddProxyLBParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *ResponseHeaderAddProxyLBParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *ResponseHeaderAddProxyLBParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetColumn() []string {
+	return p.Column
+}
+func (p *ResponseHeaderAddProxyLBParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *ResponseHeaderAddProxyLBParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetFormat() string {
+	return p.Format
+}
+func (p *ResponseHeaderAddProxyLBParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *ResponseHeaderAddProxyLBParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetQuery() string {
+	return p.Query
+}
+func (p *ResponseHeaderAddProxyLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
+func (p *ResponseHeaderAddProxyLBParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *ResponseHeaderAddProxyLBParam) GetId() int64 {
+	return p.Id
+}
+
+// ResponseHeaderUpdateProxyLBParam is input parameters for the sacloud API
+type ResponseHeaderUpdateProxyLBParam struct {
+	Index             int      `json:"index"`
+	PortIndex         int      `json:"port-index"`
+	Header            string   `json:"header"`
+	Value             string   `json:"value"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
+	Id                int64    `json:"id"`
+}
+
+// NewResponseHeaderUpdateProxyLBParam return new ResponseHeaderUpdateProxyLBParam
+func NewResponseHeaderUpdateProxyLBParam() *ResponseHeaderUpdateProxyLBParam {
+	return &ResponseHeaderUpdateProxyLBParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *ResponseHeaderUpdateProxyLBParam) FillValueToSkeleton() {
+	if isEmpty(p.Index) {
+		p.Index = 0
+	}
+	if isEmpty(p.PortIndex) {
+		p.PortIndex = 0
+	}
+	if isEmpty(p.Header) {
+		p.Header = ""
+	}
+	if isEmpty(p.Value) {
+		p.Value = ""
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *ResponseHeaderUpdateProxyLBParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--index", p.Index)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateRequired
+		errs := validator("--port-index", p.PortIndex)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetResourceDef() *schema.Resource {
+	return define.Resources["ProxyLB"]
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["response-header-update"]
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) SetIndex(v int) {
+	p.Index = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetIndex() int {
+	return p.Index
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetPortIndex(v int) {
+	p.PortIndex = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetPortIndex() int {
+	return p.PortIndex
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetHeader(v string) {
+	p.Header = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetHeader() string {
+	return p.Header
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetValue(v string) {
+	p.Value = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetValue() string {
+	return p.Value
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetColumn() []string {
+	return p.Column
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetFormat() string {
+	return p.Format
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetQuery() string {
+	return p.Query
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
+func (p *ResponseHeaderUpdateProxyLBParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *ResponseHeaderUpdateProxyLBParam) GetId() int64 {
+	return p.Id
+}
+
+// ResponseHeaderDeleteProxyLBParam is input parameters for the sacloud API
+type ResponseHeaderDeleteProxyLBParam struct {
+	Index             int      `json:"index"`
+	PortIndex         int      `json:"port-index"`
+	Selector          []string `json:"selector"`
+	Assumeyes         bool     `json:"assumeyes"`
+	ParamTemplate     string   `json:"param-template"`
+	ParamTemplateFile string   `json:"param-template-file"`
+	GenerateSkeleton  bool     `json:"generate-skeleton"`
+	OutputType        string   `json:"output-type"`
+	Column            []string `json:"column"`
+	Quiet             bool     `json:"quiet"`
+	Format            string   `json:"format"`
+	FormatFile        string   `json:"format-file"`
+	Query             string   `json:"query"`
+	QueryFile         string   `json:"query-file"`
+	Id                int64    `json:"id"`
+}
+
+// NewResponseHeaderDeleteProxyLBParam return new ResponseHeaderDeleteProxyLBParam
+func NewResponseHeaderDeleteProxyLBParam() *ResponseHeaderDeleteProxyLBParam {
+	return &ResponseHeaderDeleteProxyLBParam{}
+}
+
+// FillValueToSkeleton fill values to empty fields
+func (p *ResponseHeaderDeleteProxyLBParam) FillValueToSkeleton() {
+	if isEmpty(p.Index) {
+		p.Index = 0
+	}
+	if isEmpty(p.PortIndex) {
+		p.PortIndex = 0
+	}
+	if isEmpty(p.Selector) {
+		p.Selector = []string{""}
+	}
+	if isEmpty(p.Assumeyes) {
+		p.Assumeyes = false
+	}
+	if isEmpty(p.ParamTemplate) {
+		p.ParamTemplate = ""
+	}
+	if isEmpty(p.ParamTemplateFile) {
+		p.ParamTemplateFile = ""
+	}
+	if isEmpty(p.GenerateSkeleton) {
+		p.GenerateSkeleton = false
+	}
+	if isEmpty(p.OutputType) {
+		p.OutputType = ""
+	}
+	if isEmpty(p.Column) {
+		p.Column = []string{""}
+	}
+	if isEmpty(p.Quiet) {
+		p.Quiet = false
+	}
+	if isEmpty(p.Format) {
+		p.Format = ""
+	}
+	if isEmpty(p.FormatFile) {
+		p.FormatFile = ""
+	}
+	if isEmpty(p.Query) {
+		p.Query = ""
+	}
+	if isEmpty(p.QueryFile) {
+		p.QueryFile = ""
+	}
+	if isEmpty(p.Id) {
+		p.Id = 0
+	}
+
+}
+
+// Validate checks current values in model
+func (p *ResponseHeaderDeleteProxyLBParam) Validate() []error {
+	errors := []error{}
+	{
+		validator := validateRequired
+		errs := validator("--index", p.Index)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateRequired
+		errs := validator("--port-index", p.PortIndex)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		validator := validateSakuraID
+		errs := validator("--id", p.Id)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	{
+		validator := schema.ValidateInStrValues(define.AllowOutputTypes...)
+		errs := validator("--output-type", p.OutputType)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateInputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+	{
+		errs := validateOutputOption(p)
+		if errs != nil {
+			errors = append(errors, errs...)
+		}
+	}
+
+	return errors
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetResourceDef() *schema.Resource {
+	return define.Resources["ProxyLB"]
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetCommandDef() *schema.Command {
+	return p.GetResourceDef().Commands["response-header-delete"]
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetIncludeFields() []string {
+	return p.GetCommandDef().IncludeFields
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetExcludeFields() []string {
+	return p.GetCommandDef().ExcludeFields
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetTableType() output.TableType {
+	return p.GetCommandDef().TableType
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetColumnDefs() []output.ColumnDef {
+	return p.GetCommandDef().TableColumnDefines
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) SetIndex(v int) {
+	p.Index = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetIndex() int {
+	return p.Index
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetPortIndex(v int) {
+	p.PortIndex = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetPortIndex() int {
+	return p.PortIndex
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetSelector(v []string) {
+	p.Selector = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetSelector() []string {
+	return p.Selector
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetAssumeyes(v bool) {
+	p.Assumeyes = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetAssumeyes() bool {
+	return p.Assumeyes
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetParamTemplate(v string) {
+	p.ParamTemplate = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetParamTemplate() string {
+	return p.ParamTemplate
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetParamTemplateFile(v string) {
+	p.ParamTemplateFile = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetParamTemplateFile() string {
+	return p.ParamTemplateFile
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetGenerateSkeleton(v bool) {
+	p.GenerateSkeleton = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetGenerateSkeleton() bool {
+	return p.GenerateSkeleton
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetOutputType(v string) {
+	p.OutputType = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetOutputType() string {
+	return p.OutputType
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetColumn(v []string) {
+	p.Column = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetColumn() []string {
+	return p.Column
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetQuiet(v bool) {
+	p.Quiet = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetQuiet() bool {
+	return p.Quiet
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetFormat(v string) {
+	p.Format = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetFormat() string {
+	return p.Format
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetFormatFile(v string) {
+	p.FormatFile = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetFormatFile() string {
+	return p.FormatFile
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetQuery(v string) {
+	p.Query = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetQuery() string {
+	return p.Query
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetQueryFile(v string) {
+	p.QueryFile = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetQueryFile() string {
+	return p.QueryFile
+}
+func (p *ResponseHeaderDeleteProxyLBParam) SetId(v int64) {
+	p.Id = v
+}
+
+func (p *ResponseHeaderDeleteProxyLBParam) GetId() int64 {
+	return p.Id
+}
+
 // AcmeInfoProxyLBParam is input parameters for the sacloud API
 type AcmeInfoProxyLBParam struct {
 	Selector          []string `json:"selector"`

--- a/define/proxylb.go
+++ b/define/proxylb.go
@@ -102,6 +102,45 @@ func ProxyLBResource() *schema.Resource {
 			Category:           "bind-port",
 			Order:              40,
 		},
+		"response-header-info": {
+			Type:               schema.CommandManipulateSingle,
+			Params:             proxyLBResponseHeaderListParam(),
+			Aliases:            []string{"response-header-list"},
+			TableType:          output.TableSimple,
+			TableColumnDefines: proxyLBResponseHeaderListColumns(),
+			UseCustomCommand:   true,
+			NeedlessConfirm:    true,
+			Category:           "response-header",
+			Order:              10,
+		},
+		"response-header-add": {
+			Type:               schema.CommandManipulateSingle,
+			Params:             proxyLBResponseHeaderAddParam(),
+			TableType:          output.TableSimple,
+			TableColumnDefines: proxyLBResponseHeaderListColumns(),
+			UseCustomCommand:   true,
+			Category:           "response-header",
+			Order:              20,
+		},
+		"response-header-update": {
+			Type:               schema.CommandManipulateSingle,
+			Params:             proxyLBResponseHeaderUpdateParam(),
+			TableType:          output.TableSimple,
+			TableColumnDefines: proxyLBResponseHeaderListColumns(),
+			UseCustomCommand:   true,
+			Category:           "response-header",
+			Order:              30,
+		},
+		"response-header-delete": {
+			Type:               schema.CommandManipulateSingle,
+			Params:             proxyLBResponseHeaderDeleteParam(),
+			TableType:          output.TableSimple,
+			TableColumnDefines: proxyLBResponseHeaderListColumns(),
+			UseCustomCommand:   true,
+			ConfirmMessage:     "delete response-header",
+			Category:           "response-header",
+			Order:              40,
+		},
 		"acme-info": {
 			Type:               schema.CommandManipulateSingle,
 			Params:             proxyLBACMEInfoParam(),
@@ -241,6 +280,11 @@ var proxyLBCommandCategories = []schema.Category{
 		Order:       20,
 	},
 	{
+		Key:         "response-header",
+		DisplayName: "Additional Response Header(s) Management",
+		Order:       22,
+	},
+	{
 		Key:         "acme",
 		DisplayName: "ACME settings",
 		Order:       25,
@@ -302,6 +346,14 @@ func proxyLBBindPortListColumns() []output.ColumnDef {
 			Name:    "SupportHTTP2",
 			Sources: []string{"SupportHttp2"},
 		},
+	}
+}
+
+func proxyLBResponseHeaderListColumns() []output.ColumnDef {
+	return []output.ColumnDef{
+		{Name: "__ORDER__"}, // magic column name(generated on demand)
+		{Name: "Header"},
+		{Name: "Value"},
 	}
 }
 
@@ -595,6 +647,103 @@ func proxyLBBindPortDeleteParam() map[string]*schema.Schema {
 			Required:    true,
 			Category:    "bind-port",
 			Order:       1,
+		},
+	}
+}
+
+func proxyLBResponseHeaderListParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"port-index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target bind-port",
+			Required:    true,
+			Category:    "response-header",
+			Order:       2,
+		},
+	}
+}
+
+func proxyLBResponseHeaderAddParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"port-index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target bind-port",
+			Required:    true,
+			Category:    "response-header",
+			Order:       2,
+		},
+		"header": {
+			Type:        schema.TypeString,
+			HandlerType: schema.HandlerNoop,
+			Description: "set Header",
+			Required:    true,
+			Category:    "response-header",
+			Order:       10,
+		},
+		"value": {
+			Type:        schema.TypeString,
+			HandlerType: schema.HandlerNoop,
+			Description: "set Value",
+			Required:    true,
+			Category:    "response-header",
+			Order:       20,
+		},
+	}
+}
+func proxyLBResponseHeaderUpdateParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target server",
+			Required:    true,
+			Category:    "server",
+			Order:       1,
+		},
+		"port-index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target bind-port",
+			Required:    true,
+			Category:    "response-header",
+			Order:       2,
+		},
+		"header": {
+			Type:        schema.TypeString,
+			HandlerType: schema.HandlerNoop,
+			Description: "set Header",
+			Category:    "response-header",
+			Order:       10,
+		},
+		"value": {
+			Type:        schema.TypeString,
+			HandlerType: schema.HandlerNoop,
+			Description: "set Value",
+			Category:    "response-header",
+			Order:       20,
+		},
+	}
+}
+
+func proxyLBResponseHeaderDeleteParam() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target bind-port",
+			Required:    true,
+			Category:    "bind-port",
+			Order:       1,
+		},
+		"port-index": {
+			Type:        schema.TypeInt,
+			HandlerType: schema.HandlerNoop,
+			Description: "index of target bind-port",
+			Required:    true,
+			Category:    "response-header",
+			Order:       2,
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe
 	github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08
-	github.com/sacloud/libsacloud v1.25.1
+	github.com/sacloud/libsacloud v1.26.0
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe h1:JSZLn4B8X9V1ynSEht
 github.com/sacloud/ftps v0.0.0-20171205062625-42fc0f9886fe/go.mod h1:sdVeG85LaUt1f+0meZqSf6hSQYlwdgFLI8tJqLZ58VM=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08 h1:hGFzyq3AgiEHgI9xYPrtbK466gP7AimFCjrn3nZktc8=
 github.com/sacloud/go-jmespath v0.0.0-20190125082617-862639817e08/go.mod h1:PLy4tK2PN6G8fxd/cCWH6db2mJGmUlflYs4ASdfNulg=
-github.com/sacloud/libsacloud v1.25.1 h1:vVicNzFtkBxghhGq2ajjqcjkIUFhmtWkpJjCl4bSv3M=
-github.com/sacloud/libsacloud v1.25.1/go.mod h1:79ZwATmHLIFZIMd7sxA3LwzVy/B77uj3LDoToVTxDoQ=
+github.com/sacloud/libsacloud v1.26.0 h1:Q/uKOJ8s1L5bywCOS0DvAktUcy7uSlPmg9tbpb1mF+o=
+github.com/sacloud/libsacloud v1.26.0/go.mod h1:79ZwATmHLIFZIMd7sxA3LwzVy/B77uj3LDoToVTxDoQ=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e h1:VAzdS5Nw68fbf5RZ8RDVlUvPXNU6Z3jtPCK/qvm4FoQ=

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 var (
 	appName      = "usacloud"
 	appUsage     = "CLI client for SakuraCloud"
-	appCopyright = "Copyright (C) 2017-2018 Kazumichi Yamamoto."
+	appCopyright = "Copyright (C) 2017-2019 Kazumichi Yamamoto."
 )
 
 func main() {


### PR DESCRIPTION
カスタムレスポンスヘッダを設定可能にする。

## 現在の設定一覧を表示

```bash
# ポート一覧で対象ポートのインデックスを確認
$ usacloud enhanced-load-balancer bind-port-info <ID or Name>
# 対象ポートのヘッダを確認
$ usacloud enhanced-load-balancer response-header-info --port-index 1 <ID or Name>
```

## 追加/更新/削除

```bash
# 追加
$ usacloud enhanced-load-balancer response-header-add --port-index 1 --header "Cache-Control" --value "public, max-age=10" <ID or Name>

# 更新
$ usacloud enhanced-load-balancer response-header-update --port-index 1 --index 1 --value "public, max-age=15" <ID or Name>

# 削除
$ usacloud enhanced-load-balancer response-header-delete --port-index 1 --index 1 <ID or Name>
```
