### PR TITLE
Copyright

### DIFF
--- a/cmdv2/commands/root_init_gen.go
+++ b/cmdv2/commands/root_init_gen.go
@@ -767,4 +767,5 @@ func init() {
 	}
 
 	buildCommandsUsage(rootCmd, rootCommandOrder(rootCmd))
+	rootCmd.SetUsageTemplate(rootCmd.UsageTemplate() + "\nCopyright 2017-2020 The Usacloud Authors\n")
 }

--- a/tools/gen-cli-v2-root-command/main.go
+++ b/tools/gen-cli-v2-root-command/main.go
@@ -100,5 +100,6 @@ func init() {
 	}
 	{{ end }}
 	buildCommandsUsage(rootCmd, rootCommandOrder(rootCmd))
+	rootCmd.SetUsageTemplate(rootCmd.UsageTemplate() + "\n{{.Copyright}}\n")
 }
 `

--- a/tools/generate_context.go
+++ b/tools/generate_context.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/sacloud/usacloud/version"
+
 	"github.com/sacloud/usacloud/define"
 	"github.com/sacloud/usacloud/schema"
 )
@@ -84,6 +86,10 @@ func (c *GenerateContext) buildCategorizedResources() {
 		}
 		return c.CategorizedResources[i].Order < c.CategorizedResources[j].Order
 	})
+}
+
+func (c *GenerateContext) Copyright() string {
+	return fmt.Sprintf("Copyright %s The Usacloud Authors", version.CopyrightYear)
 }
 
 func (c *GenerateContext) SetCurrentR(k string) {

--- a/version/version.go
+++ b/version/version.go
@@ -24,6 +24,9 @@ var (
 	Version = "0.0.0" // set on build time
 	// Revision git commit short commithash
 	Revision = "xxxxxx" // set on build time
+
+	// CopyrightYear .
+	CopyrightYear = "2017-2020"
 )
 
 // FullVersion return sackerel full version text


### PR DESCRIPTION
fixes #505

Copyrightをヘルプに表示する。
当初は全コマンドに対して表示するつもりだったが、実装が煩雑になることからトップレベルのヘルプのみ表示することにする。