### PR TITLE
Rename command alias from selector to select

### DIFF
--- a/cmdv2/commands/zz_archive_gen.go
+++ b/cmdv2/commands/zz_archive_gen.go
@@ -44,7 +44,7 @@ func archiveListCmd() *cobra.Command {
 	archiveListParam := params.NewListArchiveParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List Archive",
 		Long:         `List Archive`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_auto_backup_gen.go
+++ b/cmdv2/commands/zz_auto_backup_gen.go
@@ -44,7 +44,7 @@ func autoBackupListCmd() *cobra.Command {
 	autoBackupListParam := params.NewListAutoBackupParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List AutoBackup",
 		Long:         `List AutoBackup`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_database_gen.go
+++ b/cmdv2/commands/zz_database_gen.go
@@ -44,7 +44,7 @@ func databaseListCmd() *cobra.Command {
 	databaseListParam := params.NewListDatabaseParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List Database",
 		Long:         `List Database`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_disk_gen.go
+++ b/cmdv2/commands/zz_disk_gen.go
@@ -44,7 +44,7 @@ func diskListCmd() *cobra.Command {
 	diskListParam := params.NewListDiskParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List Disk",
 		Long:         `List Disk`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_dns_gen.go
+++ b/cmdv2/commands/zz_dns_gen.go
@@ -44,7 +44,7 @@ func dnsListCmd() *cobra.Command {
 	dnsListParam := params.NewListDNSParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List DNS",
 		Long:         `List DNS`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_gslb_gen.go
+++ b/cmdv2/commands/zz_gslb_gen.go
@@ -44,7 +44,7 @@ func gslbListCmd() *cobra.Command {
 	gslbListParam := params.NewListGSLBParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List GSLB",
 		Long:         `List GSLB`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_icon_gen.go
+++ b/cmdv2/commands/zz_icon_gen.go
@@ -44,7 +44,7 @@ func iconListCmd() *cobra.Command {
 	iconListParam := params.NewListIconParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List Icon",
 		Long:         `List Icon`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_internet_gen.go
+++ b/cmdv2/commands/zz_internet_gen.go
@@ -44,7 +44,7 @@ func internetListCmd() *cobra.Command {
 	internetListParam := params.NewListInternetParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List Internet",
 		Long:         `List Internet`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_iso_image_gen.go
+++ b/cmdv2/commands/zz_iso_image_gen.go
@@ -44,7 +44,7 @@ func isoImageListCmd() *cobra.Command {
 	isoImageListParam := params.NewListISOImageParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List ISOImage",
 		Long:         `List ISOImage`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_load_balancer_gen.go
+++ b/cmdv2/commands/zz_load_balancer_gen.go
@@ -44,7 +44,7 @@ func loadBalancerListCmd() *cobra.Command {
 	loadBalancerListParam := params.NewListLoadBalancerParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List LoadBalancer",
 		Long:         `List LoadBalancer`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_mobile_gateway_gen.go
+++ b/cmdv2/commands/zz_mobile_gateway_gen.go
@@ -44,7 +44,7 @@ func mobileGatewayListCmd() *cobra.Command {
 	mobileGatewayListParam := params.NewListMobileGatewayParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List MobileGateway",
 		Long:         `List MobileGateway`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_nfs_gen.go
+++ b/cmdv2/commands/zz_nfs_gen.go
@@ -44,7 +44,7 @@ func nfsListCmd() *cobra.Command {
 	nfsListParam := params.NewListNFSParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List NFS",
 		Long:         `List NFS`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_private_host_gen.go
+++ b/cmdv2/commands/zz_private_host_gen.go
@@ -44,7 +44,7 @@ func privateHostListCmd() *cobra.Command {
 	privateHostListParam := params.NewListPrivateHostParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List PrivateHost",
 		Long:         `List PrivateHost`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_proxy_lb_gen.go
+++ b/cmdv2/commands/zz_proxy_lb_gen.go
@@ -44,7 +44,7 @@ func proxyLBListCmd() *cobra.Command {
 	proxyLBListParam := params.NewListProxyLBParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List ProxyLB",
 		Long:         `List ProxyLB`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_server_gen.go
+++ b/cmdv2/commands/zz_server_gen.go
@@ -44,7 +44,7 @@ func serverListCmd() *cobra.Command {
 	serverListParam := params.NewListServerParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List Server",
 		Long:         `List Server`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_sim_gen.go
+++ b/cmdv2/commands/zz_sim_gen.go
@@ -44,7 +44,7 @@ func simListCmd() *cobra.Command {
 	simListParam := params.NewListSIMParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List SIM",
 		Long:         `List SIM`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_simple_monitor_gen.go
+++ b/cmdv2/commands/zz_simple_monitor_gen.go
@@ -44,7 +44,7 @@ func simpleMonitorListCmd() *cobra.Command {
 	simpleMonitorListParam := params.NewListSimpleMonitorParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List SimpleMonitor",
 		Long:         `List SimpleMonitor`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_startup_script_gen.go
+++ b/cmdv2/commands/zz_startup_script_gen.go
@@ -44,7 +44,7 @@ func startupScriptListCmd() *cobra.Command {
 	startupScriptListParam := params.NewListStartupScriptParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List StartupScript",
 		Long:         `List StartupScript`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_switch_gen.go
+++ b/cmdv2/commands/zz_switch_gen.go
@@ -44,7 +44,7 @@ func switchListCmd() *cobra.Command {
 	switchListParam := params.NewListSwitchParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List Switch",
 		Long:         `List Switch`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_vpc_router_gen.go
+++ b/cmdv2/commands/zz_vpc_router_gen.go
@@ -44,7 +44,7 @@ func vpcRouterListCmd() *cobra.Command {
 	vpcRouterListParam := params.NewListVPCRouterParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List VPCRouter",
 		Long:         `List VPCRouter`,
 		SilenceUsage: true,

--- a/cmdv2/commands/zz_web_accel_gen.go
+++ b/cmdv2/commands/zz_web_accel_gen.go
@@ -43,7 +43,7 @@ func webAccelListCmd() *cobra.Command {
 	webAccelListParam := params.NewListWebAccelParam()
 	cmd := &cobra.Command{
 		Use:          "list",
-		Aliases:      []string{"ls", "find", "selector"},
+		Aliases:      []string{"ls", "find", "select"},
 		Short:        "List WebAccel",
 		Long:         `List WebAccel`,
 		SilenceUsage: true,

--- a/command/cli/cli_archive_gen.go
+++ b/command/cli/cli_archive_gen.go
@@ -49,7 +49,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List Archive",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_auto_backup_gen.go
+++ b/command/cli/cli_auto_backup_gen.go
@@ -44,7 +44,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List AutoBackup",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_database_gen.go
+++ b/command/cli/cli_database_gen.go
@@ -66,7 +66,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List Database",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_disk_gen.go
+++ b/command/cli/cli_disk_gen.go
@@ -53,7 +53,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List Disk",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_dns_gen.go
+++ b/command/cli/cli_dns_gen.go
@@ -49,7 +49,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List DNS",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_gslb_gen.go
+++ b/command/cli/cli_gslb_gen.go
@@ -48,7 +48,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List GSLB",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_icon_gen.go
+++ b/command/cli/cli_icon_gen.go
@@ -44,7 +44,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List Icon",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_internet_gen.go
+++ b/command/cli/cli_internet_gen.go
@@ -53,7 +53,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List Internet",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_iso_image_gen.go
+++ b/command/cli/cli_iso_image_gen.go
@@ -48,7 +48,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List ISOImage",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_load_balancer_gen.go
+++ b/command/cli/cli_load_balancer_gen.go
@@ -59,7 +59,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List LoadBalancer",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_mobile_gateway_gen.go
+++ b/command/cli/cli_mobile_gateway_gen.go
@@ -73,7 +73,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List MobileGateway",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_nfs_gen.go
+++ b/command/cli/cli_nfs_gen.go
@@ -52,7 +52,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List NFS",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_private_host_gen.go
+++ b/command/cli/cli_private_host_gen.go
@@ -47,7 +47,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List PrivateHost",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_proxy_lb_gen.go
+++ b/command/cli/cli_proxy_lb_gen.go
@@ -66,7 +66,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List ProxyLB",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_server_gen.go
+++ b/command/cli/cli_server_gen.go
@@ -75,7 +75,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List Server",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_sim_gen.go
+++ b/command/cli/cli_sim_gen.go
@@ -54,7 +54,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List SIM",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_simple_monitor_gen.go
+++ b/command/cli/cli_simple_monitor_gen.go
@@ -45,7 +45,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List SimpleMonitor",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_startup_script_gen.go
+++ b/command/cli/cli_startup_script_gen.go
@@ -45,7 +45,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List StartupScript",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_switch_gen.go
+++ b/command/cli/cli_switch_gen.go
@@ -46,7 +46,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List Switch",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_vpc_router_gen.go
+++ b/command/cli/cli_vpc_router_gen.go
@@ -95,7 +95,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List VPCRouter",
 				Flags: []cli.Flag{
 					&cli.StringSliceFlag{

--- a/command/cli/cli_web_accel_gen.go
+++ b/command/cli/cli_web_accel_gen.go
@@ -45,7 +45,7 @@ func init() {
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",
-				Aliases: []string{"ls", "find", "selector"},
+				Aliases: []string{"ls", "find", "select"},
 				Usage:   "List WebAccel",
 				Flags: []cli.Flag{
 					&cli.StringFlag{

--- a/define/archive.go
+++ b/define/archive.go
@@ -24,7 +24,7 @@ func ArchiveResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             archiveListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: archiveListColumns(),

--- a/define/auto_backup.go
+++ b/define/auto_backup.go
@@ -25,7 +25,7 @@ func AutoBackupResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             autoBackupListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: autoBackupListColumns(),

--- a/define/database.go
+++ b/define/database.go
@@ -28,7 +28,7 @@ func DatabaseResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             databaseListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: databaseListColumns(),

--- a/define/disk.go
+++ b/define/disk.go
@@ -27,7 +27,7 @@ func DiskResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             diskListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: diskListColumns(),

--- a/define/dns.go
+++ b/define/dns.go
@@ -24,7 +24,7 @@ func DNSResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             dnsListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: dnsListColumns(),

--- a/define/gslb.go
+++ b/define/gslb.go
@@ -25,7 +25,7 @@ func GSLBResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             gslbListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: gslbListColumns(),

--- a/define/icon.go
+++ b/define/icon.go
@@ -27,7 +27,7 @@ func IconResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             iconListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: iconListColumns(),

--- a/define/internet.go
+++ b/define/internet.go
@@ -25,7 +25,7 @@ func InternetResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             internetListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: internetListColumns(),

--- a/define/iso_image.go
+++ b/define/iso_image.go
@@ -24,7 +24,7 @@ func ISOImageResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             isoImageListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: isoImageListColumns(),

--- a/define/load_balancer.go
+++ b/define/load_balancer.go
@@ -27,7 +27,7 @@ func LoadBalancerResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             loadBalancerListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: loadBalancerListColumns(),

--- a/define/mobile_gateway.go
+++ b/define/mobile_gateway.go
@@ -27,7 +27,7 @@ func MobileGatewayResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             mobileGatewayListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: mobileGatewayListColumns(),

--- a/define/nfs.go
+++ b/define/nfs.go
@@ -27,7 +27,7 @@ func NFSResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             nfsListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: nfsListColumns(),

--- a/define/private_host.go
+++ b/define/private_host.go
@@ -24,7 +24,7 @@ func PrivateHostResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             privateHostListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: privateHostListColumns(),

--- a/define/proxylb.go
+++ b/define/proxylb.go
@@ -28,7 +28,7 @@ func ProxyLBResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             proxyLBListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: proxyLBListColumns(),

--- a/define/server.go
+++ b/define/server.go
@@ -28,7 +28,7 @@ func ServerResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             serverListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: serverListColumns(),

--- a/define/sim.go
+++ b/define/sim.go
@@ -42,7 +42,7 @@ func SIMResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             simListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: simListColumns(),

--- a/define/simple_monitor.go
+++ b/define/simple_monitor.go
@@ -25,7 +25,7 @@ func SimpleMonitorResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             simpleMonitorListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: simpleMonitorListColumns(),

--- a/define/startup_script.go
+++ b/define/startup_script.go
@@ -25,7 +25,7 @@ func StartupScriptResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             startupScriptListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: startupScriptListColumns(),

--- a/define/switch.go
+++ b/define/switch.go
@@ -24,7 +24,7 @@ func SwitchResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             switchListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: switchListColumns(),

--- a/define/vpc_router.go
+++ b/define/vpc_router.go
@@ -28,7 +28,7 @@ func VPCRouterResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             vpcRouterListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: vpcRouterListColumns(),

--- a/define/webaccel.go
+++ b/define/webaccel.go
@@ -24,7 +24,7 @@ func WebAccelResource() *schema.Resource {
 	commands := map[string]*schema.Command{
 		"list": {
 			Type:               schema.CommandList,
-			Aliases:            []string{"ls", "find", "selector"},
+			Aliases:            []string{"ls", "find", "select"},
 			Params:             webAccelListParam(),
 			TableType:          output.TableSimple,
 			TableColumnDefines: webAccelListColumns(),


### PR DESCRIPTION
fixes #503 

各リソースの`list`コマンドのエイリアス`selector`を`select`にリネームする。

エイリアス`selector`は #171 により追加されたが、本来オプション項目のみの追加を意図したものであり、コマンドのエイリアスとして追加しているのは誤り。
もしコマンドのエイリアスとして追加するのであれば`select`のような動詞であることが望ましい。

このため、このPRで追加されてしまっていたエイリアス`selector`をリネームして対応する。