### PR TITLE
コピーライト表記の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,10 +453,6 @@ $ make docker-integration-test
 
 ## License
 
- `usacloud` Copyright (C) 2017-2019 Kazumichi Yamamoto.
+ `usacloud` Copyright (C) 2017-2019 The Usacloud Authors.
 
   This project is published under [Apache 2.0 License](LICENSE.txt).
-  
-## Author
-
-  * [Usacloud Authors](AUTHORS)

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -451,10 +451,6 @@ You can generate static files with the `mkdocs` command.
 
 ## License
 
- `usacloud` Copyright (C) 2017-2019 Kazumichi Yamamoto.
+ `usacloud` Copyright (C) 2017-2019 The Usacloud Authors.
 
   This project is published under [Apache 2.0 License](LICENSE.txt).
-  
-## Author
-
-  * [Usacloud Authors](AUTHORS)

--- a/build_docs/mkdocs.yml
+++ b/build_docs/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: Usacloud日本語ドキュメント
 site_author: '@yamamoto-febc'
 repo_url: https://github.com/sacloud/usacloud
 repo_name: usacloud
-copyright: Copyright (C) 2017 Kazumichi Yamamoto.
+copyright: Copyright (C) 2017-2019 The Usacloud Authors.
 google_analytics: ['UA-63739336-4','auto']
 theme: readthedocs
 extra_css:

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 var (
 	appName      = "usacloud"
 	appUsage     = "CLI client for SakuraCloud"
-	appCopyright = "Copyright (C) 2017-2019 Kazumichi Yamamoto."
+	appCopyright = "Copyright (C) 2017-2019 The Usacloud Authors"
 )
 
 func main() {


### PR DESCRIPTION
#467 の修正漏れ

コピーライト表記を個人名からUsacloud Authorsへ修正

- README
- main.go
- mkdocs.yml