### PR TITLE
k3OS利用時のデフォルトユーザー名検出処理の修正

### DIFF
--- a/command/funcs/functions.go
+++ b/command/funcs/functions.go
@@ -90,6 +90,10 @@ func getSSHDefaultUserNameArchiveRec(client *api.Client, archiveID int64) (strin
 		if archive.HasTag("distro-rancheros") {
 			return "rancher", nil
 		}
+
+		if archive.HasTag("distro-k3os") {
+			return "rancher", nil
+		}
 	}
 	if archive.SourceDisk != nil {
 		return getSSHDefaultUserNameDiskRec(client, archive.SourceDisk.ID)


### PR DESCRIPTION
fixes #462 

SSH接続時のデフォルトユーザー名検出処理でk3OS利用時に`rancher`を返すようにする。