### PR TITLE
Supports default command

### DIFF
--- a/cmdv2/commands/usage.go
+++ b/cmdv2/commands/usage.go
@@ -69,6 +69,15 @@ func lookupCmd(cmd *cobra.Command, name string) *cobra.Command {
 	return nil
 }
 
+func runDefaultCmd(cmd *cobra.Command, args []string, commandName string) error {
+	defaultCmd := lookupCmd(cmd, commandName)
+	if defaultCmd == nil {
+		cmd.HelpFunc()(cmd, args)
+		return nil
+	}
+	return defaultCmd.RunE(defaultCmd, args)
+}
+
 const originalFlagsUsage = `Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}`
 

--- a/cmdv2/commands/zz_archive_gen.go
+++ b/cmdv2/commands/zz_archive_gen.go
@@ -34,8 +34,9 @@ func archiveCmd() *cobra.Command {
 		Use:   "archive",
 		Short: "A manage commands of Archive",
 		Long:  `A manage commands of Archive`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_auth_status_gen.go
+++ b/cmdv2/commands/zz_auth_status_gen.go
@@ -28,8 +28,8 @@ func authStatusCmd() *cobra.Command {
 		Use:   "auth-status",
 		Short: "A manage commands of AuthStatus",
 		Long:  `A manage commands of AuthStatus`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call show func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "show")
 		},
 	}
 }

--- a/cmdv2/commands/zz_auto_backup_gen.go
+++ b/cmdv2/commands/zz_auto_backup_gen.go
@@ -34,8 +34,9 @@ func autoBackupCmd() *cobra.Command {
 		Use:   "auto-backup",
 		Short: "A manage commands of AutoBackup",
 		Long:  `A manage commands of AutoBackup`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_bill_gen.go
+++ b/cmdv2/commands/zz_bill_gen.go
@@ -28,8 +28,8 @@ func billCmd() *cobra.Command {
 		Use:   "bill",
 		Short: "A manage commands of Bill",
 		Long:  `A manage commands of Bill`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_bridge_gen.go
+++ b/cmdv2/commands/zz_bridge_gen.go
@@ -34,8 +34,9 @@ func bridgeCmd() *cobra.Command {
 		Use:   "bridge",
 		Short: "A manage commands of Bridge",
 		Long:  `A manage commands of Bridge`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_config_gen.go
+++ b/cmdv2/commands/zz_config_gen.go
@@ -31,8 +31,8 @@ func configCmd() *cobra.Command {
 		Use:   "config",
 		Short: "A manage command of APIKey settings",
 		Long:  `A manage command of APIKey settings`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call edit func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "edit")
 		},
 	}
 }

--- a/cmdv2/commands/zz_coupon_gen.go
+++ b/cmdv2/commands/zz_coupon_gen.go
@@ -28,8 +28,8 @@ func couponCmd() *cobra.Command {
 		Use:   "coupon",
 		Short: "A manage commands of Coupon",
 		Long:  `A manage commands of Coupon`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_database_gen.go
+++ b/cmdv2/commands/zz_database_gen.go
@@ -34,8 +34,9 @@ func databaseCmd() *cobra.Command {
 		Use:   "database",
 		Short: "A manage commands of Database",
 		Long:  `A manage commands of Database`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_disk_gen.go
+++ b/cmdv2/commands/zz_disk_gen.go
@@ -34,8 +34,9 @@ func diskCmd() *cobra.Command {
 		Use:   "disk",
 		Short: "A manage commands of Disk",
 		Long:  `A manage commands of Disk`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_dns_gen.go
+++ b/cmdv2/commands/zz_dns_gen.go
@@ -34,8 +34,9 @@ func dnsCmd() *cobra.Command {
 		Use:   "dns",
 		Short: "A manage commands of DNS",
 		Long:  `A manage commands of DNS`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_gslb_gen.go
+++ b/cmdv2/commands/zz_gslb_gen.go
@@ -34,8 +34,9 @@ func gslbCmd() *cobra.Command {
 		Use:   "gslb",
 		Short: "A manage commands of GSLB",
 		Long:  `A manage commands of GSLB`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_icon_gen.go
+++ b/cmdv2/commands/zz_icon_gen.go
@@ -34,8 +34,9 @@ func iconCmd() *cobra.Command {
 		Use:   "icon",
 		Short: "A manage commands of Icon",
 		Long:  `A manage commands of Icon`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_interface_gen.go
+++ b/cmdv2/commands/zz_interface_gen.go
@@ -34,8 +34,9 @@ func interfaceCmd() *cobra.Command {
 		Use:   "interface",
 		Short: "A manage commands of Interface",
 		Long:  `A manage commands of Interface`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_internet_gen.go
+++ b/cmdv2/commands/zz_internet_gen.go
@@ -34,8 +34,9 @@ func internetCmd() *cobra.Command {
 		Use:   "internet",
 		Short: "A manage commands of Internet",
 		Long:  `A manage commands of Internet`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_ipv4_gen.go
+++ b/cmdv2/commands/zz_ipv4_gen.go
@@ -32,8 +32,9 @@ func ipv4Cmd() *cobra.Command {
 		Use:   "ipv4",
 		Short: "A manage commands of IPv4",
 		Long:  `A manage commands of IPv4`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_ipv6_gen.go
+++ b/cmdv2/commands/zz_ipv6_gen.go
@@ -32,8 +32,9 @@ func ipv6Cmd() *cobra.Command {
 		Use:   "ipv6",
 		Short: "A manage commands of IPv6",
 		Long:  `A manage commands of IPv6`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_iso_image_gen.go
+++ b/cmdv2/commands/zz_iso_image_gen.go
@@ -34,8 +34,9 @@ func isoImageCmd() *cobra.Command {
 		Use:   "iso-image",
 		Short: "A manage commands of ISOImage",
 		Long:  `A manage commands of ISOImage`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_license_gen.go
+++ b/cmdv2/commands/zz_license_gen.go
@@ -34,8 +34,9 @@ func licenseCmd() *cobra.Command {
 		Use:   "license",
 		Short: "A manage commands of License",
 		Long:  `A manage commands of License`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_load_balancer_gen.go
+++ b/cmdv2/commands/zz_load_balancer_gen.go
@@ -34,8 +34,9 @@ func loadBalancerCmd() *cobra.Command {
 		Use:   "load-balancer",
 		Short: "A manage commands of LoadBalancer",
 		Long:  `A manage commands of LoadBalancer`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_mobile_gateway_gen.go
+++ b/cmdv2/commands/zz_mobile_gateway_gen.go
@@ -34,8 +34,9 @@ func mobileGatewayCmd() *cobra.Command {
 		Use:   "mobile-gateway",
 		Short: "A manage commands of MobileGateway",
 		Long:  `A manage commands of MobileGateway`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_nfs_gen.go
+++ b/cmdv2/commands/zz_nfs_gen.go
@@ -34,8 +34,9 @@ func nfsCmd() *cobra.Command {
 		Use:   "nfs",
 		Short: "A manage commands of NFS",
 		Long:  `A manage commands of NFS`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_object_storage_gen.go
+++ b/cmdv2/commands/zz_object_storage_gen.go
@@ -31,8 +31,9 @@ func objectStorageCmd() *cobra.Command {
 		Use:   "object-storage",
 		Short: "A manage commands of ObjectStorage",
 		Long:  `A manage commands of ObjectStorage`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_packet_filter_gen.go
+++ b/cmdv2/commands/zz_packet_filter_gen.go
@@ -34,8 +34,9 @@ func packetFilterCmd() *cobra.Command {
 		Use:   "packet-filter",
 		Short: "A manage commands of PacketFilter",
 		Long:  `A manage commands of PacketFilter`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_price_gen.go
+++ b/cmdv2/commands/zz_price_gen.go
@@ -29,8 +29,8 @@ func priceCmd() *cobra.Command {
 		Use:   "price",
 		Short: "A manage commands of Price",
 		Long:  `A manage commands of Price`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_private_host_gen.go
+++ b/cmdv2/commands/zz_private_host_gen.go
@@ -34,8 +34,9 @@ func privateHostCmd() *cobra.Command {
 		Use:   "private-host",
 		Short: "A manage commands of PrivateHost",
 		Long:  `A manage commands of PrivateHost`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_product_disk_gen.go
+++ b/cmdv2/commands/zz_product_disk_gen.go
@@ -32,8 +32,8 @@ func productDiskCmd() *cobra.Command {
 		Use:   "product-disk",
 		Short: "A manage commands of ProductDisk",
 		Long:  `A manage commands of ProductDisk`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_product_internet_gen.go
+++ b/cmdv2/commands/zz_product_internet_gen.go
@@ -32,8 +32,8 @@ func productInternetCmd() *cobra.Command {
 		Use:   "product-internet",
 		Short: "A manage commands of ProductInternet",
 		Long:  `A manage commands of ProductInternet`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_product_license_gen.go
+++ b/cmdv2/commands/zz_product_license_gen.go
@@ -32,8 +32,8 @@ func productLicenseCmd() *cobra.Command {
 		Use:   "product-license",
 		Short: "A manage commands of ProductLicense",
 		Long:  `A manage commands of ProductLicense`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_product_server_gen.go
+++ b/cmdv2/commands/zz_product_server_gen.go
@@ -32,8 +32,8 @@ func productServerCmd() *cobra.Command {
 		Use:   "product-server",
 		Short: "A manage commands of ProductServer",
 		Long:  `A manage commands of ProductServer`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_proxy_lb_gen.go
+++ b/cmdv2/commands/zz_proxy_lb_gen.go
@@ -34,8 +34,9 @@ func proxyLBCmd() *cobra.Command {
 		Use:   "proxy-lb",
 		Short: "A manage commands of ProxyLB",
 		Long:  `A manage commands of ProxyLB`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_region_gen.go
+++ b/cmdv2/commands/zz_region_gen.go
@@ -32,8 +32,8 @@ func regionCmd() *cobra.Command {
 		Use:   "region",
 		Short: "A manage commands of Region",
 		Long:  `A manage commands of Region`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/cmdv2/commands/zz_self_gen.go
+++ b/cmdv2/commands/zz_self_gen.go
@@ -28,8 +28,8 @@ func selfCmd() *cobra.Command {
 		Use:   "self",
 		Short: "Show self info",
 		Long:  `Show self info`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call info func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "info")
 		},
 	}
 }

--- a/cmdv2/commands/zz_server_gen.go
+++ b/cmdv2/commands/zz_server_gen.go
@@ -34,8 +34,9 @@ func serverCmd() *cobra.Command {
 		Use:   "server",
 		Short: "A manage commands of Server",
 		Long:  `A manage commands of Server`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_sim_gen.go
+++ b/cmdv2/commands/zz_sim_gen.go
@@ -34,8 +34,9 @@ func simCmd() *cobra.Command {
 		Use:   "sim",
 		Short: "A manage commands of SIM",
 		Long:  `A manage commands of SIM`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_simple_monitor_gen.go
+++ b/cmdv2/commands/zz_simple_monitor_gen.go
@@ -34,8 +34,9 @@ func simpleMonitorCmd() *cobra.Command {
 		Use:   "simple-monitor",
 		Short: "A manage commands of SimpleMonitor",
 		Long:  `A manage commands of SimpleMonitor`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_ssh_key_gen.go
+++ b/cmdv2/commands/zz_ssh_key_gen.go
@@ -34,8 +34,9 @@ func sshKeyCmd() *cobra.Command {
 		Use:   "ssh-key",
 		Short: "A manage commands of SSHKey",
 		Long:  `A manage commands of SSHKey`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_startup_script_gen.go
+++ b/cmdv2/commands/zz_startup_script_gen.go
@@ -34,8 +34,9 @@ func startupScriptCmd() *cobra.Command {
 		Use:   "startup-script",
 		Short: "A manage commands of StartupScript",
 		Long:  `A manage commands of StartupScript`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_summary_gen.go
+++ b/cmdv2/commands/zz_summary_gen.go
@@ -28,8 +28,8 @@ func summaryCmd() *cobra.Command {
 		Use:   "summary",
 		Short: "Show summary of resource usage",
 		Long:  `Show summary of resource usage`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call show func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "show")
 		},
 	}
 }

--- a/cmdv2/commands/zz_switch_gen.go
+++ b/cmdv2/commands/zz_switch_gen.go
@@ -34,8 +34,9 @@ func switchCmd() *cobra.Command {
 		Use:   "switch",
 		Short: "A manage commands of Switch",
 		Long:  `A manage commands of Switch`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_vpc_router_gen.go
+++ b/cmdv2/commands/zz_vpc_router_gen.go
@@ -34,8 +34,9 @@ func vpcRouterCmd() *cobra.Command {
 		Use:   "vpc-router",
 		Short: "A manage commands of VPCRouter",
 		Long:  `A manage commands of VPCRouter`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_web_accel_gen.go
+++ b/cmdv2/commands/zz_web_accel_gen.go
@@ -33,8 +33,9 @@ func webAccelCmd() *cobra.Command {
 		Use:   "web-accel",
 		Short: "A manage commands of WebAccel",
 		Long:  `A manage commands of WebAccel`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 }

--- a/cmdv2/commands/zz_zone_gen.go
+++ b/cmdv2/commands/zz_zone_gen.go
@@ -32,8 +32,8 @@ func zoneCmd() *cobra.Command {
 		Use:   "zone",
 		Short: "A manage commands of Zone",
 		Long:  `A manage commands of Zone`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// TODO not implements: call list func as default
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDefaultCmd(cmd, args, "list")
 		},
 	}
 }

--- a/tools/gen-cli-v2-commands/main.go
+++ b/tools/gen-cli-v2-commands/main.go
@@ -87,8 +87,13 @@ func {{ .CLIVariableFuncName }}() *cobra.Command {
 		Use:   "{{ .CLIName }}",
 		Short: "{{ .Usage }}",
 		Long: ` + "`{{.Usage}}`" + `,
-		Run: func(cmd *cobra.Command, args []string) {
-			{{ if .DefaultCommand }}// TODO not implements: call {{.DefaultCommand}} func as default{{ else }}cmd.HelpFunc()(cmd,args){{ end }}
+		RunE: func(cmd *cobra.Command, args []string) error {
+		{{ if .DefaultCommand -}}
+			return runDefaultCmd(cmd, args, "{{.DefaultCommand}}")
+		{{ else -}}
+			cmd.HelpFunc()(cmd,args)
+			return nil
+		{{ end -}}
 		},
 	}
 }


### PR DESCRIPTION
fixes #504 

リソースレベルでのデフォルトコマンドを実装する。

コマンドは`usacloud <リソース名> <コマンド>`という形式となっているが、
一部の参照系コマンドにおいて`usacloud zone`のようにリソース名まで指定するだけであらかじめ定義されたデフォルトコマンドを実行するようにする。

ただし、v1時点ではデフォルトコマンドへのフラグ指定はサポートせず、単純なコマンドの実行のみサポートすることとする。

```bash
# リソースレベルのデフォルトコマンドの実行
$ usacloud auth-status

# 以下と同等となる(auth-statusの場合)
$ usacloud auth-status show

# 以下のようにフラグ指定はサポートしない
$ usacloud auth-status -o json
# フラグ指定する場合は以下のようにコマンドを省略せず指定する
$ usacloud auth-status show -o json
```