### PR TITLE
ディスクの修正APIでのBackgroundパラメータの利用

### DIFF
--- a/command/funcs/disk_edit.go
+++ b/command/funcs/disk_edit.go
@@ -27,6 +27,11 @@ func DiskEdit(ctx command.Context, params *params.EditDiskParam) error {
 				errChan <- err
 				return
 			}
+			if err := api.SleepWhileCopying(params.Id, client.DefaultTimeoutDuration); err != nil {
+				errChan <- err
+				return
+			}
+
 			compChan <- true
 		},
 	)
@@ -45,6 +50,7 @@ func DiskEdit(ctx command.Context, params *params.EditDiskParam) error {
 
 func buildDiskEditValue(ctx command.Context, params *params.EditDiskParam) *sacloud.DiskEditValue {
 	p := ctx.GetAPIClient().GetDiskAPI().NewCondig()
+	p.SetBackground(true)
 
 	// set params
 	if ctx.IsSet("hostname") {

--- a/command/funcs/server_interface_add_for_internet.go
+++ b/command/funcs/server_interface_add_for_internet.go
@@ -59,8 +59,12 @@ func ServerInterfaceAddForInternet(ctx command.Context, params *params.Interface
 	if !params.WithoutDiskEdit {
 		// disk edit
 		editParam := diskAPI.NewCondig()
+		editParam.SetBackground(true)
 		_, err := diskAPI.Config(p.GetDisks()[0].ID, editParam)
 		if err != nil {
+			return fmt.Errorf("ServerInterfaceAddForInternet is failed: %s", err)
+		}
+		if err := diskAPI.SleepWhileCopying(p.GetDisks()[0].ID, client.DefaultTimeoutDuration); err != nil {
 			return fmt.Errorf("ServerInterfaceAddForInternet is failed: %s", err)
 		}
 	}

--- a/command/funcs/server_interface_add_for_router.go
+++ b/command/funcs/server_interface_add_for_router.go
@@ -69,6 +69,7 @@ func ServerInterfaceAddForRouter(ctx command.Context, params *params.InterfaceAd
 	if !params.WithoutDiskEdit {
 		// disk edit
 		editParam := diskAPI.NewCondig()
+		editParam.SetBackground(true)
 
 		if params.Ipaddress != "" {
 			editParam.SetUserIPAddress(params.Ipaddress)
@@ -83,6 +84,9 @@ func ServerInterfaceAddForRouter(ctx command.Context, params *params.InterfaceAd
 		_, err := diskAPI.Config(p.GetDisks()[0].ID, editParam)
 		if err != nil {
 			return fmt.Errorf("ServerInterfaceAddForRouter is failed: %s", err)
+		}
+		if err := diskAPI.SleepWhileCopying(p.GetDisks()[0].ID, client.DefaultTimeoutDuration); err != nil {
+			return fmt.Errorf("ServerInterfaceAddForInternet is failed: %s", err)
 		}
 	}
 

--- a/command/funcs/server_interface_add_for_switch.go
+++ b/command/funcs/server_interface_add_for_switch.go
@@ -80,6 +80,7 @@ func ServerInterfaceAddForSwitch(ctx command.Context, params *params.InterfaceAd
 	if !params.WithoutDiskEdit {
 		// disk edit
 		editParam := diskAPI.NewCondig()
+		editParam.SetBackground(true)
 
 		if params.Ipaddress != "" {
 			editParam.SetUserIPAddress(params.Ipaddress)
@@ -94,6 +95,9 @@ func ServerInterfaceAddForSwitch(ctx command.Context, params *params.InterfaceAd
 		_, err := diskAPI.Config(p.GetDisks()[0].ID, editParam)
 		if err != nil {
 			return fmt.Errorf("ServerInterfaceAddForSwitch is failed: %s", err)
+		}
+		if err := diskAPI.SleepWhileCopying(p.GetDisks()[0].ID, client.DefaultTimeoutDuration); err != nil {
+			return fmt.Errorf("ServerInterfaceAddForInternet is failed: %s", err)
 		}
 	}
 


### PR DESCRIPTION
( a part of #449 )

ディスクの修正実行時にBackgroundパラメータを利用する。

参考: BackgroundパラメータはパーティションリサイズAPIでも利用可能であるが、このプロジェクトからは利用していない。