### PR TITLE
エンハンスドロードバランサでのTCPサポート

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -66,7 +66,8 @@ contrib/completion/bash/usacloud: define/*.go
 gen: command/cli/*_gen.go command/completion/*_gen.go command/funcs/*_gen.go command/params/*_gen.go
 
 .PHONY: gen-force
-gen-force: clean-all contrib/completion/bash/usacloud
+gen-force: clean-all contrib/completion/bash/usacloud _gen-force set-license
+_gen-force: 
 	go generate -mod=vendor $(GOGEN_FILES); gofmt -s -l -w $(GOFMT_FILES); goimports -l -w $(GOFMT_FILES)
 
 command/*_gen.go: define/*.go tools/gen-cli-commands/*.go tools/gen-command-funcs/*.go tools/gen-input-models/*.go

--- a/command/cli/cli_proxy_lb_gen.go
+++ b/command/cli/cli_proxy_lb_gen.go
@@ -2883,7 +2883,7 @@ func init() {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:  "mode",
-						Usage: "[Required] set bind mode[http/https]",
+						Usage: "[Required] set bind mode[http/https/tcp]",
 					},
 					&cli.IntFlag{
 						Name:  "port",
@@ -3320,7 +3320,7 @@ func init() {
 					},
 					&cli.StringFlag{
 						Name:  "mode",
-						Usage: "set bind mode[http/https]",
+						Usage: "set bind mode[http/https/tcp]",
 					},
 					&cli.IntFlag{
 						Name:  "port",

--- a/define/proxylb.go
+++ b/define/proxylb.go
@@ -15,6 +15,9 @@
 package define
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/output"
 	"github.com/sacloud/usacloud/schema"
@@ -594,7 +597,7 @@ func proxyLBBindPortAddParam() map[string]*schema.Schema {
 		"mode": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
-			Description:  "set bind mode[http/https]",
+			Description:  fmt.Sprintf("set bind mode[%s]", strings.Join(sacloud.AllowProxyLBBindModes, "/")),
 			Required:     true,
 			ValidateFunc: validateInStrValues(sacloud.AllowProxyLBBindModes...),
 			CompleteFunc: completeInStrValues(sacloud.AllowProxyLBBindModes...),
@@ -639,7 +642,7 @@ func proxyLBBindPortUpdateParam() map[string]*schema.Schema {
 		"mode": {
 			Type:         schema.TypeString,
 			HandlerType:  schema.HandlerNoop,
-			Description:  "set bind mode[http/https]",
+			Description:  fmt.Sprintf("set bind mode[%s]", strings.Join(sacloud.AllowProxyLBBindModes, "/")),
 			ValidateFunc: validateInStrValues(sacloud.AllowProxyLBBindModes...),
 			CompleteFunc: completeInStrValues(sacloud.AllowProxyLBBindModes...),
 			Category:     "bind-port",


### PR DESCRIPTION
fixes #471 

利用例:

```bash
$ usacloud proxylb bind-port-add --mode=tcp --port=8080 <id or name>
```