### PR TITLE
Fix validator - use sacloud.ID#IsEmpty for validate the conflistWith rule

### DIFF
--- a/command/functions.go
+++ b/command/functions.go
@@ -61,6 +61,10 @@ func IsEmpty(object interface{}) bool {
 		}
 	}
 
+	if id, ok := object.(sacloud.ID); ok {
+		return id.IsEmpty()
+	}
+
 	objValue := reflect.ValueOf(object)
 
 	switch objValue.Kind() {


### PR DESCRIPTION
followup #487 

オプション項目のバリデーション時にゼロ値であるかをusacloud/command.IsEmpty(v)で検証しているが、sacloud.ID型を正しく判定できていなかったためにconflictWithなどが正しく動作しなかった問題を修正。