### PR TITLE
Reduce scope of GlobalOption

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -24,24 +24,22 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-
-	"github.com/sacloud/libsacloud/api"
-
-	"github.com/spf13/pflag"
-
 	libsacloudv1 "github.com/sacloud/libsacloud"
+	"github.com/sacloud/libsacloud/api"
 	libsacloudv2 "github.com/sacloud/libsacloud/v2"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/fake"
 	"github.com/sacloud/libsacloud/v2/sacloud/trace"
 	"github.com/sacloud/libsacloud/v2/utils/builder"
 	"github.com/sacloud/libsacloud/v2/utils/setup"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/version"
+	"github.com/spf13/pflag"
 )
 
 type Context interface {
-	Option() *CLIOptions
+	Option() *flags.Flags
 	Output() output.Output
 	Client() sacloud.APICaller
 	Zone() string
@@ -60,7 +58,7 @@ type Context interface {
 
 type cliContext struct {
 	parentCtx     context.Context
-	option        *CLIOptions
+	option        *flags.Flags
 	output        output.Output
 	cliIO         IO
 	args          []string
@@ -84,13 +82,10 @@ func NewCLIContext(globalFlags *pflag.FlagSet, args []string, parameter interfac
 
 	io := newIO()
 
-	option, err := initCLIOptions(globalFlags, io)
+	option, err := flags.LoadFlags(globalFlags, io.Err())
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO あとでグローバル変数を消す
-	GlobalOption = option
 
 	return &cliContext{
 		parentCtx:     ctx,
@@ -106,7 +101,7 @@ func (c *cliContext) IO() IO {
 	return c.cliIO
 }
 
-func (c *cliContext) Option() *CLIOptions {
+func (c *cliContext) Option() *flags.Flags {
 	return c.option
 }
 

--- a/pkg/cli/validators.go
+++ b/pkg/cli/validators.go
@@ -130,9 +130,7 @@ func ValidateBetween(fieldName string, object interface{}, min int, max int) []e
 	return []error{}
 }
 
-func ValidateOutputOption(o output.Option) []error {
-
-	defaultOutputType := GlobalOption.DefaultOutputType
+func ValidateOutputOption(o output.Option, defaultOutputType string) []error {
 	outputType := o.GetOutputType()
 	columns := o.GetColumn()
 	format := o.GetFormat()

--- a/pkg/cli/validators_test.go
+++ b/pkg/cli/validators_test.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"testing"
 
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -298,15 +299,15 @@ func TestValidateOutputOption(t *testing.T) {
 	// do table-driven test
 	for _, expect := range expects {
 		// TODO グローバルオプションの扱いが確定したら修正する
-		GlobalOption = &CLIOptions{}
+		options := &flags.Flags{}
 		t.Run(expect.testName, func(t *testing.T) {
 			if expect.option.defaultOutputType == "" {
-				GlobalOption.DefaultOutputType = "table"
+				options.DefaultOutputType = "table"
 			} else {
-				GlobalOption.DefaultOutputType = expect.option.defaultOutputType
+				options.DefaultOutputType = expect.option.defaultOutputType
 			}
 
-			res := ValidateOutputOption(expect.option)
+			res := ValidateOutputOption(expect.option, options.DefaultOutputType)
 			assert.Equal(t, expect.expect, len(res) == 0)
 		})
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/sacloud/usacloud/pkg/cli"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -45,5 +45,5 @@ func init() {
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false
 
-	cli.InitGlobalFlags(globalFlags())
+	flags.InitGlobalFlags(globalFlags())
 }

--- a/pkg/cmd/zz_archive_gen.go
+++ b/pkg/cmd/zz_archive_gen.go
@@ -50,12 +50,12 @@ func archiveListCmd() *cobra.Command {
 		Short:        "List Archive",
 		Long:         `List Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveListParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -106,12 +106,12 @@ func archiveCreateCmd() *cobra.Command {
 		Short:        "Create Archive",
 		Long:         `Create Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -173,12 +173,12 @@ func archiveReadCmd() *cobra.Command {
 		Short:        "Read Archive",
 		Long:         `Read Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveReadParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -243,12 +243,12 @@ func archiveUpdateCmd() *cobra.Command {
 		Short:        "Update Archive",
 		Long:         `Update Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -329,12 +329,12 @@ func archiveDeleteCmd() *cobra.Command {
 		Short:        "Delete Archive",
 		Long:         `Delete Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -411,12 +411,12 @@ func archiveUploadCmd() *cobra.Command {
 		Short:        "Upload Archive",
 		Long:         `Upload Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveUploadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveUploadParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveUploadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -494,12 +494,12 @@ func archiveDownloadCmd() *cobra.Command {
 		Short:        "Download Archive",
 		Long:         `Download Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveDownloadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveDownloadParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveDownloadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -570,12 +570,12 @@ func archiveFTPOpenCmd() *cobra.Command {
 		Short:        "FTPOpen Archive",
 		Long:         `FTPOpen Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveFTPOpenParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveFTPOpenParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveFTPOpenParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -652,12 +652,12 @@ func archiveFTPCloseCmd() *cobra.Command {
 		Short:        "FTPClose Archive",
 		Long:         `FTPClose Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveFTPCloseParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveFTPCloseParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveFTPCloseParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -727,12 +727,12 @@ func archiveWaitForCopyCmd() *cobra.Command {
 		Short:        "WaitForCopy Archive",
 		Long:         `WaitForCopy Archive`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return archiveWaitForCopyParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, archiveWaitForCopyParam)
 			if err != nil {
+				return err
+			}
+			if err := archiveWaitForCopyParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_auth_status_gen.go
+++ b/pkg/cmd/zz_auth_status_gen.go
@@ -44,12 +44,12 @@ func authStatusShowCmd() *cobra.Command {
 		Short:        "Show AuthStatus (default)",
 		Long:         `Show AuthStatus (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return authStatusShowParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, authStatusShowParam)
 			if err != nil {
+				return err
+			}
+			if err := authStatusShowParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_auto_backup_gen.go
+++ b/pkg/cmd/zz_auto_backup_gen.go
@@ -50,12 +50,12 @@ func autoBackupListCmd() *cobra.Command {
 		Short:        "List AutoBackup",
 		Long:         `List AutoBackup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return autoBackupListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, autoBackupListParam)
 			if err != nil {
+				return err
+			}
+			if err := autoBackupListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func autoBackupCreateCmd() *cobra.Command {
 		Short:        "Create AutoBackup",
 		Long:         `Create AutoBackup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return autoBackupCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, autoBackupCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := autoBackupCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -169,12 +169,12 @@ func autoBackupReadCmd() *cobra.Command {
 		Short:        "Read AutoBackup",
 		Long:         `Read AutoBackup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return autoBackupReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, autoBackupReadParam)
 			if err != nil {
+				return err
+			}
+			if err := autoBackupReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -239,12 +239,12 @@ func autoBackupUpdateCmd() *cobra.Command {
 		Short:        "Update AutoBackup",
 		Long:         `Update AutoBackup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return autoBackupUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, autoBackupUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := autoBackupUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -327,12 +327,12 @@ func autoBackupDeleteCmd() *cobra.Command {
 		Short:        "Delete AutoBackup",
 		Long:         `Delete AutoBackup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return autoBackupDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, autoBackupDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := autoBackupDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_bill_gen.go
+++ b/pkg/cmd/zz_bill_gen.go
@@ -44,12 +44,12 @@ func billCsvCmd() *cobra.Command {
 		Short:        "Csv Bill",
 		Long:         `Csv Bill`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return billCsvParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, billCsvParam)
 			if err != nil {
+				return err
+			}
+			if err := billCsvParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -87,12 +87,12 @@ func billListCmd() *cobra.Command {
 		Short:        "List Bill (default)",
 		Long:         `List Bill (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return billListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, billListParam)
 			if err != nil {
+				return err
+			}
+			if err := billListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_bridge_gen.go
+++ b/pkg/cmd/zz_bridge_gen.go
@@ -50,12 +50,12 @@ func bridgeListCmd() *cobra.Command {
 		Short:        "List Bridge",
 		Long:         `List Bridge`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, bridgeListParam)
 			if err != nil {
+				return err
+			}
+			if err := bridgeListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -102,12 +102,12 @@ func bridgeCreateCmd() *cobra.Command {
 		Short:        "Create Bridge",
 		Long:         `Create Bridge`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, bridgeCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := bridgeCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -163,12 +163,12 @@ func bridgeReadCmd() *cobra.Command {
 		Short:        "Read Bridge",
 		Long:         `Read Bridge`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, bridgeReadParam)
 			if err != nil {
+				return err
+			}
+			if err := bridgeReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -232,12 +232,12 @@ func bridgeUpdateCmd() *cobra.Command {
 		Short:        "Update Bridge",
 		Long:         `Update Bridge`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, bridgeUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := bridgeUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -315,12 +315,12 @@ func bridgeDeleteCmd() *cobra.Command {
 		Short:        "Delete Bridge",
 		Long:         `Delete Bridge`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, bridgeDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := bridgeDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_config_gen.go
+++ b/pkg/cmd/zz_config_gen.go
@@ -47,12 +47,12 @@ func configCurrentCmd() *cobra.Command {
 		Short:        "Current Config",
 		Long:         `Current Config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return configCurrentParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, configCurrentParam)
 			if err != nil {
+				return err
+			}
+			if err := configCurrentParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -87,12 +87,12 @@ func configDeleteCmd() *cobra.Command {
 		Short:        "Delete Config",
 		Long:         `Delete Config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return configDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, configDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := configDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -139,12 +139,12 @@ func configEditCmd() *cobra.Command {
 		Short:        "Edit Config (default)",
 		Long:         `Edit Config (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return configEditParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, configEditParam)
 			if err != nil {
+				return err
+			}
+			if err := configEditParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -183,12 +183,12 @@ func configListCmd() *cobra.Command {
 		Short:        "List Config",
 		Long:         `List Config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return configListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, configListParam)
 			if err != nil {
+				return err
+			}
+			if err := configListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -223,12 +223,12 @@ func configMigrateCmd() *cobra.Command {
 		Short:        "Migrate Config",
 		Long:         `Migrate Config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return configMigrateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, configMigrateParam)
 			if err != nil {
+				return err
+			}
+			if err := configMigrateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -263,12 +263,12 @@ func configShowCmd() *cobra.Command {
 		Short:        "Show Config",
 		Long:         `Show Config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return configShowParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, configShowParam)
 			if err != nil {
+				return err
+			}
+			if err := configShowParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -303,12 +303,12 @@ func configUseCmd() *cobra.Command {
 		Short:        "Use Config",
 		Long:         `Use Config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return configUseParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, configUseParam)
 			if err != nil {
+				return err
+			}
+			if err := configUseParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_coupon_gen.go
+++ b/pkg/cmd/zz_coupon_gen.go
@@ -44,12 +44,12 @@ func couponListCmd() *cobra.Command {
 		Short:        "List Coupon (default)",
 		Long:         `List Coupon (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return couponListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, couponListParam)
 			if err != nil {
+				return err
+			}
+			if err := couponListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_database_gen.go
+++ b/pkg/cmd/zz_database_gen.go
@@ -50,12 +50,12 @@ func databaseListCmd() *cobra.Command {
 		Short:        "List Database",
 		Long:         `List Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseListParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func databaseCreateCmd() *cobra.Command {
 		Short:        "Create Database",
 		Long:         `Create Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -181,12 +181,12 @@ func databaseReadCmd() *cobra.Command {
 		Short:        "Read Database",
 		Long:         `Read Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseReadParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -251,12 +251,12 @@ func databaseUpdateCmd() *cobra.Command {
 		Short:        "Update Database",
 		Long:         `Update Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -346,12 +346,12 @@ func databaseDeleteCmd() *cobra.Command {
 		Short:        "Delete Database",
 		Long:         `Delete Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -429,12 +429,12 @@ func databaseBootCmd() *cobra.Command {
 		Short:        "Boot Database",
 		Long:         `Boot Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseBootParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -504,12 +504,12 @@ func databaseShutdownCmd() *cobra.Command {
 		Short:        "Shutdown Database",
 		Long:         `Shutdown Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseShutdownParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -579,12 +579,12 @@ func databaseShutdownForceCmd() *cobra.Command {
 		Short:        "ShutdownForce Database",
 		Long:         `ShutdownForce Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseShutdownForceParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -654,12 +654,12 @@ func databaseResetCmd() *cobra.Command {
 		Short:        "Reset Database",
 		Long:         `Reset Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseResetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseResetParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseResetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -729,12 +729,12 @@ func databaseWaitForBootCmd() *cobra.Command {
 		Short:        "Wait until boot is completed",
 		Long:         `Wait until boot is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseWaitForBootParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -792,12 +792,12 @@ func databaseWaitForDownCmd() *cobra.Command {
 		Short:        "Wait until shutdown is completed",
 		Long:         `Wait until shutdown is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseWaitForDownParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -855,12 +855,12 @@ func databaseBackupInfoCmd() *cobra.Command {
 		Short:        "Show information of backup",
 		Long:         `Show information of backup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseBackupInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseBackupInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseBackupInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -925,12 +925,12 @@ func databaseBackupCreateCmd() *cobra.Command {
 		Short:        "Make new database backup",
 		Long:         `Make new database backup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseBackupCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseBackupCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseBackupCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1006,12 +1006,12 @@ func databaseBackupRestoreCmd() *cobra.Command {
 		Short:        "Restore database from backup",
 		Long:         `Restore database from backup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseBackupRestoreParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseBackupRestoreParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseBackupRestoreParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1088,12 +1088,12 @@ func databaseBackupLockCmd() *cobra.Command {
 		Short:        "Lock backup",
 		Long:         `Lock backup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseBackupLockParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseBackupLockParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseBackupLockParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1170,12 +1170,12 @@ func databaseBackupUnlockCmd() *cobra.Command {
 		Short:        "Unlock backup",
 		Long:         `Unlock backup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseBackupUnlockParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseBackupUnlockParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseBackupUnlockParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1252,12 +1252,12 @@ func databaseBackupRemoveCmd() *cobra.Command {
 		Short:        "Remove backup",
 		Long:         `Remove backup`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseBackupRemoveParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseBackupRemoveParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseBackupRemoveParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1334,12 +1334,12 @@ func databaseCloneCmd() *cobra.Command {
 		Short:        "Create clone instance",
 		Long:         `Create clone instance`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseCloneParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseCloneParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseCloneParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1431,12 +1431,12 @@ func databaseReplicaCreateCmd() *cobra.Command {
 		Short:        "Create replication slave instance",
 		Long:         `Create replication slave instance`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseReplicaCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseReplicaCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseReplicaCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1520,12 +1520,12 @@ func databaseMonitorCPUCmd() *cobra.Command {
 		Short:        "Collect CPU monitor values",
 		Long:         `Collect CPU monitor values`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseMonitorCPUParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseMonitorCPUParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseMonitorCPUParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1593,12 +1593,12 @@ func databaseMonitorMemoryCmd() *cobra.Command {
 		Short:        "Collect memory monitor values",
 		Long:         `Collect memory monitor values`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseMonitorMemoryParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseMonitorMemoryParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseMonitorMemoryParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1666,12 +1666,12 @@ func databaseMonitorNicCmd() *cobra.Command {
 		Short:        "Collect NIC(s) monitor values",
 		Long:         `Collect NIC(s) monitor values`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseMonitorNicParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseMonitorNicParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseMonitorNicParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1739,12 +1739,12 @@ func databaseMonitorSystemDiskCmd() *cobra.Command {
 		Short:        "Collect system-disk monitor values(IO)",
 		Long:         `Collect system-disk monitor values(IO)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseMonitorSystemDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseMonitorSystemDiskParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseMonitorSystemDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1812,12 +1812,12 @@ func databaseMonitorBackupDiskCmd() *cobra.Command {
 		Short:        "Collect backup-disk monitor values(IO)",
 		Long:         `Collect backup-disk monitor values(IO)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseMonitorBackupDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseMonitorBackupDiskParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseMonitorBackupDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1885,12 +1885,12 @@ func databaseMonitorSystemDiskSizeCmd() *cobra.Command {
 		Short:        "Collect system-disk monitor values(usage)",
 		Long:         `Collect system-disk monitor values(usage)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseMonitorSystemDiskSizeParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseMonitorSystemDiskSizeParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseMonitorSystemDiskSizeParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1958,12 +1958,12 @@ func databaseMonitorBackupDiskSizeCmd() *cobra.Command {
 		Short:        "Collect backup-disk monitor values(usage)",
 		Long:         `Collect backup-disk monitor values(usage)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseMonitorBackupDiskSizeParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseMonitorBackupDiskSizeParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseMonitorBackupDiskSizeParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2031,12 +2031,12 @@ func databaseLogsCmd() *cobra.Command {
 		Short:        "Logs Database",
 		Long:         `Logs Database`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return databaseLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, databaseLogsParam)
 			if err != nil {
+				return err
+			}
+			if err := databaseLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_disk_gen.go
+++ b/pkg/cmd/zz_disk_gen.go
@@ -50,12 +50,12 @@ func diskListCmd() *cobra.Command {
 		Short:        "List Disk",
 		Long:         `List Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskListParam)
 			if err != nil {
+				return err
+			}
+			if err := diskListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -107,12 +107,12 @@ func diskCreateCmd() *cobra.Command {
 		Short:        "Create Disk",
 		Long:         `Create Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := diskCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -176,12 +176,12 @@ func diskReadCmd() *cobra.Command {
 		Short:        "Read Disk",
 		Long:         `Read Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskReadParam)
 			if err != nil {
+				return err
+			}
+			if err := diskReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -246,12 +246,12 @@ func diskUpdateCmd() *cobra.Command {
 		Short:        "Update Disk",
 		Long:         `Update Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := diskUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -333,12 +333,12 @@ func diskDeleteCmd() *cobra.Command {
 		Short:        "Delete Disk",
 		Long:         `Delete Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := diskDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -415,12 +415,12 @@ func diskEditCmd() *cobra.Command {
 		Short:        "Edit Disk",
 		Long:         `Edit Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskEditParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskEditParam)
 			if err != nil {
+				return err
+			}
+			if err := diskEditParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -505,12 +505,12 @@ func diskResizePartitionCmd() *cobra.Command {
 		Short:        "ResizePartition Disk",
 		Long:         `ResizePartition Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskResizePartitionParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskResizePartitionParam)
 			if err != nil {
+				return err
+			}
+			if err := diskResizePartitionParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -587,12 +587,12 @@ func diskReinstallFromArchiveCmd() *cobra.Command {
 		Short:        "ReinstallFromArchive Disk",
 		Long:         `ReinstallFromArchive Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskReinstallFromArchiveParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskReinstallFromArchiveParam)
 			if err != nil {
+				return err
+			}
+			if err := diskReinstallFromArchiveParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -664,12 +664,12 @@ func diskReinstallFromDiskCmd() *cobra.Command {
 		Short:        "ReinstallFromDisk Disk",
 		Long:         `ReinstallFromDisk Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskReinstallFromDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskReinstallFromDiskParam)
 			if err != nil {
+				return err
+			}
+			if err := diskReinstallFromDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -741,12 +741,12 @@ func diskReinstallToBlankCmd() *cobra.Command {
 		Short:        "ReinstallToBlank Disk",
 		Long:         `ReinstallToBlank Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskReinstallToBlankParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskReinstallToBlankParam)
 			if err != nil {
+				return err
+			}
+			if err := diskReinstallToBlankParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -817,12 +817,12 @@ func diskServerConnectCmd() *cobra.Command {
 		Short:        "ServerConnect Disk",
 		Long:         `ServerConnect Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskServerConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskServerConnectParam)
 			if err != nil {
+				return err
+			}
+			if err := diskServerConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -893,12 +893,12 @@ func diskServerDisconnectCmd() *cobra.Command {
 		Short:        "ServerDisconnect Disk",
 		Long:         `ServerDisconnect Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskServerDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskServerDisconnectParam)
 			if err != nil {
+				return err
+			}
+			if err := diskServerDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -968,12 +968,12 @@ func diskMonitorCmd() *cobra.Command {
 		Short:        "Monitor Disk",
 		Long:         `Monitor Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskMonitorParam)
 			if err != nil {
+				return err
+			}
+			if err := diskMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1041,12 +1041,12 @@ func diskWaitForCopyCmd() *cobra.Command {
 		Short:        "WaitForCopy Disk",
 		Long:         `WaitForCopy Disk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return diskWaitForCopyParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, diskWaitForCopyParam)
 			if err != nil {
+				return err
+			}
+			if err := diskWaitForCopyParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_dns_gen.go
+++ b/pkg/cmd/zz_dns_gen.go
@@ -50,12 +50,12 @@ func dnsListCmd() *cobra.Command {
 		Short:        "List DNS",
 		Long:         `List DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsListParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func dnsRecordInfoCmd() *cobra.Command {
 		Short:        "RecordInfo DNS",
 		Long:         `RecordInfo DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsRecordInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsRecordInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsRecordInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -175,12 +175,12 @@ func dnsRecordBulkUpdateCmd() *cobra.Command {
 		Short:        "RecordBulkUpdate DNS",
 		Long:         `RecordBulkUpdate DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsRecordBulkUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsRecordBulkUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsRecordBulkUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -259,12 +259,12 @@ func dnsCreateCmd() *cobra.Command {
 		Short:        "Create DNS",
 		Long:         `Create DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -322,12 +322,12 @@ func dnsRecordAddCmd() *cobra.Command {
 		Short:        "RecordAdd DNS",
 		Long:         `RecordAdd DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsRecordAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsRecordAddParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsRecordAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -413,12 +413,12 @@ func dnsReadCmd() *cobra.Command {
 		Short:        "Read DNS",
 		Long:         `Read DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsReadParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -483,12 +483,12 @@ func dnsRecordUpdateCmd() *cobra.Command {
 		Short:        "RecordUpdate DNS",
 		Long:         `RecordUpdate DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsRecordUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsRecordUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsRecordUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -575,12 +575,12 @@ func dnsRecordDeleteCmd() *cobra.Command {
 		Short:        "RecordDelete DNS",
 		Long:         `RecordDelete DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsRecordDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsRecordDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsRecordDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -658,12 +658,12 @@ func dnsUpdateCmd() *cobra.Command {
 		Short:        "Update DNS",
 		Long:         `Update DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -743,12 +743,12 @@ func dnsDeleteCmd() *cobra.Command {
 		Short:        "Delete DNS",
 		Long:         `Delete DNS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return dnsDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, dnsDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := dnsDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_gslb_gen.go
+++ b/pkg/cmd/zz_gslb_gen.go
@@ -50,12 +50,12 @@ func gslbListCmd() *cobra.Command {
 		Short:        "List GSLB",
 		Long:         `List GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbListParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func gslbServerInfoCmd() *cobra.Command {
 		Short:        "ServerInfo GSLB",
 		Long:         `ServerInfo GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbServerInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -173,12 +173,12 @@ func gslbCreateCmd() *cobra.Command {
 		Short:        "Create GSLB",
 		Long:         `Create GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -244,12 +244,12 @@ func gslbServerAddCmd() *cobra.Command {
 		Short:        "ServerAdd GSLB",
 		Long:         `ServerAdd GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbServerAddParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -329,12 +329,12 @@ func gslbReadCmd() *cobra.Command {
 		Short:        "Read GSLB",
 		Long:         `Read GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbReadParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -399,12 +399,12 @@ func gslbServerUpdateCmd() *cobra.Command {
 		Short:        "ServerUpdate GSLB",
 		Long:         `ServerUpdate GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbServerUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -485,12 +485,12 @@ func gslbServerDeleteCmd() *cobra.Command {
 		Short:        "ServerDelete GSLB",
 		Long:         `ServerDelete GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbServerDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -568,12 +568,12 @@ func gslbUpdateCmd() *cobra.Command {
 		Short:        "Update GSLB",
 		Long:         `Update GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -662,12 +662,12 @@ func gslbDeleteCmd() *cobra.Command {
 		Short:        "Delete GSLB",
 		Long:         `Delete GSLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return gslbDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, gslbDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := gslbDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_icon_gen.go
+++ b/pkg/cmd/zz_icon_gen.go
@@ -50,12 +50,12 @@ func iconListCmd() *cobra.Command {
 		Short:        "List Icon",
 		Long:         `List Icon`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return iconListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, iconListParam)
 			if err != nil {
+				return err
+			}
+			if err := iconListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -104,12 +104,12 @@ func iconCreateCmd() *cobra.Command {
 		Short:        "Create Icon",
 		Long:         `Create Icon`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return iconCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, iconCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := iconCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -166,12 +166,12 @@ func iconReadCmd() *cobra.Command {
 		Short:        "Read Icon",
 		Long:         `Read Icon`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return iconReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, iconReadParam)
 			if err != nil {
+				return err
+			}
+			if err := iconReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -236,12 +236,12 @@ func iconUpdateCmd() *cobra.Command {
 		Short:        "Update Icon",
 		Long:         `Update Icon`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return iconUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, iconUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := iconUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -320,12 +320,12 @@ func iconDeleteCmd() *cobra.Command {
 		Short:        "Delete Icon",
 		Long:         `Delete Icon`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return iconDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, iconDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := iconDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_interface_gen.go
+++ b/pkg/cmd/zz_interface_gen.go
@@ -50,12 +50,12 @@ func interfaceListCmd() *cobra.Command {
 		Short:        "List Interface",
 		Long:         `List Interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return interfaceListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, interfaceListParam)
 			if err != nil {
+				return err
+			}
+			if err := interfaceListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -102,12 +102,12 @@ func interfacePacketFilterConnectCmd() *cobra.Command {
 		Short:        "PacketFilterConnect Interface",
 		Long:         `PacketFilterConnect Interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return interfacePacketFilterConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, interfacePacketFilterConnectParam)
 			if err != nil {
+				return err
+			}
+			if err := interfacePacketFilterConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -177,12 +177,12 @@ func interfaceCreateCmd() *cobra.Command {
 		Short:        "Create Interface",
 		Long:         `Create Interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return interfaceCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, interfaceCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := interfaceCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -237,12 +237,12 @@ func interfacePacketFilterDisconnectCmd() *cobra.Command {
 		Short:        "PacketFilterDisconnect Interface",
 		Long:         `PacketFilterDisconnect Interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return interfacePacketFilterDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, interfacePacketFilterDisconnectParam)
 			if err != nil {
+				return err
+			}
+			if err := interfacePacketFilterDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -312,12 +312,12 @@ func interfaceReadCmd() *cobra.Command {
 		Short:        "Read Interface",
 		Long:         `Read Interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return interfaceReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, interfaceReadParam)
 			if err != nil {
+				return err
+			}
+			if err := interfaceReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -381,12 +381,12 @@ func interfaceUpdateCmd() *cobra.Command {
 		Short:        "Update Interface",
 		Long:         `Update Interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return interfaceUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, interfaceUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := interfaceUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -463,12 +463,12 @@ func interfaceDeleteCmd() *cobra.Command {
 		Short:        "Delete Interface",
 		Long:         `Delete Interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return interfaceDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, interfaceDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := interfaceDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_internet_gen.go
+++ b/pkg/cmd/zz_internet_gen.go
@@ -50,12 +50,12 @@ func internetListCmd() *cobra.Command {
 		Short:        "List Internet",
 		Long:         `List Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetListParam)
 			if err != nil {
+				return err
+			}
+			if err := internetListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func internetCreateCmd() *cobra.Command {
 		Short:        "Create Internet",
 		Long:         `Create Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := internetCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -168,12 +168,12 @@ func internetReadCmd() *cobra.Command {
 		Short:        "Read Internet",
 		Long:         `Read Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetReadParam)
 			if err != nil {
+				return err
+			}
+			if err := internetReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -238,12 +238,12 @@ func internetUpdateCmd() *cobra.Command {
 		Short:        "Update Internet",
 		Long:         `Update Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := internetUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -325,12 +325,12 @@ func internetDeleteCmd() *cobra.Command {
 		Short:        "Delete Internet",
 		Long:         `Delete Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := internetDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -407,12 +407,12 @@ func internetUpdateBandwidthCmd() *cobra.Command {
 		Short:        "UpdateBandwidth Internet",
 		Long:         `UpdateBandwidth Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetUpdateBandwidthParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetUpdateBandwidthParam)
 			if err != nil {
+				return err
+			}
+			if err := internetUpdateBandwidthParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -490,12 +490,12 @@ func internetSubnetInfoCmd() *cobra.Command {
 		Short:        "SubnetInfo Internet",
 		Long:         `SubnetInfo Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetSubnetInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetSubnetInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := internetSubnetInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -560,12 +560,12 @@ func internetSubnetAddCmd() *cobra.Command {
 		Short:        "SubnetAdd Internet",
 		Long:         `SubnetAdd Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetSubnetAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetSubnetAddParam)
 			if err != nil {
+				return err
+			}
+			if err := internetSubnetAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -644,12 +644,12 @@ func internetSubnetDeleteCmd() *cobra.Command {
 		Short:        "SubnetDelete Internet",
 		Long:         `SubnetDelete Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetSubnetDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetSubnetDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := internetSubnetDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -720,12 +720,12 @@ func internetSubnetUpdateCmd() *cobra.Command {
 		Short:        "SubnetUpdate Internet",
 		Long:         `SubnetUpdate Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetSubnetUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetSubnetUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := internetSubnetUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -804,12 +804,12 @@ func internetIPv6InfoCmd() *cobra.Command {
 		Short:        "IPv6Info Internet",
 		Long:         `IPv6Info Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetIPv6InfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetIPv6InfoParam)
 			if err != nil {
+				return err
+			}
+			if err := internetIPv6InfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -874,12 +874,12 @@ func internetIPv6EnableCmd() *cobra.Command {
 		Short:        "IPv6Enable Internet",
 		Long:         `IPv6Enable Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetIPv6EnableParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetIPv6EnableParam)
 			if err != nil {
+				return err
+			}
+			if err := internetIPv6EnableParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -956,12 +956,12 @@ func internetIPv6DisableCmd() *cobra.Command {
 		Short:        "IPv6Disable Internet",
 		Long:         `IPv6Disable Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetIPv6DisableParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetIPv6DisableParam)
 			if err != nil {
+				return err
+			}
+			if err := internetIPv6DisableParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1031,12 +1031,12 @@ func internetMonitorCmd() *cobra.Command {
 		Short:        "Monitor Internet",
 		Long:         `Monitor Internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return internetMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, internetMonitorParam)
 			if err != nil {
+				return err
+			}
+			if err := internetMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_ipv4_gen.go
+++ b/pkg/cmd/zz_ipv4_gen.go
@@ -49,12 +49,12 @@ func ipv4ListCmd() *cobra.Command {
 		Short:        "List IPv4",
 		Long:         `List IPv4`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv4ListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv4ListParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv4ListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -101,12 +101,12 @@ func ipv4PtrAddCmd() *cobra.Command {
 		Short:        "PtrAdd IPv4",
 		Long:         `PtrAdd IPv4`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv4PtrAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv4PtrAddParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv4PtrAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -161,12 +161,12 @@ func ipv4PtrReadCmd() *cobra.Command {
 		Short:        "PtrRead IPv4",
 		Long:         `PtrRead IPv4`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv4PtrReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv4PtrReadParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv4PtrReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -208,12 +208,12 @@ func ipv4PtrUpdateCmd() *cobra.Command {
 		Short:        "PtrUpdate IPv4",
 		Long:         `PtrUpdate IPv4`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv4PtrUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv4PtrUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv4PtrUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -268,12 +268,12 @@ func ipv4PtrDeleteCmd() *cobra.Command {
 		Short:        "PtrDelete IPv4",
 		Long:         `PtrDelete IPv4`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv4PtrDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv4PtrDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv4PtrDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_ipv6_gen.go
+++ b/pkg/cmd/zz_ipv6_gen.go
@@ -49,12 +49,12 @@ func ipv6ListCmd() *cobra.Command {
 		Short:        "List IPv6",
 		Long:         `List IPv6`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv6ListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv6ListParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv6ListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func ipv6PtrAddCmd() *cobra.Command {
 		Short:        "PtrAdd IPv6",
 		Long:         `PtrAdd IPv6`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv6PtrAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv6PtrAddParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv6PtrAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -163,12 +163,12 @@ func ipv6PtrReadCmd() *cobra.Command {
 		Short:        "PtrRead IPv6",
 		Long:         `PtrRead IPv6`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv6PtrReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv6PtrReadParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv6PtrReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -210,12 +210,12 @@ func ipv6PtrUpdateCmd() *cobra.Command {
 		Short:        "PtrUpdate IPv6",
 		Long:         `PtrUpdate IPv6`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv6PtrUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv6PtrUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv6PtrUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -270,12 +270,12 @@ func ipv6PtrDeleteCmd() *cobra.Command {
 		Short:        "PtrDelete IPv6",
 		Long:         `PtrDelete IPv6`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ipv6PtrDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, ipv6PtrDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := ipv6PtrDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_iso_image_gen.go
+++ b/pkg/cmd/zz_iso_image_gen.go
@@ -50,12 +50,12 @@ func isoImageListCmd() *cobra.Command {
 		Short:        "List ISOImage",
 		Long:         `List ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageListParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -104,12 +104,12 @@ func isoImageCreateCmd() *cobra.Command {
 		Short:        "Create ISOImage",
 		Long:         `Create ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -169,12 +169,12 @@ func isoImageReadCmd() *cobra.Command {
 		Short:        "Read ISOImage",
 		Long:         `Read ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageReadParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -239,12 +239,12 @@ func isoImageUpdateCmd() *cobra.Command {
 		Short:        "Update ISOImage",
 		Long:         `Update ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -325,12 +325,12 @@ func isoImageDeleteCmd() *cobra.Command {
 		Short:        "Delete ISOImage",
 		Long:         `Delete ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -407,12 +407,12 @@ func isoImageUploadCmd() *cobra.Command {
 		Short:        "Upload ISOImage",
 		Long:         `Upload ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageUploadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageUploadParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageUploadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -490,12 +490,12 @@ func isoImageDownloadCmd() *cobra.Command {
 		Short:        "Download ISOImage",
 		Long:         `Download ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageDownloadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageDownloadParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageDownloadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -566,12 +566,12 @@ func isoImageFTPOpenCmd() *cobra.Command {
 		Short:        "FTPOpen ISOImage",
 		Long:         `FTPOpen ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageFTPOpenParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageFTPOpenParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageFTPOpenParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -648,12 +648,12 @@ func isoImageFTPCloseCmd() *cobra.Command {
 		Short:        "FTPClose ISOImage",
 		Long:         `FTPClose ISOImage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return isoImageFTPCloseParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, isoImageFTPCloseParam)
 			if err != nil {
+				return err
+			}
+			if err := isoImageFTPCloseParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_license_gen.go
+++ b/pkg/cmd/zz_license_gen.go
@@ -50,12 +50,12 @@ func licenseListCmd() *cobra.Command {
 		Short:        "List License",
 		Long:         `List License`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return licenseListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, licenseListParam)
 			if err != nil {
+				return err
+			}
+			if err := licenseListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -102,12 +102,12 @@ func licenseCreateCmd() *cobra.Command {
 		Short:        "Create License",
 		Long:         `Create License`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return licenseCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, licenseCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := licenseCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -163,12 +163,12 @@ func licenseReadCmd() *cobra.Command {
 		Short:        "Read License",
 		Long:         `Read License`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return licenseReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, licenseReadParam)
 			if err != nil {
+				return err
+			}
+			if err := licenseReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -232,12 +232,12 @@ func licenseUpdateCmd() *cobra.Command {
 		Short:        "Update License",
 		Long:         `Update License`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return licenseUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, licenseUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := licenseUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -314,12 +314,12 @@ func licenseDeleteCmd() *cobra.Command {
 		Short:        "Delete License",
 		Long:         `Delete License`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return licenseDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, licenseDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := licenseDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_load_balancer_gen.go
+++ b/pkg/cmd/zz_load_balancer_gen.go
@@ -50,12 +50,12 @@ func loadBalancerListCmd() *cobra.Command {
 		Short:        "List LoadBalancer",
 		Long:         `List LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerListParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func loadBalancerCreateCmd() *cobra.Command {
 		Short:        "Create LoadBalancer",
 		Long:         `Create LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -174,12 +174,12 @@ func loadBalancerReadCmd() *cobra.Command {
 		Short:        "Read LoadBalancer",
 		Long:         `Read LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerReadParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -244,12 +244,12 @@ func loadBalancerUpdateCmd() *cobra.Command {
 		Short:        "Update LoadBalancer",
 		Long:         `Update LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -330,12 +330,12 @@ func loadBalancerDeleteCmd() *cobra.Command {
 		Short:        "Delete LoadBalancer",
 		Long:         `Delete LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -413,12 +413,12 @@ func loadBalancerBootCmd() *cobra.Command {
 		Short:        "Boot LoadBalancer",
 		Long:         `Boot LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerBootParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -488,12 +488,12 @@ func loadBalancerShutdownCmd() *cobra.Command {
 		Short:        "Shutdown LoadBalancer",
 		Long:         `Shutdown LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerShutdownParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -563,12 +563,12 @@ func loadBalancerShutdownForceCmd() *cobra.Command {
 		Short:        "ShutdownForce LoadBalancer",
 		Long:         `ShutdownForce LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerShutdownForceParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -638,12 +638,12 @@ func loadBalancerResetCmd() *cobra.Command {
 		Short:        "Reset LoadBalancer",
 		Long:         `Reset LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerResetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerResetParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerResetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -713,12 +713,12 @@ func loadBalancerWaitForBootCmd() *cobra.Command {
 		Short:        "Wait until boot is completed",
 		Long:         `Wait until boot is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerWaitForBootParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -776,12 +776,12 @@ func loadBalancerWaitForDownCmd() *cobra.Command {
 		Short:        "Wait until shutdown is completed",
 		Long:         `Wait until shutdown is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerWaitForDownParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -839,12 +839,12 @@ func loadBalancerVipInfoCmd() *cobra.Command {
 		Short:        "Show information of VIP(s)",
 		Long:         `Show information of VIP(s)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerVipInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerVipInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerVipInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -909,12 +909,12 @@ func loadBalancerVipAddCmd() *cobra.Command {
 		Short:        "Add VIP to LoadBalancer",
 		Long:         `Add VIP to LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerVipAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerVipAddParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerVipAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -989,12 +989,12 @@ func loadBalancerVipUpdateCmd() *cobra.Command {
 		Short:        "Update VIP",
 		Long:         `Update VIP`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerVipUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerVipUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerVipUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1070,12 +1070,12 @@ func loadBalancerVipDeleteCmd() *cobra.Command {
 		Short:        "Delete VIP from LoadBalancer",
 		Long:         `Delete VIP from LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerVipDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerVipDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerVipDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1146,12 +1146,12 @@ func loadBalancerServerInfoCmd() *cobra.Command {
 		Short:        "Show servers under VIP(s)",
 		Long:         `Show servers under VIP(s)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerServerInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1219,12 +1219,12 @@ func loadBalancerServerAddCmd() *cobra.Command {
 		Short:        "Add server under VIP(s)",
 		Long:         `Add server under VIP(s)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerServerAddParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1302,12 +1302,12 @@ func loadBalancerServerUpdateCmd() *cobra.Command {
 		Short:        "Update server under VIP(s)",
 		Long:         `Update server under VIP(s)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerServerUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1385,12 +1385,12 @@ func loadBalancerServerDeleteCmd() *cobra.Command {
 		Short:        "Delete server under VIP(s)",
 		Long:         `Delete server under VIP(s)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerServerDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1464,12 +1464,12 @@ func loadBalancerMonitorCmd() *cobra.Command {
 		Short:        "Monitor LoadBalancer",
 		Long:         `Monitor LoadBalancer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return loadBalancerMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, loadBalancerMonitorParam)
 			if err != nil {
+				return err
+			}
+			if err := loadBalancerMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_mobile_gateway_gen.go
+++ b/pkg/cmd/zz_mobile_gateway_gen.go
@@ -50,12 +50,12 @@ func mobileGatewayListCmd() *cobra.Command {
 		Short:        "List MobileGateway",
 		Long:         `List MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayListParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func mobileGatewayCreateCmd() *cobra.Command {
 		Short:        "Create MobileGateway",
 		Long:         `Create MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -167,12 +167,12 @@ func mobileGatewayReadCmd() *cobra.Command {
 		Short:        "Read MobileGateway",
 		Long:         `Read MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayReadParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -237,12 +237,12 @@ func mobileGatewayUpdateCmd() *cobra.Command {
 		Short:        "Update MobileGateway",
 		Long:         `Update MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -324,12 +324,12 @@ func mobileGatewayDeleteCmd() *cobra.Command {
 		Short:        "Delete MobileGateway",
 		Long:         `Delete MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -407,12 +407,12 @@ func mobileGatewayBootCmd() *cobra.Command {
 		Short:        "Boot MobileGateway",
 		Long:         `Boot MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayBootParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -482,12 +482,12 @@ func mobileGatewayShutdownCmd() *cobra.Command {
 		Short:        "Shutdown MobileGateway",
 		Long:         `Shutdown MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayShutdownParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -557,12 +557,12 @@ func mobileGatewayShutdownForceCmd() *cobra.Command {
 		Short:        "ShutdownForce MobileGateway",
 		Long:         `ShutdownForce MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayShutdownForceParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -632,12 +632,12 @@ func mobileGatewayResetCmd() *cobra.Command {
 		Short:        "Reset MobileGateway",
 		Long:         `Reset MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayResetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayResetParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayResetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -707,12 +707,12 @@ func mobileGatewayWaitForBootCmd() *cobra.Command {
 		Short:        "Wait until boot is completed",
 		Long:         `Wait until boot is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayWaitForBootParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -770,12 +770,12 @@ func mobileGatewayWaitForDownCmd() *cobra.Command {
 		Short:        "Wait until shutdown is completed",
 		Long:         `Wait until shutdown is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayWaitForDownParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -833,12 +833,12 @@ func mobileGatewayInterfaceInfoCmd() *cobra.Command {
 		Short:        "Show information of NIC(s) connected to mobile-gateway",
 		Long:         `Show information of NIC(s) connected to mobile-gateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayInterfaceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayInterfaceInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayInterfaceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -903,12 +903,12 @@ func mobileGatewayInterfaceConnectCmd() *cobra.Command {
 		Short:        "Connected to switch",
 		Long:         `Connected to switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayInterfaceConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayInterfaceConnectParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayInterfaceConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -981,12 +981,12 @@ func mobileGatewayInterfaceUpdateCmd() *cobra.Command {
 		Short:        "Update interface",
 		Long:         `Update interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayInterfaceUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayInterfaceUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayInterfaceUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1058,12 +1058,12 @@ func mobileGatewayInterfaceDisconnectCmd() *cobra.Command {
 		Short:        "Disconnected to switch",
 		Long:         `Disconnected to switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayInterfaceDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayInterfaceDisconnectParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayInterfaceDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1133,12 +1133,12 @@ func mobileGatewayTrafficControlInfoCmd() *cobra.Command {
 		Short:        "Show information of traffic-control",
 		Long:         `Show information of traffic-control`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayTrafficControlInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayTrafficControlInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayTrafficControlInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1203,12 +1203,12 @@ func mobileGatewayTrafficControlEnableCmd() *cobra.Command {
 		Short:        "Enable traffic-control",
 		Long:         `Enable traffic-control`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayTrafficControlEnableParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayTrafficControlEnableParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayTrafficControlEnableParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1283,12 +1283,12 @@ func mobileGatewayTrafficControlUpdateCmd() *cobra.Command {
 		Short:        "Update traffic-control config",
 		Long:         `Update traffic-control config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayTrafficControlUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayTrafficControlUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayTrafficControlUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1363,12 +1363,12 @@ func mobileGatewayTrafficControlDisableCmd() *cobra.Command {
 		Short:        "Disable traffic-control config",
 		Long:         `Disable traffic-control config`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayTrafficControlDisableParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayTrafficControlDisableParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayTrafficControlDisableParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1438,12 +1438,12 @@ func mobileGatewayStaticRouteInfoCmd() *cobra.Command {
 		Short:        "Show information of static-routes",
 		Long:         `Show information of static-routes`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayStaticRouteInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayStaticRouteInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayStaticRouteInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1508,12 +1508,12 @@ func mobileGatewayStaticRouteAddCmd() *cobra.Command {
 		Short:        "Add static-route",
 		Long:         `Add static-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayStaticRouteAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayStaticRouteAddParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayStaticRouteAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1585,12 +1585,12 @@ func mobileGatewayStaticRouteUpdateCmd() *cobra.Command {
 		Short:        "Update static-route",
 		Long:         `Update static-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayStaticRouteUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayStaticRouteUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayStaticRouteUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1663,12 +1663,12 @@ func mobileGatewayStaticRouteDeleteCmd() *cobra.Command {
 		Short:        "Delete static-route",
 		Long:         `Delete static-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayStaticRouteDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayStaticRouteDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayStaticRouteDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1739,12 +1739,12 @@ func mobileGatewaySIMInfoCmd() *cobra.Command {
 		Short:        "Show information of NIC(s) connected to mobile-gateway",
 		Long:         `Show information of NIC(s) connected to mobile-gateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1809,12 +1809,12 @@ func mobileGatewaySIMAddCmd() *cobra.Command {
 		Short:        "Connected to switch",
 		Long:         `Connected to switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMAddParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1886,12 +1886,12 @@ func mobileGatewaySIMUpdateCmd() *cobra.Command {
 		Short:        "Connected to switch",
 		Long:         `Connected to switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1963,12 +1963,12 @@ func mobileGatewaySIMDeleteCmd() *cobra.Command {
 		Short:        "Disconnected to switch",
 		Long:         `Disconnected to switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2039,12 +2039,12 @@ func mobileGatewaySIMRouteInfoCmd() *cobra.Command {
 		Short:        "Show information of sim-routes",
 		Long:         `Show information of sim-routes`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMRouteInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMRouteInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMRouteInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2109,12 +2109,12 @@ func mobileGatewaySIMRouteAddCmd() *cobra.Command {
 		Short:        "Add sim-route",
 		Long:         `Add sim-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMRouteAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMRouteAddParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMRouteAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2186,12 +2186,12 @@ func mobileGatewaySIMRouteUpdateCmd() *cobra.Command {
 		Short:        "Update sim-route",
 		Long:         `Update sim-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMRouteUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMRouteUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMRouteUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2264,12 +2264,12 @@ func mobileGatewaySIMRouteDeleteCmd() *cobra.Command {
 		Short:        "Delete sim-route",
 		Long:         `Delete sim-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewaySIMRouteDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewaySIMRouteDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewaySIMRouteDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2340,12 +2340,12 @@ func mobileGatewayDNSUpdateCmd() *cobra.Command {
 		Short:        "Update interface",
 		Long:         `Update interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayDNSUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayDNSUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayDNSUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2417,12 +2417,12 @@ func mobileGatewayLogsCmd() *cobra.Command {
 		Short:        "Logs MobileGateway",
 		Long:         `Logs MobileGateway`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mobileGatewayLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, mobileGatewayLogsParam)
 			if err != nil {
+				return err
+			}
+			if err := mobileGatewayLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_nfs_gen.go
+++ b/pkg/cmd/zz_nfs_gen.go
@@ -50,12 +50,12 @@ func nfsListCmd() *cobra.Command {
 		Short:        "List NFS",
 		Long:         `List NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsListParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func nfsCreateCmd() *cobra.Command {
 		Short:        "Create NFS",
 		Long:         `Create NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -172,12 +172,12 @@ func nfsReadCmd() *cobra.Command {
 		Short:        "Read NFS",
 		Long:         `Read NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsReadParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -242,12 +242,12 @@ func nfsUpdateCmd() *cobra.Command {
 		Short:        "Update NFS",
 		Long:         `Update NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -328,12 +328,12 @@ func nfsDeleteCmd() *cobra.Command {
 		Short:        "Delete NFS",
 		Long:         `Delete NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -411,12 +411,12 @@ func nfsBootCmd() *cobra.Command {
 		Short:        "Boot NFS",
 		Long:         `Boot NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsBootParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -486,12 +486,12 @@ func nfsShutdownCmd() *cobra.Command {
 		Short:        "Shutdown NFS",
 		Long:         `Shutdown NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsShutdownParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -561,12 +561,12 @@ func nfsShutdownForceCmd() *cobra.Command {
 		Short:        "ShutdownForce NFS",
 		Long:         `ShutdownForce NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsShutdownForceParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -636,12 +636,12 @@ func nfsResetCmd() *cobra.Command {
 		Short:        "Reset NFS",
 		Long:         `Reset NFS`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsResetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsResetParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsResetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -711,12 +711,12 @@ func nfsWaitForBootCmd() *cobra.Command {
 		Short:        "Wait until boot is completed",
 		Long:         `Wait until boot is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsWaitForBootParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -774,12 +774,12 @@ func nfsWaitForDownCmd() *cobra.Command {
 		Short:        "Wait until shutdown is completed",
 		Long:         `Wait until shutdown is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsWaitForDownParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -837,12 +837,12 @@ func nfsMonitorNicCmd() *cobra.Command {
 		Short:        "Collect NIC(s) monitor values",
 		Long:         `Collect NIC(s) monitor values`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsMonitorNicParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsMonitorNicParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsMonitorNicParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -910,12 +910,12 @@ func nfsMonitorFreeDiskSizeCmd() *cobra.Command {
 		Short:        "Collect system-disk monitor values(IO)",
 		Long:         `Collect system-disk monitor values(IO)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return nfsMonitorFreeDiskSizeParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, nfsMonitorFreeDiskSizeParam)
 			if err != nil {
+				return err
+			}
+			if err := nfsMonitorFreeDiskSizeParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_object_storage_gen.go
+++ b/pkg/cmd/zz_object_storage_gen.go
@@ -48,12 +48,12 @@ func objectStorageListCmd() *cobra.Command {
 		Short:        "List ObjectStorage",
 		Long:         `List ObjectStorage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return objectStorageListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, objectStorageListParam)
 			if err != nil {
+				return err
+			}
+			if err := objectStorageListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -98,12 +98,12 @@ func objectStoragePutCmd() *cobra.Command {
 		Short:        "Put ObjectStorage",
 		Long:         `Put ObjectStorage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return objectStoragePutParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, objectStoragePutParam)
 			if err != nil {
+				return err
+			}
+			if err := objectStoragePutParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -155,12 +155,12 @@ func objectStorageGetCmd() *cobra.Command {
 		Short:        "Get ObjectStorage",
 		Long:         `Get ObjectStorage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return objectStorageGetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, objectStorageGetParam)
 			if err != nil {
+				return err
+			}
+			if err := objectStorageGetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -199,12 +199,12 @@ func objectStorageDeleteCmd() *cobra.Command {
 		Short:        "Delete ObjectStorage",
 		Long:         `Delete ObjectStorage`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return objectStorageDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, objectStorageDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := objectStorageDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_packet_filter_gen.go
+++ b/pkg/cmd/zz_packet_filter_gen.go
@@ -50,12 +50,12 @@ func packetFilterListCmd() *cobra.Command {
 		Short:        "List PacketFilter",
 		Long:         `List PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterListParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -102,12 +102,12 @@ func packetFilterCreateCmd() *cobra.Command {
 		Short:        "Create PacketFilter",
 		Long:         `Create PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -163,12 +163,12 @@ func packetFilterReadCmd() *cobra.Command {
 		Short:        "Read PacketFilter",
 		Long:         `Read PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterReadParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -232,12 +232,12 @@ func packetFilterUpdateCmd() *cobra.Command {
 		Short:        "Update PacketFilter",
 		Long:         `Update PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -315,12 +315,12 @@ func packetFilterDeleteCmd() *cobra.Command {
 		Short:        "Delete PacketFilter",
 		Long:         `Delete PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -396,12 +396,12 @@ func packetFilterRuleInfoCmd() *cobra.Command {
 		Short:        "RuleInfo PacketFilter",
 		Long:         `RuleInfo PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterRuleInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterRuleInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterRuleInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -465,12 +465,12 @@ func packetFilterRuleAddCmd() *cobra.Command {
 		Short:        "RuleAdd PacketFilter",
 		Long:         `RuleAdd PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterRuleAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterRuleAddParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterRuleAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -553,12 +553,12 @@ func packetFilterRuleUpdateCmd() *cobra.Command {
 		Short:        "RuleUpdate PacketFilter",
 		Long:         `RuleUpdate PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterRuleUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterRuleUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterRuleUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -641,12 +641,12 @@ func packetFilterRuleDeleteCmd() *cobra.Command {
 		Short:        "RuleDelete PacketFilter",
 		Long:         `RuleDelete PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterRuleDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterRuleDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterRuleDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -723,12 +723,12 @@ func packetFilterInterfaceConnectCmd() *cobra.Command {
 		Short:        "InterfaceConnect PacketFilter",
 		Long:         `InterfaceConnect PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterInterfaceConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterInterfaceConnectParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterInterfaceConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -798,12 +798,12 @@ func packetFilterInterfaceDisconnectCmd() *cobra.Command {
 		Short:        "InterfaceDisconnect PacketFilter",
 		Long:         `InterfaceDisconnect PacketFilter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return packetFilterInterfaceDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, packetFilterInterfaceDisconnectParam)
 			if err != nil {
+				return err
+			}
+			if err := packetFilterInterfaceDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_price_gen.go
+++ b/pkg/cmd/zz_price_gen.go
@@ -45,12 +45,12 @@ func priceListCmd() *cobra.Command {
 		Short:        "List Price (default)",
 		Long:         `List Price (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return priceListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, priceListParam)
 			if err != nil {
+				return err
+			}
+			if err := priceListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_private_host_gen.go
+++ b/pkg/cmd/zz_private_host_gen.go
@@ -50,12 +50,12 @@ func privateHostListCmd() *cobra.Command {
 		Short:        "List PrivateHost",
 		Long:         `List PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostListParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func privateHostCreateCmd() *cobra.Command {
 		Short:        "Create PrivateHost",
 		Long:         `Create PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -166,12 +166,12 @@ func privateHostReadCmd() *cobra.Command {
 		Short:        "Read PrivateHost",
 		Long:         `Read PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostReadParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -236,12 +236,12 @@ func privateHostUpdateCmd() *cobra.Command {
 		Short:        "Update PrivateHost",
 		Long:         `Update PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -322,12 +322,12 @@ func privateHostDeleteCmd() *cobra.Command {
 		Short:        "Delete PrivateHost",
 		Long:         `Delete PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -404,12 +404,12 @@ func privateHostServerInfoCmd() *cobra.Command {
 		Short:        "ServerInfo PrivateHost",
 		Long:         `ServerInfo PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostServerInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -474,12 +474,12 @@ func privateHostServerAddCmd() *cobra.Command {
 		Short:        "ServerAdd PrivateHost",
 		Long:         `ServerAdd PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostServerAddParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -557,12 +557,12 @@ func privateHostServerDeleteCmd() *cobra.Command {
 		Short:        "ServerDelete PrivateHost",
 		Long:         `ServerDelete PrivateHost`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return privateHostServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, privateHostServerDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := privateHostServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_product_disk_gen.go
+++ b/pkg/cmd/zz_product_disk_gen.go
@@ -48,12 +48,12 @@ func productDiskListCmd() *cobra.Command {
 		Short:        "List ProductDisk (default)",
 		Long:         `List ProductDisk (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productDiskListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productDiskListParam)
 			if err != nil {
+				return err
+			}
+			if err := productDiskListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -100,12 +100,12 @@ func productDiskReadCmd() *cobra.Command {
 		Short:        "Read ProductDisk",
 		Long:         `Read ProductDisk`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productDiskReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productDiskReadParam)
 			if err != nil {
+				return err
+			}
+			if err := productDiskReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_product_internet_gen.go
+++ b/pkg/cmd/zz_product_internet_gen.go
@@ -48,12 +48,12 @@ func productInternetListCmd() *cobra.Command {
 		Short:        "List ProductInternet (default)",
 		Long:         `List ProductInternet (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productInternetListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productInternetListParam)
 			if err != nil {
+				return err
+			}
+			if err := productInternetListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -100,12 +100,12 @@ func productInternetReadCmd() *cobra.Command {
 		Short:        "Read ProductInternet",
 		Long:         `Read ProductInternet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productInternetReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productInternetReadParam)
 			if err != nil {
+				return err
+			}
+			if err := productInternetReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_product_license_gen.go
+++ b/pkg/cmd/zz_product_license_gen.go
@@ -48,12 +48,12 @@ func productLicenseListCmd() *cobra.Command {
 		Short:        "List ProductLicense (default)",
 		Long:         `List ProductLicense (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productLicenseListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productLicenseListParam)
 			if err != nil {
+				return err
+			}
+			if err := productLicenseListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -100,12 +100,12 @@ func productLicenseReadCmd() *cobra.Command {
 		Short:        "Read ProductLicense",
 		Long:         `Read ProductLicense`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productLicenseReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productLicenseReadParam)
 			if err != nil {
+				return err
+			}
+			if err := productLicenseReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_product_server_gen.go
+++ b/pkg/cmd/zz_product_server_gen.go
@@ -48,12 +48,12 @@ func productServerListCmd() *cobra.Command {
 		Short:        "List ProductServer (default)",
 		Long:         `List ProductServer (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productServerListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productServerListParam)
 			if err != nil {
+				return err
+			}
+			if err := productServerListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -100,12 +100,12 @@ func productServerReadCmd() *cobra.Command {
 		Short:        "Read ProductServer",
 		Long:         `Read ProductServer`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return productServerReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, productServerReadParam)
 			if err != nil {
+				return err
+			}
+			if err := productServerReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_proxy_lb_gen.go
+++ b/pkg/cmd/zz_proxy_lb_gen.go
@@ -50,12 +50,12 @@ func proxyLBListCmd() *cobra.Command {
 		Short:        "List ProxyLB",
 		Long:         `List ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBListParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func proxyLBCreateCmd() *cobra.Command {
 		Short:        "Create ProxyLB",
 		Long:         `Create ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -175,12 +175,12 @@ func proxyLBReadCmd() *cobra.Command {
 		Short:        "Read ProxyLB",
 		Long:         `Read ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBReadParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -245,12 +245,12 @@ func proxyLBUpdateCmd() *cobra.Command {
 		Short:        "Update ProxyLB",
 		Long:         `Update ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -339,12 +339,12 @@ func proxyLBDeleteCmd() *cobra.Command {
 		Short:        "Delete ProxyLB",
 		Long:         `Delete ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -421,12 +421,12 @@ func proxyLBPlanChangeCmd() *cobra.Command {
 		Short:        "Change ProxyLB plan",
 		Long:         `Change ProxyLB plan`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBPlanChangeParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBPlanChangeParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBPlanChangeParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -504,12 +504,12 @@ func proxyLBBindPortInfoCmd() *cobra.Command {
 		Short:        "BindPortInfo ProxyLB",
 		Long:         `BindPortInfo ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBBindPortInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBBindPortInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBBindPortInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -574,12 +574,12 @@ func proxyLBBindPortAddCmd() *cobra.Command {
 		Short:        "BindPortAdd ProxyLB",
 		Long:         `BindPortAdd ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBBindPortAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBBindPortAddParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBBindPortAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -660,12 +660,12 @@ func proxyLBBindPortUpdateCmd() *cobra.Command {
 		Short:        "BindPortUpdate ProxyLB",
 		Long:         `BindPortUpdate ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBBindPortUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBBindPortUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBBindPortUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -747,12 +747,12 @@ func proxyLBBindPortDeleteCmd() *cobra.Command {
 		Short:        "BindPortDelete ProxyLB",
 		Long:         `BindPortDelete ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBBindPortDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBBindPortDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBBindPortDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -830,12 +830,12 @@ func proxyLBResponseHeaderInfoCmd() *cobra.Command {
 		Short:        "ResponseHeaderInfo ProxyLB",
 		Long:         `ResponseHeaderInfo ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBResponseHeaderInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBResponseHeaderInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBResponseHeaderInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -901,12 +901,12 @@ func proxyLBResponseHeaderAddCmd() *cobra.Command {
 		Short:        "ResponseHeaderAdd ProxyLB",
 		Long:         `ResponseHeaderAdd ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBResponseHeaderAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBResponseHeaderAddParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBResponseHeaderAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -986,12 +986,12 @@ func proxyLBResponseHeaderUpdateCmd() *cobra.Command {
 		Short:        "ResponseHeaderUpdate ProxyLB",
 		Long:         `ResponseHeaderUpdate ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBResponseHeaderUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBResponseHeaderUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBResponseHeaderUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1072,12 +1072,12 @@ func proxyLBResponseHeaderDeleteCmd() *cobra.Command {
 		Short:        "ResponseHeaderDelete ProxyLB",
 		Long:         `ResponseHeaderDelete ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBResponseHeaderDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBResponseHeaderDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBResponseHeaderDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1156,12 +1156,12 @@ func proxyLBACMEInfoCmd() *cobra.Command {
 		Short:        "ACMEInfo ProxyLB",
 		Long:         `ACMEInfo ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBACMEInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBACMEInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBACMEInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1226,12 +1226,12 @@ func proxyLBACMESettingCmd() *cobra.Command {
 		Short:        "ACMESetting ProxyLB",
 		Long:         `ACMESetting ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBACMESettingParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBACMESettingParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBACMESettingParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1311,12 +1311,12 @@ func proxyLBACMERenewCmd() *cobra.Command {
 		Short:        "ACMERenew ProxyLB",
 		Long:         `ACMERenew ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBACMERenewParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBACMERenewParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBACMERenewParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1386,12 +1386,12 @@ func proxyLBServerInfoCmd() *cobra.Command {
 		Short:        "ServerInfo ProxyLB",
 		Long:         `ServerInfo ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBServerInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1456,12 +1456,12 @@ func proxyLBServerAddCmd() *cobra.Command {
 		Short:        "ServerAdd ProxyLB",
 		Long:         `ServerAdd ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBServerAddParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1541,12 +1541,12 @@ func proxyLBServerUpdateCmd() *cobra.Command {
 		Short:        "ServerUpdate ProxyLB",
 		Long:         `ServerUpdate ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBServerUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1627,12 +1627,12 @@ func proxyLBServerDeleteCmd() *cobra.Command {
 		Short:        "ServerDelete ProxyLB",
 		Long:         `ServerDelete ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBServerDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1710,12 +1710,12 @@ func proxyLBCertificateInfoCmd() *cobra.Command {
 		Short:        "CertificateInfo ProxyLB",
 		Long:         `CertificateInfo ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBCertificateInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBCertificateInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBCertificateInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1780,12 +1780,12 @@ func proxyLBCertificateAddCmd() *cobra.Command {
 		Short:        "CertificateAdd ProxyLB",
 		Long:         `CertificateAdd ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBCertificateAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBCertificateAddParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBCertificateAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1865,12 +1865,12 @@ func proxyLBCertificateUpdateCmd() *cobra.Command {
 		Short:        "CertificateUpdate ProxyLB",
 		Long:         `CertificateUpdate ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBCertificateUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBCertificateUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBCertificateUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1950,12 +1950,12 @@ func proxyLBCertificateDeleteCmd() *cobra.Command {
 		Short:        "CertificateDelete ProxyLB",
 		Long:         `CertificateDelete ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBCertificateDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBCertificateDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBCertificateDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2032,12 +2032,12 @@ func proxyLBMonitorCmd() *cobra.Command {
 		Short:        "Monitor ProxyLB",
 		Long:         `Monitor ProxyLB`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return proxyLBMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, proxyLBMonitorParam)
 			if err != nil {
+				return err
+			}
+			if err := proxyLBMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_region_gen.go
+++ b/pkg/cmd/zz_region_gen.go
@@ -48,12 +48,12 @@ func regionListCmd() *cobra.Command {
 		Short:        "List Region (default)",
 		Long:         `List Region (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return regionListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, regionListParam)
 			if err != nil {
+				return err
+			}
+			if err := regionListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -100,12 +100,12 @@ func regionReadCmd() *cobra.Command {
 		Short:        "Read Region",
 		Long:         `Read Region`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return regionReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, regionReadParam)
 			if err != nil {
+				return err
+			}
+			if err := regionReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_self_gen.go
+++ b/pkg/cmd/zz_self_gen.go
@@ -44,12 +44,12 @@ func selfInfoCmd() *cobra.Command {
 		Short:        "Info Self (default)",
 		Long:         `Info Self (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return selfInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, selfInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := selfInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_server_gen.go
+++ b/pkg/cmd/zz_server_gen.go
@@ -50,12 +50,12 @@ func serverListCmd() *cobra.Command {
 		Short:        "List Server",
 		Long:         `List Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverListParam)
 			if err != nil {
+				return err
+			}
+			if err := serverListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func serverBuildCmd() *cobra.Command {
 		Short:        "Build Server",
 		Long:         `Build Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverBuildParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverBuildParam)
 			if err != nil {
+				return err
+			}
+			if err := serverBuildParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -204,12 +204,12 @@ func serverReadCmd() *cobra.Command {
 		Short:        "Read Server",
 		Long:         `Read Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverReadParam)
 			if err != nil {
+				return err
+			}
+			if err := serverReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -274,12 +274,12 @@ func serverUpdateCmd() *cobra.Command {
 		Short:        "Update Server",
 		Long:         `Update Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := serverUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -361,12 +361,12 @@ func serverDeleteCmd() *cobra.Command {
 		Short:        "Delete Server",
 		Long:         `Delete Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := serverDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -445,12 +445,12 @@ func serverPlanChangeCmd() *cobra.Command {
 		Short:        "Change server plan(core/memory)",
 		Long:         `Change server plan(core/memory)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverPlanChangeParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverPlanChangeParam)
 			if err != nil {
+				return err
+			}
+			if err := serverPlanChangeParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -530,12 +530,12 @@ func serverBootCmd() *cobra.Command {
 		Short:        "Boot Server",
 		Long:         `Boot Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverBootParam)
 			if err != nil {
+				return err
+			}
+			if err := serverBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -605,12 +605,12 @@ func serverShutdownCmd() *cobra.Command {
 		Short:        "Shutdown Server",
 		Long:         `Shutdown Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverShutdownParam)
 			if err != nil {
+				return err
+			}
+			if err := serverShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -680,12 +680,12 @@ func serverShutdownForceCmd() *cobra.Command {
 		Short:        "ShutdownForce Server",
 		Long:         `ShutdownForce Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverShutdownForceParam)
 			if err != nil {
+				return err
+			}
+			if err := serverShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -755,12 +755,12 @@ func serverResetCmd() *cobra.Command {
 		Short:        "Reset Server",
 		Long:         `Reset Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverResetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverResetParam)
 			if err != nil {
+				return err
+			}
+			if err := serverResetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -830,12 +830,12 @@ func serverWaitForBootCmd() *cobra.Command {
 		Short:        "Wait until boot is completed",
 		Long:         `Wait until boot is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverWaitForBootParam)
 			if err != nil {
+				return err
+			}
+			if err := serverWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -893,12 +893,12 @@ func serverWaitForDownCmd() *cobra.Command {
 		Short:        "Wait until shutdown is completed",
 		Long:         `Wait until shutdown is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverWaitForDownParam)
 			if err != nil {
+				return err
+			}
+			if err := serverWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -956,12 +956,12 @@ func serverSSHCmd() *cobra.Command {
 		Short:        "Connect to server by SSH",
 		Long:         `Connect to server by SSH`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverSSHParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverSSHParam)
 			if err != nil {
+				return err
+			}
+			if err := serverSSHParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1024,12 +1024,12 @@ func serverSSHExecCmd() *cobra.Command {
 		Short:        "Execute command on server connected by SSH",
 		Long:         `Execute command on server connected by SSH`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverSSHExecParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverSSHExecParam)
 			if err != nil {
+				return err
+			}
+			if err := serverSSHExecParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1091,12 +1091,12 @@ func serverScpCmd() *cobra.Command {
 		Short:        "Copy files/directories by SSH",
 		Long:         `Copy files/directories by SSH`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverScpParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverScpParam)
 			if err != nil {
+				return err
+			}
+			if err := serverScpParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1149,12 +1149,12 @@ func serverVncCmd() *cobra.Command {
 		Short:        "Open VNC client using the OS's default application",
 		Long:         `Open VNC client using the OS's default application`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverVncParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverVncParam)
 			if err != nil {
+				return err
+			}
+			if err := serverVncParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1213,12 +1213,12 @@ func serverVncInfoCmd() *cobra.Command {
 		Short:        "Show VNC proxy information",
 		Long:         `Show VNC proxy information`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverVncInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverVncInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := serverVncInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1284,12 +1284,12 @@ func serverVncSendCmd() *cobra.Command {
 		Short:        "Send keys over VNC connection",
 		Long:         `Send keys over VNC connection`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverVncSendParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverVncSendParam)
 			if err != nil {
+				return err
+			}
+			if err := serverVncSendParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1371,12 +1371,12 @@ func serverVncSnapshotCmd() *cobra.Command {
 		Short:        "Capture VNC snapshot",
 		Long:         `Capture VNC snapshot`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverVncSnapshotParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverVncSnapshotParam)
 			if err != nil {
+				return err
+			}
+			if err := serverVncSnapshotParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1455,12 +1455,12 @@ func serverRemoteDesktopCmd() *cobra.Command {
 		Short:        "Open RDP client using the OS's default application",
 		Long:         `Open RDP client using the OS's default application`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverRemoteDesktopParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverRemoteDesktopParam)
 			if err != nil {
+				return err
+			}
+			if err := serverRemoteDesktopParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1520,12 +1520,12 @@ func serverRemoteDesktopInfoCmd() *cobra.Command {
 		Short:        "Show RDP information(.rdp)",
 		Long:         `Show RDP information(.rdp)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverRemoteDesktopInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverRemoteDesktopInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := serverRemoteDesktopInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1592,12 +1592,12 @@ func serverDiskInfoCmd() *cobra.Command {
 		Short:        "Show information of disk(s) connected to server",
 		Long:         `Show information of disk(s) connected to server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverDiskInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverDiskInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := serverDiskInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1662,12 +1662,12 @@ func serverDiskConnectCmd() *cobra.Command {
 		Short:        "Connect disk to server",
 		Long:         `Connect disk to server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverDiskConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverDiskConnectParam)
 			if err != nil {
+				return err
+			}
+			if err := serverDiskConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1738,12 +1738,12 @@ func serverDiskDisconnectCmd() *cobra.Command {
 		Short:        "Disconnect disk from server",
 		Long:         `Disconnect disk from server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverDiskDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverDiskDisconnectParam)
 			if err != nil {
+				return err
+			}
+			if err := serverDiskDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1814,12 +1814,12 @@ func serverInterfaceInfoCmd() *cobra.Command {
 		Short:        "Show information of NIC(s) connected to server",
 		Long:         `Show information of NIC(s) connected to server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverInterfaceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverInterfaceInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := serverInterfaceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1884,12 +1884,12 @@ func serverInterfaceAddForInternetCmd() *cobra.Command {
 		Short:        "Create and connect NIC connected to the internet",
 		Long:         `Create and connect NIC connected to the internet`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverInterfaceAddForInternetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverInterfaceAddForInternetParam)
 			if err != nil {
+				return err
+			}
+			if err := serverInterfaceAddForInternetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1960,12 +1960,12 @@ func serverInterfaceAddForRouterCmd() *cobra.Command {
 		Short:        "Create and connect NIC connected to the router",
 		Long:         `Create and connect NIC connected to the router`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverInterfaceAddForRouterParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverInterfaceAddForRouterParam)
 			if err != nil {
+				return err
+			}
+			if err := serverInterfaceAddForRouterParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2040,12 +2040,12 @@ func serverInterfaceAddForSwitchCmd() *cobra.Command {
 		Short:        "Create and connect NIC connected to the switch",
 		Long:         `Create and connect NIC connected to the switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverInterfaceAddForSwitchParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverInterfaceAddForSwitchParam)
 			if err != nil {
+				return err
+			}
+			if err := serverInterfaceAddForSwitchParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2120,12 +2120,12 @@ func serverInterfaceAddDisconnectedCmd() *cobra.Command {
 		Short:        "Create and connect a disconnected NIC",
 		Long:         `Create and connect a disconnected NIC`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverInterfaceAddDisconnectedParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverInterfaceAddDisconnectedParam)
 			if err != nil {
+				return err
+			}
+			if err := serverInterfaceAddDisconnectedParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2195,12 +2195,12 @@ func serverISOInfoCmd() *cobra.Command {
 		Short:        "Show information of ISO-Image inserted to server",
 		Long:         `Show information of ISO-Image inserted to server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverISOInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverISOInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := serverISOInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2265,12 +2265,12 @@ func serverISOInsertCmd() *cobra.Command {
 		Short:        "Insert ISO-Image to server",
 		Long:         `Insert ISO-Image to server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverISOInsertParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverISOInsertParam)
 			if err != nil {
+				return err
+			}
+			if err := serverISOInsertParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2347,12 +2347,12 @@ func serverISOEjectCmd() *cobra.Command {
 		Short:        "Eject ISO-Image from server",
 		Long:         `Eject ISO-Image from server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverISOEjectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverISOEjectParam)
 			if err != nil {
+				return err
+			}
+			if err := serverISOEjectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2422,12 +2422,12 @@ func serverMonitorCPUCmd() *cobra.Command {
 		Short:        "Collect CPU monitor values",
 		Long:         `Collect CPU monitor values`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverMonitorCPUParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverMonitorCPUParam)
 			if err != nil {
+				return err
+			}
+			if err := serverMonitorCPUParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2495,12 +2495,12 @@ func serverMonitorNicCmd() *cobra.Command {
 		Short:        "Collect NIC(s) monitor values",
 		Long:         `Collect NIC(s) monitor values`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverMonitorNicParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverMonitorNicParam)
 			if err != nil {
+				return err
+			}
+			if err := serverMonitorNicParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2569,12 +2569,12 @@ func serverMonitorDiskCmd() *cobra.Command {
 		Short:        "Collect Disk(s) monitor values",
 		Long:         `Collect Disk(s) monitor values`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverMonitorDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverMonitorDiskParam)
 			if err != nil {
+				return err
+			}
+			if err := serverMonitorDiskParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2643,12 +2643,12 @@ func serverMaintenanceInfoCmd() *cobra.Command {
 		Short:        "MaintenanceInfo Server",
 		Long:         `MaintenanceInfo Server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return serverMaintenanceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, serverMaintenanceInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := serverMaintenanceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_sim_gen.go
+++ b/pkg/cmd/zz_sim_gen.go
@@ -50,12 +50,12 @@ func simListCmd() *cobra.Command {
 		Short:        "List SIM",
 		Long:         `List SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simListParam)
 			if err != nil {
+				return err
+			}
+			if err := simListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func simCreateCmd() *cobra.Command {
 		Short:        "Create SIM",
 		Long:         `Create SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := simCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -171,12 +171,12 @@ func simReadCmd() *cobra.Command {
 		Short:        "Read SIM",
 		Long:         `Read SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simReadParam)
 			if err != nil {
+				return err
+			}
+			if err := simReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -241,12 +241,12 @@ func simUpdateCmd() *cobra.Command {
 		Short:        "Update SIM",
 		Long:         `Update SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := simUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -327,12 +327,12 @@ func simDeleteCmd() *cobra.Command {
 		Short:        "Delete SIM",
 		Long:         `Delete SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := simDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -403,12 +403,12 @@ func simCarrierInfoCmd() *cobra.Command {
 		Short:        "CarrierInfo SIM",
 		Long:         `CarrierInfo SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simCarrierInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simCarrierInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := simCarrierInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -473,12 +473,12 @@ func simCarrierUpdateCmd() *cobra.Command {
 		Short:        "CarrierUpdate SIM",
 		Long:         `CarrierUpdate SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simCarrierUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simCarrierUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := simCarrierUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -549,12 +549,12 @@ func simActivateCmd() *cobra.Command {
 		Short:        "Activate SIM",
 		Long:         `Activate SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simActivateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simActivateParam)
 			if err != nil {
+				return err
+			}
+			if err := simActivateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -624,12 +624,12 @@ func simDeactivateCmd() *cobra.Command {
 		Short:        "Deactivate SIM",
 		Long:         `Deactivate SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simDeactivateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simDeactivateParam)
 			if err != nil {
+				return err
+			}
+			if err := simDeactivateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -699,12 +699,12 @@ func simImeiLockCmd() *cobra.Command {
 		Short:        "ImeiLock SIM",
 		Long:         `ImeiLock SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simImeiLockParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simImeiLockParam)
 			if err != nil {
+				return err
+			}
+			if err := simImeiLockParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -775,12 +775,12 @@ func simIpAddCmd() *cobra.Command {
 		Short:        "IpAdd SIM",
 		Long:         `IpAdd SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simIpAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simIpAddParam)
 			if err != nil {
+				return err
+			}
+			if err := simIpAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -851,12 +851,12 @@ func simImeiUnlockCmd() *cobra.Command {
 		Short:        "ImeiUnlock SIM",
 		Long:         `ImeiUnlock SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simImeiUnlockParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simImeiUnlockParam)
 			if err != nil {
+				return err
+			}
+			if err := simImeiUnlockParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -926,12 +926,12 @@ func simIpDeleteCmd() *cobra.Command {
 		Short:        "IpDelete SIM",
 		Long:         `IpDelete SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simIpDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simIpDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := simIpDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1001,12 +1001,12 @@ func simLogsCmd() *cobra.Command {
 		Short:        "Logs SIM",
 		Long:         `Logs SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simLogsParam)
 			if err != nil {
+				return err
+			}
+			if err := simLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1073,12 +1073,12 @@ func simMonitorCmd() *cobra.Command {
 		Short:        "Monitor SIM",
 		Long:         `Monitor SIM`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simMonitorParam)
 			if err != nil {
+				return err
+			}
+			if err := simMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_simple_monitor_gen.go
+++ b/pkg/cmd/zz_simple_monitor_gen.go
@@ -50,12 +50,12 @@ func simpleMonitorListCmd() *cobra.Command {
 		Short:        "List SimpleMonitor",
 		Long:         `List SimpleMonitor`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simpleMonitorListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simpleMonitorListParam)
 			if err != nil {
+				return err
+			}
+			if err := simpleMonitorListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -104,12 +104,12 @@ func simpleMonitorCreateCmd() *cobra.Command {
 		Short:        "Create SimpleMonitor",
 		Long:         `Create SimpleMonitor`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simpleMonitorCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simpleMonitorCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := simpleMonitorCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -184,12 +184,12 @@ func simpleMonitorReadCmd() *cobra.Command {
 		Short:        "Read SimpleMonitor",
 		Long:         `Read SimpleMonitor`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simpleMonitorReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simpleMonitorReadParam)
 			if err != nil {
+				return err
+			}
+			if err := simpleMonitorReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -254,12 +254,12 @@ func simpleMonitorUpdateCmd() *cobra.Command {
 		Short:        "Update SimpleMonitor",
 		Long:         `Update SimpleMonitor`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simpleMonitorUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simpleMonitorUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := simpleMonitorUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -356,12 +356,12 @@ func simpleMonitorDeleteCmd() *cobra.Command {
 		Short:        "Delete SimpleMonitor",
 		Long:         `Delete SimpleMonitor`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simpleMonitorDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simpleMonitorDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := simpleMonitorDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -438,12 +438,12 @@ func simpleMonitorHealthCmd() *cobra.Command {
 		Short:        "Health SimpleMonitor",
 		Long:         `Health SimpleMonitor`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return simpleMonitorHealthParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, simpleMonitorHealthParam)
 			if err != nil {
+				return err
+			}
+			if err := simpleMonitorHealthParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_ssh_key_gen.go
+++ b/pkg/cmd/zz_ssh_key_gen.go
@@ -50,12 +50,12 @@ func sshKeyListCmd() *cobra.Command {
 		Short:        "List SSHKey",
 		Long:         `List SSHKey`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return sshKeyListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, sshKeyListParam)
 			if err != nil {
+				return err
+			}
+			if err := sshKeyListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -102,12 +102,12 @@ func sshKeyCreateCmd() *cobra.Command {
 		Short:        "Create SSHKey",
 		Long:         `Create SSHKey`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return sshKeyCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, sshKeyCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := sshKeyCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -165,12 +165,12 @@ func sshKeyReadCmd() *cobra.Command {
 		Short:        "Read SSHKey",
 		Long:         `Read SSHKey`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return sshKeyReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, sshKeyReadParam)
 			if err != nil {
+				return err
+			}
+			if err := sshKeyReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -234,12 +234,12 @@ func sshKeyUpdateCmd() *cobra.Command {
 		Short:        "Update SSHKey",
 		Long:         `Update SSHKey`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return sshKeyUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, sshKeyUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := sshKeyUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -317,12 +317,12 @@ func sshKeyDeleteCmd() *cobra.Command {
 		Short:        "Delete SSHKey",
 		Long:         `Delete SSHKey`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return sshKeyDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, sshKeyDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := sshKeyDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -398,12 +398,12 @@ func sshKeyGenerateCmd() *cobra.Command {
 		Short:        "Generate SSHKey",
 		Long:         `Generate SSHKey`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return sshKeyGenerateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, sshKeyGenerateParam)
 			if err != nil {
+				return err
+			}
+			if err := sshKeyGenerateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_startup_script_gen.go
+++ b/pkg/cmd/zz_startup_script_gen.go
@@ -50,12 +50,12 @@ func startupScriptListCmd() *cobra.Command {
 		Short:        "List StartupScript",
 		Long:         `List StartupScript`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return startupScriptListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, startupScriptListParam)
 			if err != nil {
+				return err
+			}
+			if err := startupScriptListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -105,12 +105,12 @@ func startupScriptCreateCmd() *cobra.Command {
 		Short:        "Create StartupScript",
 		Long:         `Create StartupScript`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return startupScriptCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, startupScriptCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := startupScriptCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -170,12 +170,12 @@ func startupScriptReadCmd() *cobra.Command {
 		Short:        "Read StartupScript",
 		Long:         `Read StartupScript`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return startupScriptReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, startupScriptReadParam)
 			if err != nil {
+				return err
+			}
+			if err := startupScriptReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -240,12 +240,12 @@ func startupScriptUpdateCmd() *cobra.Command {
 		Short:        "Update StartupScript",
 		Long:         `Update StartupScript`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return startupScriptUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, startupScriptUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := startupScriptUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -328,12 +328,12 @@ func startupScriptDeleteCmd() *cobra.Command {
 		Short:        "Delete StartupScript",
 		Long:         `Delete StartupScript`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return startupScriptDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, startupScriptDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := startupScriptDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_summary_gen.go
+++ b/pkg/cmd/zz_summary_gen.go
@@ -44,12 +44,12 @@ func summaryShowCmd() *cobra.Command {
 		Short:        "Show Summary (default)",
 		Long:         `Show Summary (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return summaryShowParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, summaryShowParam)
 			if err != nil {
+				return err
+			}
+			if err := summaryShowParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_switch_gen.go
+++ b/pkg/cmd/zz_switch_gen.go
@@ -50,12 +50,12 @@ func switchListCmd() *cobra.Command {
 		Short:        "List Switch",
 		Long:         `List Switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return switchListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, switchListParam)
 			if err != nil {
+				return err
+			}
+			if err := switchListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func switchCreateCmd() *cobra.Command {
 		Short:        "Create Switch",
 		Long:         `Create Switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return switchCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, switchCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := switchCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -166,12 +166,12 @@ func switchReadCmd() *cobra.Command {
 		Short:        "Read Switch",
 		Long:         `Read Switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return switchReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, switchReadParam)
 			if err != nil {
+				return err
+			}
+			if err := switchReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -236,12 +236,12 @@ func switchUpdateCmd() *cobra.Command {
 		Short:        "Update Switch",
 		Long:         `Update Switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return switchUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, switchUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := switchUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -322,12 +322,12 @@ func switchDeleteCmd() *cobra.Command {
 		Short:        "Delete Switch",
 		Long:         `Delete Switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return switchDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, switchDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := switchDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -404,12 +404,12 @@ func switchBridgeConnectCmd() *cobra.Command {
 		Short:        "BridgeConnect Switch",
 		Long:         `BridgeConnect Switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return switchBridgeConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, switchBridgeConnectParam)
 			if err != nil {
+				return err
+			}
+			if err := switchBridgeConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -480,12 +480,12 @@ func switchBridgeDisconnectCmd() *cobra.Command {
 		Short:        "BridgeDisconnect Switch",
 		Long:         `BridgeDisconnect Switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return switchBridgeDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, switchBridgeDisconnectParam)
 			if err != nil {
+				return err
+			}
+			if err := switchBridgeDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_vpc_router_gen.go
+++ b/pkg/cmd/zz_vpc_router_gen.go
@@ -50,12 +50,12 @@ func vpcRouterListCmd() *cobra.Command {
 		Short:        "List VPCRouter",
 		Long:         `List VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterListParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -103,12 +103,12 @@ func vpcRouterCreateCmd() *cobra.Command {
 		Short:        "Create VPCRouter",
 		Long:         `Create VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterCreateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterCreateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -174,12 +174,12 @@ func vpcRouterReadCmd() *cobra.Command {
 		Short:        "Read VPCRouter",
 		Long:         `Read VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterReadParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -244,12 +244,12 @@ func vpcRouterUpdateCmd() *cobra.Command {
 		Short:        "Update VPCRouter",
 		Long:         `Update VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -332,12 +332,12 @@ func vpcRouterDeleteCmd() *cobra.Command {
 		Short:        "Delete VPCRouter",
 		Long:         `Delete VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -415,12 +415,12 @@ func vpcRouterBootCmd() *cobra.Command {
 		Short:        "Boot VPCRouter",
 		Long:         `Boot VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterBootParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -490,12 +490,12 @@ func vpcRouterShutdownCmd() *cobra.Command {
 		Short:        "Shutdown VPCRouter",
 		Long:         `Shutdown VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterShutdownParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterShutdownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -565,12 +565,12 @@ func vpcRouterShutdownForceCmd() *cobra.Command {
 		Short:        "ShutdownForce VPCRouter",
 		Long:         `ShutdownForce VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterShutdownForceParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterShutdownForceParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -640,12 +640,12 @@ func vpcRouterResetCmd() *cobra.Command {
 		Short:        "Reset VPCRouter",
 		Long:         `Reset VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterResetParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterResetParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterResetParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -715,12 +715,12 @@ func vpcRouterWaitForBootCmd() *cobra.Command {
 		Short:        "Wait until boot is completed",
 		Long:         `Wait until boot is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterWaitForBootParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterWaitForBootParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -778,12 +778,12 @@ func vpcRouterWaitForDownCmd() *cobra.Command {
 		Short:        "Wait until shutdown is completed",
 		Long:         `Wait until shutdown is completed`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterWaitForDownParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterWaitForDownParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -841,12 +841,12 @@ func vpcRouterEnableInternetConnectionCmd() *cobra.Command {
 		Short:        "Enable internet connection from VPCRouter",
 		Long:         `Enable internet connection from VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterEnableInternetConnectionParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterEnableInternetConnectionParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterEnableInternetConnectionParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -916,12 +916,12 @@ func vpcRouterDisableInternetConnectionCmd() *cobra.Command {
 		Short:        "Enable internet connection from VPCRouter",
 		Long:         `Enable internet connection from VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDisableInternetConnectionParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDisableInternetConnectionParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDisableInternetConnectionParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -991,12 +991,12 @@ func vpcRouterInterfaceInfoCmd() *cobra.Command {
 		Short:        "Show information of NIC(s) connected to vpc-router",
 		Long:         `Show information of NIC(s) connected to vpc-router`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterInterfaceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterInterfaceInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterInterfaceInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1061,12 +1061,12 @@ func vpcRouterInterfaceConnectCmd() *cobra.Command {
 		Short:        "Connected to switch",
 		Long:         `Connected to switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterInterfaceConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterInterfaceConnectParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterInterfaceConnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1143,12 +1143,12 @@ func vpcRouterInterfaceUpdateCmd() *cobra.Command {
 		Short:        "Update interface",
 		Long:         `Update interface`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterInterfaceUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterInterfaceUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterInterfaceUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1226,12 +1226,12 @@ func vpcRouterInterfaceDisconnectCmd() *cobra.Command {
 		Short:        "Disconnected to switch",
 		Long:         `Disconnected to switch`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterInterfaceDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterInterfaceDisconnectParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterInterfaceDisconnectParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1303,12 +1303,12 @@ func vpcRouterStaticNatInfoCmd() *cobra.Command {
 		Short:        "Show information of static NAT settings",
 		Long:         `Show information of static NAT settings`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticNatInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticNatInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticNatInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1373,12 +1373,12 @@ func vpcRouterStaticNatAddCmd() *cobra.Command {
 		Short:        "Add static NAT",
 		Long:         `Add static NAT`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticNatAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticNatAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticNatAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1451,12 +1451,12 @@ func vpcRouterStaticNatUpdateCmd() *cobra.Command {
 		Short:        "Update static NAT",
 		Long:         `Update static NAT`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticNatUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticNatUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticNatUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1530,12 +1530,12 @@ func vpcRouterStaticNatDeleteCmd() *cobra.Command {
 		Short:        "Delete static NAT",
 		Long:         `Delete static NAT`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticNatDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticNatDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticNatDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1606,12 +1606,12 @@ func vpcRouterPortForwardingInfoCmd() *cobra.Command {
 		Short:        "Show information of port-forwarding settings",
 		Long:         `Show information of port-forwarding settings`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterPortForwardingInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterPortForwardingInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterPortForwardingInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1676,12 +1676,12 @@ func vpcRouterPortForwardingAddCmd() *cobra.Command {
 		Short:        "Add port forwarding",
 		Long:         `Add port forwarding`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterPortForwardingAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterPortForwardingAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterPortForwardingAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1756,12 +1756,12 @@ func vpcRouterPortForwardingUpdateCmd() *cobra.Command {
 		Short:        "Update port forwarding",
 		Long:         `Update port forwarding`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterPortForwardingUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterPortForwardingUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterPortForwardingUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1837,12 +1837,12 @@ func vpcRouterPortForwardingDeleteCmd() *cobra.Command {
 		Short:        "Delete port forwarding",
 		Long:         `Delete port forwarding`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterPortForwardingDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterPortForwardingDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterPortForwardingDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1913,12 +1913,12 @@ func vpcRouterFirewallInfoCmd() *cobra.Command {
 		Short:        "Show information of firewall rules",
 		Long:         `Show information of firewall rules`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterFirewallInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterFirewallInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterFirewallInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -1985,12 +1985,12 @@ func vpcRouterFirewallAddCmd() *cobra.Command {
 		Short:        "Add firewall rule",
 		Long:         `Add firewall rule`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterFirewallAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterFirewallAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterFirewallAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2070,12 +2070,12 @@ func vpcRouterFirewallUpdateCmd() *cobra.Command {
 		Short:        "Update firewall rule",
 		Long:         `Update firewall rule`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterFirewallUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterFirewallUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterFirewallUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2156,12 +2156,12 @@ func vpcRouterFirewallDeleteCmd() *cobra.Command {
 		Short:        "Delete firewall rule",
 		Long:         `Delete firewall rule`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterFirewallDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterFirewallDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterFirewallDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2234,12 +2234,12 @@ func vpcRouterDhcpServerInfoCmd() *cobra.Command {
 		Short:        "Show information of DHCP servers",
 		Long:         `Show information of DHCP servers`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpServerInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2304,12 +2304,12 @@ func vpcRouterDhcpServerAddCmd() *cobra.Command {
 		Short:        "Add DHCP server",
 		Long:         `Add DHCP server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpServerAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpServerAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2383,12 +2383,12 @@ func vpcRouterDhcpServerUpdateCmd() *cobra.Command {
 		Short:        "Update DHCP server",
 		Long:         `Update DHCP server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpServerUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2462,12 +2462,12 @@ func vpcRouterDhcpServerDeleteCmd() *cobra.Command {
 		Short:        "Delete DHCP server",
 		Long:         `Delete DHCP server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpServerDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpServerDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2538,12 +2538,12 @@ func vpcRouterDhcpStaticMappingInfoCmd() *cobra.Command {
 		Short:        "Show information of DHCP static mapping",
 		Long:         `Show information of DHCP static mapping`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpStaticMappingInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpStaticMappingInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpStaticMappingInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2608,12 +2608,12 @@ func vpcRouterDhcpStaticMappingAddCmd() *cobra.Command {
 		Short:        "Add DHCP static mapping",
 		Long:         `Add DHCP static mapping`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpStaticMappingAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpStaticMappingAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpStaticMappingAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2685,12 +2685,12 @@ func vpcRouterDhcpStaticMappingUpdateCmd() *cobra.Command {
 		Short:        "Update DHCP static mapping",
 		Long:         `Update DHCP static mapping`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpStaticMappingUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpStaticMappingUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpStaticMappingUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2763,12 +2763,12 @@ func vpcRouterDhcpStaticMappingDeleteCmd() *cobra.Command {
 		Short:        "Delete DHCP static mapping",
 		Long:         `Delete DHCP static mapping`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterDhcpStaticMappingDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterDhcpStaticMappingDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterDhcpStaticMappingDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2839,12 +2839,12 @@ func vpcRouterPptpServerInfoCmd() *cobra.Command {
 		Short:        "Show information of PPTP server",
 		Long:         `Show information of PPTP server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterPptpServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterPptpServerInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterPptpServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2909,12 +2909,12 @@ func vpcRouterPptpServerUpdateCmd() *cobra.Command {
 		Short:        "Update PPTP server setting",
 		Long:         `Update PPTP server setting`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterPptpServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterPptpServerUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterPptpServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -2987,12 +2987,12 @@ func vpcRouterL2TPServerInfoCmd() *cobra.Command {
 		Short:        "Show information of L2TP/IPSec server",
 		Long:         `Show information of L2TP/IPSec server`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterL2TPServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterL2TPServerInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterL2TPServerInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3057,12 +3057,12 @@ func vpcRouterL2TPServerUpdateCmd() *cobra.Command {
 		Short:        "Update L2TP/IPSec server setting",
 		Long:         `Update L2TP/IPSec server setting`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterL2TPServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterL2TPServerUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterL2TPServerUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3136,12 +3136,12 @@ func vpcRouterUserInfoCmd() *cobra.Command {
 		Short:        "Show information of remote-access users",
 		Long:         `Show information of remote-access users`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterUserInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterUserInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterUserInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3206,12 +3206,12 @@ func vpcRouterUserAddCmd() *cobra.Command {
 		Short:        "Add remote-access user",
 		Long:         `Add remote-access user`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterUserAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterUserAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterUserAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3283,12 +3283,12 @@ func vpcRouterUserUpdateCmd() *cobra.Command {
 		Short:        "Update remote-access user",
 		Long:         `Update remote-access user`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterUserUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterUserUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterUserUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3361,12 +3361,12 @@ func vpcRouterUserDeleteCmd() *cobra.Command {
 		Short:        "Delete remote-access user",
 		Long:         `Delete remote-access user`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterUserDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterUserDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterUserDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3437,12 +3437,12 @@ func vpcRouterSiteToSiteVPNInfoCmd() *cobra.Command {
 		Short:        "Show information of site-to-site IPSec VPN settings",
 		Long:         `Show information of site-to-site IPSec VPN settings`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterSiteToSiteVPNInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterSiteToSiteVPNInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterSiteToSiteVPNInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3507,12 +3507,12 @@ func vpcRouterSiteToSiteVPNAddCmd() *cobra.Command {
 		Short:        "Add site-to-site IPSec VPN setting",
 		Long:         `Add site-to-site IPSec VPN setting`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterSiteToSiteVPNAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterSiteToSiteVPNAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterSiteToSiteVPNAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3587,12 +3587,12 @@ func vpcRouterSiteToSiteVPNUpdateCmd() *cobra.Command {
 		Short:        "Update site-to-site IPSec VPN setting",
 		Long:         `Update site-to-site IPSec VPN setting`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterSiteToSiteVPNUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterSiteToSiteVPNUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterSiteToSiteVPNUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3668,12 +3668,12 @@ func vpcRouterSiteToSiteVPNDeleteCmd() *cobra.Command {
 		Short:        "Delete site-to-site IPSec VPN setting",
 		Long:         `Delete site-to-site IPSec VPN setting`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterSiteToSiteVPNDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterSiteToSiteVPNDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterSiteToSiteVPNDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3744,12 +3744,12 @@ func vpcRouterSiteToSiteVPNPeersCmd() *cobra.Command {
 		Short:        "Show status of site-to-site IPSec VPN peers",
 		Long:         `Show status of site-to-site IPSec VPN peers`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterSiteToSiteVPNPeersParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterSiteToSiteVPNPeersParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterSiteToSiteVPNPeersParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3814,12 +3814,12 @@ func vpcRouterStaticRouteInfoCmd() *cobra.Command {
 		Short:        "Show information of static-routes",
 		Long:         `Show information of static-routes`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticRouteInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticRouteInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticRouteInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3884,12 +3884,12 @@ func vpcRouterStaticRouteAddCmd() *cobra.Command {
 		Short:        "Add static-route",
 		Long:         `Add static-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticRouteAddParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticRouteAddParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticRouteAddParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -3961,12 +3961,12 @@ func vpcRouterStaticRouteUpdateCmd() *cobra.Command {
 		Short:        "Update static-route",
 		Long:         `Update static-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticRouteUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticRouteUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticRouteUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -4039,12 +4039,12 @@ func vpcRouterStaticRouteDeleteCmd() *cobra.Command {
 		Short:        "Delete static-route",
 		Long:         `Delete static-route`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterStaticRouteDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterStaticRouteDeleteParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterStaticRouteDeleteParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -4115,12 +4115,12 @@ func vpcRouterMonitorCmd() *cobra.Command {
 		Short:        "Monitor VPCRouter",
 		Long:         `Monitor VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterMonitorParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterMonitorParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -4189,12 +4189,12 @@ func vpcRouterLogsCmd() *cobra.Command {
 		Short:        "Logs VPCRouter",
 		Long:         `Logs VPCRouter`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return vpcRouterLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, vpcRouterLogsParam)
 			if err != nil {
+				return err
+			}
+			if err := vpcRouterLogsParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_web_accel_gen.go
+++ b/pkg/cmd/zz_web_accel_gen.go
@@ -49,12 +49,12 @@ func webAccelListCmd() *cobra.Command {
 		Short:        "List WebAccel",
 		Long:         `List WebAccel`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return webAccelListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, webAccelListParam)
 			if err != nil {
+				return err
+			}
+			if err := webAccelListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -96,12 +96,12 @@ func webAccelReadCmd() *cobra.Command {
 		Short:        "Read WebAccel",
 		Long:         `Read WebAccel`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return webAccelReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, webAccelReadParam)
 			if err != nil {
+				return err
+			}
+			if err := webAccelReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -166,12 +166,12 @@ func webAccelCertificateInfoCmd() *cobra.Command {
 		Short:        "CertificateInfo WebAccel",
 		Long:         `CertificateInfo WebAccel`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return webAccelCertificateInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, webAccelCertificateInfoParam)
 			if err != nil {
+				return err
+			}
+			if err := webAccelCertificateInfoParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -236,12 +236,12 @@ func webAccelCertificateNewCmd() *cobra.Command {
 		Short:        "CertificateNew WebAccel",
 		Long:         `CertificateNew WebAccel`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return webAccelCertificateNewParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, webAccelCertificateNewParam)
 			if err != nil {
+				return err
+			}
+			if err := webAccelCertificateNewParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -322,12 +322,12 @@ func webAccelCertificateUpdateCmd() *cobra.Command {
 		Short:        "CertificateUpdate WebAccel",
 		Long:         `CertificateUpdate WebAccel`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return webAccelCertificateUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, webAccelCertificateUpdateParam)
 			if err != nil {
+				return err
+			}
+			if err := webAccelCertificateUpdateParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -408,12 +408,12 @@ func webAccelDeleteCacheCmd() *cobra.Command {
 		Short:        "DeleteCache WebAccel",
 		Long:         `DeleteCache WebAccel`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return webAccelDeleteCacheParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, webAccelDeleteCacheParam)
 			if err != nil {
+				return err
+			}
+			if err := webAccelDeleteCacheParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/zz_zone_gen.go
+++ b/pkg/cmd/zz_zone_gen.go
@@ -48,12 +48,12 @@ func zoneListCmd() *cobra.Command {
 		Short:        "List Zone (default)",
 		Long:         `List Zone (default)`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return zoneListParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, zoneListParam)
 			if err != nil {
+				return err
+			}
+			if err := zoneListParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 
@@ -100,12 +100,12 @@ func zoneReadCmd() *cobra.Command {
 		Short:        "Read Zone",
 		Long:         `Read Zone`,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return zoneReadParam.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, zoneReadParam)
 			if err != nil {
+				return err
+			}
+			if err := zoneReadParam.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/pkg/funcs/archive_create.go
+++ b/pkg/funcs/archive_create.go
@@ -74,6 +74,7 @@ func ArchiveCreate(ctx cli.Context, params *params.CreateArchiveParam) error {
 			fmt.Sprintf("Still uploading[ID:%d]...", res.ID),
 			fmt.Sprintf("Upload archive[ID:%d]", res.ID),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 
 				file, df, err := fileOrStdin(params.GetArchiveFile())
@@ -112,6 +113,7 @@ func ArchiveCreate(ctx cli.Context, params *params.CreateArchiveParam) error {
 			fmt.Sprintf("Still copying[ID:%d]...", res.ID),
 			fmt.Sprintf("Copy archive[ID:%d]", res.ID),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				err = api.SleepWhileCopying(res.ID, client.DefaultTimeoutDuration)
 				if err != nil {

--- a/pkg/funcs/archive_download.go
+++ b/pkg/funcs/archive_download.go
@@ -57,6 +57,7 @@ func ArchiveDownload(ctx cli.Context, params *params.DownloadArchiveParam) error
 		fmt.Sprintf("Still downloading[ID:%d]...", params.Id),
 		fmt.Sprintf("Download archive[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			path := params.FileDestination
 			if path == "" || path == "-" {

--- a/pkg/funcs/archive_upload.go
+++ b/pkg/funcs/archive_upload.go
@@ -45,6 +45,7 @@ func ArchiveUpload(ctx cli.Context, params *params.UploadArchiveParam) error {
 		fmt.Sprintf("Still uploading[ID:%d]...", params.Id),
 		fmt.Sprintf("Upload archive[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			file, df, err := fileOrStdin(params.GetArchiveFile())
 			if err != nil {

--- a/pkg/funcs/archive_wait_for_copy.go
+++ b/pkg/funcs/archive_wait_for_copy.go
@@ -36,6 +36,7 @@ func ArchiveWaitForCopy(ctx cli.Context, params *params.WaitForCopyArchiveParam)
 		fmt.Sprintf("Still copying[ID:%d]...", params.Id),
 		fmt.Sprintf("Copy archive[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			err := api.SleepWhileCopying(p.ID, client.DefaultTimeoutDuration)
 			if err != nil {

--- a/pkg/funcs/config_edit.go
+++ b/pkg/funcs/config_edit.go
@@ -36,6 +36,7 @@ func ConfigEdit(ctx cli.Context, params *params.EditConfigParam) error {
 	needAsk := inputParams.IsEmpty()
 	in := ctx.IO().In()
 	out := ctx.IO().Out()
+	printer := printer.Printer{NoColor: ctx.Option().NoColor}
 
 	// load current config file
 	profileName := ""

--- a/pkg/funcs/config_use.go
+++ b/pkg/funcs/config_use.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/sacloud/usacloud/pkg/cli"
-	"github.com/sacloud/usacloud/pkg/helper/printer"
 	"github.com/sacloud/usacloud/pkg/params"
 	"github.com/sacloud/usacloud/pkg/profile"
 )
@@ -35,6 +34,6 @@ func ConfigUse(ctx cli.Context, params *params.UseConfigParam) error {
 		return err
 	}
 
-	printer.Fprintf(ctx.IO().Out(), color.New(color.FgHiGreen), "\nCurrent profile: %q\n", profileName)
+	color.New(color.FgHiGreen).Fprintf(ctx.IO().Out(), "\nCurrent profile: %q\n", profileName)
 	return nil
 }

--- a/pkg/funcs/database_backup_create.go
+++ b/pkg/funcs/database_backup_create.go
@@ -40,6 +40,7 @@ func DatabaseBackupCreate(ctx cli.Context, params *params.BackupCreateDatabasePa
 		fmt.Sprintf("Still creating backup[ID:%d]...", params.Id),
 		fmt.Sprintf("Backup Database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Backup(params.Id)

--- a/pkg/funcs/database_backup_restore.go
+++ b/pkg/funcs/database_backup_restore.go
@@ -49,6 +49,7 @@ func DatabaseBackupRestore(ctx cli.Context, params *params.BackupRestoreDatabase
 		fmt.Sprintf("Still restoring from backup[ID:%d:%s]...", params.Id, backupID),
 		fmt.Sprintf("Restore Database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Restore(params.Id, backupID)

--- a/pkg/funcs/database_boot.go
+++ b/pkg/funcs/database_boot.go
@@ -39,6 +39,7 @@ func DatabaseBoot(ctx cli.Context, params *params.BootDatabaseParam) error {
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Boot(params.Id)

--- a/pkg/funcs/database_clone.go
+++ b/pkg/funcs/database_clone.go
@@ -92,6 +92,7 @@ func DatabaseClone(ctx cli.Context, params *params.CloneDatabaseParam) error {
 		fmt.Sprintf("Still cloning[ID:%d]...", res.ID),
 		fmt.Sprintf("Clone database[ID:%d]", res.ID),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepWhileCopying(res.ID, client.DefaultTimeoutDuration, 20)

--- a/pkg/funcs/database_create.go
+++ b/pkg/funcs/database_create.go
@@ -93,6 +93,7 @@ func DatabaseCreate(ctx cli.Context, params *params.CreateDatabaseParam) error {
 		fmt.Sprintf("Still creating[ID:%d]...", res.ID),
 		fmt.Sprintf("Create database[ID:%d]", res.ID),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepWhileCopying(res.ID, client.DefaultTimeoutDuration, 20)

--- a/pkg/funcs/database_delete.go
+++ b/pkg/funcs/database_delete.go
@@ -38,6 +38,7 @@ func DatabaseDelete(ctx cli.Context, params *params.DeleteDatabaseParam) error {
 				fmt.Sprintf("Still waiting for delete[ID:%d]...", params.Id),
 				fmt.Sprintf("Delete database[ID:%d]", params.Id),
 				ctx.IO().Progress(),
+				ctx.Option().NoColor,
 				func(compChan chan bool, errChan chan error) {
 					// call manipurate functions
 					var err error

--- a/pkg/funcs/database_logs.go
+++ b/pkg/funcs/database_logs.go
@@ -46,6 +46,7 @@ func DatabaseLogs(ctx cli.Context, params *params.LogsDatabaseParam) error {
 
 	logBuf := internal.NewHashQueue(500)
 	out := ctx.IO().Out()
+	printer := printer.Printer{NoColor: ctx.Option().NoColor}
 
 	for {
 		// call Read(id)

--- a/pkg/funcs/database_replica_create.go
+++ b/pkg/funcs/database_replica_create.go
@@ -87,6 +87,7 @@ func DatabaseReplicaCreate(ctx cli.Context, params *params.ReplicaCreateDatabase
 		fmt.Sprintf("Still creating[ID:%d]...", res.ID),
 		fmt.Sprintf("Create replica database[ID:%d]", res.ID),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepWhileCopying(res.ID, client.DefaultTimeoutDuration, 20)

--- a/pkg/funcs/database_reset.go
+++ b/pkg/funcs/database_reset.go
@@ -36,6 +36,7 @@ func DatabaseReset(ctx cli.Context, params *params.ResetDatabaseParam) error {
 		fmt.Sprintf("Still resetting[ID:%d]...", params.Id),
 		fmt.Sprintf("Reset database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.RebootForce(params.Id)

--- a/pkg/funcs/database_shutdown.go
+++ b/pkg/funcs/database_shutdown.go
@@ -39,6 +39,7 @@ func DatabaseShutdown(ctx cli.Context, params *params.ShutdownDatabaseParam) err
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/database_shutdown_force.go
+++ b/pkg/funcs/database_shutdown_force.go
@@ -39,6 +39,7 @@ func DatabaseShutdownForce(ctx cli.Context, params *params.ShutdownForceDatabase
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/database_wait_for_boot.go
+++ b/pkg/funcs/database_wait_for_boot.go
@@ -39,6 +39,7 @@ func DatabaseWaitForBoot(ctx cli.Context, params *params.WaitForBootDatabasePara
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/database_wait_for_down.go
+++ b/pkg/funcs/database_wait_for_down.go
@@ -39,6 +39,7 @@ func DatabaseWaitForDown(ctx cli.Context, params *params.WaitForDownDatabasePara
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown database[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilDown(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/disk_create.go
+++ b/pkg/funcs/disk_create.go
@@ -53,6 +53,7 @@ func DiskCreate(ctx cli.Context, params *params.CreateDiskParam) error {
 		"Still creating...",
 		"Create disk",
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call Create(id)
 			res, err = api.Create(p)

--- a/pkg/funcs/disk_edit.go
+++ b/pkg/funcs/disk_edit.go
@@ -35,6 +35,7 @@ func DiskEdit(ctx cli.Context, params *params.EditDiskParam) error {
 		fmt.Sprintf("Still editing[ID:%d]...", params.Id),
 		fmt.Sprintf("Edit disk[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Config(params.Id, p)

--- a/pkg/funcs/disk_reinstall_from_archive.go
+++ b/pkg/funcs/disk_reinstall_from_archive.go
@@ -35,6 +35,7 @@ func DiskReinstallFromArchive(ctx cli.Context, params *params.ReinstallFromArchi
 		fmt.Sprintf("Still installing[ID:%d]...", params.Id),
 		fmt.Sprintf("Reinstall disk[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			_, err := api.ReinstallFromArchive(params.Id, params.SourceArchiveId, params.DistantFrom...)
 			if err != nil {

--- a/pkg/funcs/disk_reinstall_from_disk.go
+++ b/pkg/funcs/disk_reinstall_from_disk.go
@@ -35,6 +35,7 @@ func DiskReinstallFromDisk(ctx cli.Context, params *params.ReinstallFromDiskDisk
 		fmt.Sprintf("Still installing[ID:%d]...", params.Id),
 		fmt.Sprintf("Reinstall disk[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			_, err := api.ReinstallFromDisk(params.Id, params.SourceDiskId, params.DistantFrom...)
 			if err != nil {

--- a/pkg/funcs/disk_reinstall_to_blank.go
+++ b/pkg/funcs/disk_reinstall_to_blank.go
@@ -35,6 +35,7 @@ func DiskReinstallToBlank(ctx cli.Context, params *params.ReinstallToBlankDiskPa
 		fmt.Sprintf("Still installing[ID:%d]...", params.Id),
 		fmt.Sprintf("Reinstall disk[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			_, err := api.ReinstallFromBlank(params.Id, p.SizeMB)
 			if err != nil {

--- a/pkg/funcs/disk_resize_partition.go
+++ b/pkg/funcs/disk_resize_partition.go
@@ -32,6 +32,7 @@ func DiskResizePartition(ctx cli.Context, params *params.ResizePartitionDiskPara
 		fmt.Sprintf("Still resizing[ID:%d]...", params.Id),
 		fmt.Sprintf("Resize-Partition disk[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.ResizePartitionBackground(params.Id)

--- a/pkg/funcs/disk_wait_for_copy.go
+++ b/pkg/funcs/disk_wait_for_copy.go
@@ -36,6 +36,7 @@ func DiskWaitForCopy(ctx cli.Context, params *params.WaitForCopyDiskParam) error
 		fmt.Sprintf("Still copying[ID:%d]...", params.Id),
 		fmt.Sprintf("Copy disk[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			err := api.SleepWhileCopying(p.ID, client.DefaultTimeoutDuration)
 			if err != nil {

--- a/pkg/funcs/internet_subnet_add.go
+++ b/pkg/funcs/internet_subnet_add.go
@@ -36,6 +36,7 @@ func InternetSubnetAdd(ctx cli.Context, params *params.SubnetAddInternetParam) e
 		"Still creating...",
 		"Add subnet",
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			subnet, err := api.AddSubnet(params.Id, params.NwMasklen, params.NextHop)
 			if err != nil {

--- a/pkg/funcs/internet_subnet_delete.go
+++ b/pkg/funcs/internet_subnet_delete.go
@@ -35,6 +35,7 @@ func InternetSubnetDelete(ctx cli.Context, params *params.SubnetDeleteInternetPa
 		fmt.Sprintf("Still deleting[ID:%d]...", params.SubnetId),
 		fmt.Sprintf("Delete subnet[ID:%d]", params.SubnetId),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			_, err := api.DeleteSubnet(params.Id, params.SubnetId)
 			if err != nil {

--- a/pkg/funcs/internet_subnet_update.go
+++ b/pkg/funcs/internet_subnet_update.go
@@ -36,6 +36,7 @@ func InternetSubnetUpdate(ctx cli.Context, params *params.SubnetUpdateInternetPa
 		fmt.Sprintf("Still updating[ID:%d]...", params.SubnetId),
 		fmt.Sprintf("Update subnet[ID:%d]", params.SubnetId),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			subnet, err := api.UpdateSubnet(params.Id, params.SubnetId, params.NextHop)
 			if err != nil {

--- a/pkg/funcs/iso_image_create.go
+++ b/pkg/funcs/iso_image_create.go
@@ -49,6 +49,7 @@ func ISOImageCreate(ctx cli.Context, params *params.CreateISOImageParam) error {
 		fmt.Sprintf("Still uploading[ID:%d]...", res.ID),
 		fmt.Sprintf("Upload iso-image[ID:%d]", res.ID),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 
 			file, df, err := fileOrStdin(params.GetISOFile())

--- a/pkg/funcs/iso_image_download.go
+++ b/pkg/funcs/iso_image_download.go
@@ -57,6 +57,7 @@ func ISOImageDownload(ctx cli.Context, params *params.DownloadISOImageParam) err
 		fmt.Sprintf("Still downloading[ID:%d]...", params.Id),
 		fmt.Sprintf("Download iso-image[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			path := params.FileDestination
 			if path == "" || path == "-" {

--- a/pkg/funcs/iso_image_upload.go
+++ b/pkg/funcs/iso_image_upload.go
@@ -44,6 +44,7 @@ func ISOImageUpload(ctx cli.Context, params *params.UploadISOImageParam) error {
 		fmt.Sprintf("Still uploading[ID:%d]...", params.Id),
 		fmt.Sprintf("Upload iso-image[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 
 			file, df, err := fileOrStdin(params.GetISOFile())

--- a/pkg/funcs/load_balancer_boot.go
+++ b/pkg/funcs/load_balancer_boot.go
@@ -39,6 +39,7 @@ func LoadBalancerBoot(ctx cli.Context, params *params.BootLoadBalancerParam) err
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot load-balancer[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Boot(params.Id)

--- a/pkg/funcs/load_balancer_create.go
+++ b/pkg/funcs/load_balancer_create.go
@@ -83,6 +83,7 @@ func LoadBalancerCreate(ctx cli.Context, params *params.CreateLoadBalancerParam)
 		fmt.Sprintf("Still creating[ID:%d]...", res.ID),
 		fmt.Sprintf("Create load-balancer[ID:%d]", res.ID),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepWhileCopying(res.ID, client.DefaultTimeoutDuration, 20)

--- a/pkg/funcs/load_balancer_delete.go
+++ b/pkg/funcs/load_balancer_delete.go
@@ -39,6 +39,7 @@ func LoadBalancerDelete(ctx cli.Context, params *params.DeleteLoadBalancerParam)
 				fmt.Sprintf("Still waiting for delete[ID:%d]...", params.Id),
 				fmt.Sprintf("Delete load-balancer[ID:%d]", params.Id),
 				ctx.IO().Progress(),
+				ctx.Option().NoColor,
 				func(compChan chan bool, errChan chan error) {
 					// call manipurate functions
 					var err error

--- a/pkg/funcs/load_balancer_reset.go
+++ b/pkg/funcs/load_balancer_reset.go
@@ -35,6 +35,7 @@ func LoadBalancerReset(ctx cli.Context, params *params.ResetLoadBalancerParam) e
 		fmt.Sprintf("Still resetting[ID:%d]...", params.Id),
 		fmt.Sprintf("Reset load-balancer[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.RebootForce(params.Id)

--- a/pkg/funcs/load_balancer_shutdown.go
+++ b/pkg/funcs/load_balancer_shutdown.go
@@ -39,6 +39,7 @@ func LoadBalancerShutdown(ctx cli.Context, params *params.ShutdownLoadBalancerPa
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown load-balancer[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/load_balancer_shutdown_force.go
+++ b/pkg/funcs/load_balancer_shutdown_force.go
@@ -39,6 +39,7 @@ func LoadBalancerShutdownForce(ctx cli.Context, params *params.ShutdownForceLoad
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown load-balancer[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/load_balancer_wait_for_boot.go
+++ b/pkg/funcs/load_balancer_wait_for_boot.go
@@ -39,6 +39,7 @@ func LoadBalancerWaitForBoot(ctx cli.Context, params *params.WaitForBootLoadBala
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot load-balancer[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/load_balancer_wait_for_down.go
+++ b/pkg/funcs/load_balancer_wait_for_down.go
@@ -39,6 +39,7 @@ func LoadBalancerWaitForDown(ctx cli.Context, params *params.WaitForDownLoadBala
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown load-balancer[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilDown(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/mobile_gateway_boot.go
+++ b/pkg/funcs/mobile_gateway_boot.go
@@ -39,6 +39,7 @@ func MobileGatewayBoot(ctx cli.Context, params *params.BootMobileGatewayParam) e
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot mobile-gateway[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Boot(params.Id)

--- a/pkg/funcs/mobile_gateway_create.go
+++ b/pkg/funcs/mobile_gateway_create.go
@@ -57,6 +57,7 @@ func MobileGatewayCreate(ctx cli.Context, params *params.CreateMobileGatewayPara
 		fmt.Sprintf("Still creating..."),
 		fmt.Sprintf("Create mobile-gateway"),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			// call Create(id)

--- a/pkg/funcs/mobile_gateway_delete.go
+++ b/pkg/funcs/mobile_gateway_delete.go
@@ -39,6 +39,7 @@ func MobileGatewayDelete(ctx cli.Context, params *params.DeleteMobileGatewayPara
 				fmt.Sprintf("Still waiting for delete[ID:%d]...", params.Id),
 				fmt.Sprintf("Delete mobile-gateway[ID:%d]", params.Id),
 				ctx.IO().Progress(),
+				ctx.Option().NoColor,
 				func(compChan chan bool, errChan chan error) {
 					// call manipurate functions
 					var err error

--- a/pkg/funcs/mobile_gateway_reset.go
+++ b/pkg/funcs/mobile_gateway_reset.go
@@ -35,6 +35,7 @@ func MobileGatewayReset(ctx cli.Context, params *params.ResetMobileGatewayParam)
 		fmt.Sprintf("Still resetting[ID:%d]...", params.Id),
 		fmt.Sprintf("Reset mobile-gateway[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.RebootForce(params.Id)

--- a/pkg/funcs/mobile_gateway_shutdown.go
+++ b/pkg/funcs/mobile_gateway_shutdown.go
@@ -39,6 +39,7 @@ func MobileGatewayShutdown(ctx cli.Context, params *params.ShutdownMobileGateway
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown mobile-gateway[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/mobile_gateway_shutdown_force.go
+++ b/pkg/funcs/mobile_gateway_shutdown_force.go
@@ -39,6 +39,7 @@ func MobileGatewayShutdownForce(ctx cli.Context, params *params.ShutdownForceMob
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown mobile-gateway[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/mobile_gateway_wait_for_boot.go
+++ b/pkg/funcs/mobile_gateway_wait_for_boot.go
@@ -39,6 +39,7 @@ func MobileGatewayWaitForBoot(ctx cli.Context, params *params.WaitForBootMobileG
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot mobile-gateway[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/mobile_gateway_wait_for_down.go
+++ b/pkg/funcs/mobile_gateway_wait_for_down.go
@@ -39,6 +39,7 @@ func MobileGatewayWaitForDown(ctx cli.Context, params *params.WaitForDownMobileG
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown mobile-gateway[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilDown(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/nfs_boot.go
+++ b/pkg/funcs/nfs_boot.go
@@ -39,6 +39,7 @@ func NFSBoot(ctx cli.Context, params *params.BootNFSParam) error {
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot nfs[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Boot(params.Id)

--- a/pkg/funcs/nfs_create.go
+++ b/pkg/funcs/nfs_create.go
@@ -60,6 +60,7 @@ func NFSCreate(ctx cli.Context, params *params.CreateNFSParam) error {
 		fmt.Sprintf("Still creating[ID:%d]...", res.ID),
 		fmt.Sprintf("Create nfs[ID:%d]", res.ID),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepWhileCopying(res.ID, client.DefaultTimeoutDuration, 20)

--- a/pkg/funcs/nfs_delete.go
+++ b/pkg/funcs/nfs_delete.go
@@ -39,6 +39,7 @@ func NFSDelete(ctx cli.Context, params *params.DeleteNFSParam) error {
 				fmt.Sprintf("Still waiting for delete[ID:%d]...", params.Id),
 				fmt.Sprintf("Delete nfs[ID:%d]", params.Id),
 				ctx.IO().Progress(),
+				ctx.Option().NoColor,
 				func(compChan chan bool, errChan chan error) {
 					// call manipurate functions
 					var err error

--- a/pkg/funcs/nfs_reset.go
+++ b/pkg/funcs/nfs_reset.go
@@ -35,6 +35,7 @@ func NFSReset(ctx cli.Context, params *params.ResetNFSParam) error {
 		fmt.Sprintf("Still resetting[ID:%d]...", params.Id),
 		fmt.Sprintf("Reset nfs[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.RebootForce(params.Id)

--- a/pkg/funcs/nfs_shutdown.go
+++ b/pkg/funcs/nfs_shutdown.go
@@ -39,6 +39,7 @@ func NFSShutdown(ctx cli.Context, params *params.ShutdownNFSParam) error {
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown nfs[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/nfs_shutdown_force.go
+++ b/pkg/funcs/nfs_shutdown_force.go
@@ -39,6 +39,7 @@ func NFSShutdownForce(ctx cli.Context, params *params.ShutdownForceNFSParam) err
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown nfs[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/nfs_wait_for_boot.go
+++ b/pkg/funcs/nfs_wait_for_boot.go
@@ -39,6 +39,7 @@ func NFSWaitForBoot(ctx cli.Context, params *params.WaitForBootNFSParam) error {
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot nfs[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/nfs_wait_for_down.go
+++ b/pkg/funcs/nfs_wait_for_down.go
@@ -39,6 +39,7 @@ func NFSWaitForDown(ctx cli.Context, params *params.WaitForDownNFSParam) error {
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown nfs[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilDown(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/object_storage_put.go
+++ b/pkg/funcs/object_storage_put.go
@@ -134,6 +134,7 @@ func ObjectStoragePut(ctx cli.Context, params *params.PutObjectStorageParam) err
 		fmt.Sprintf("Still uploading[%q]...", progressLabel),
 		fmt.Sprintf("Upload [%q]", progressLabel),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			if err := putFunc(); err != nil {
 				errChan <- err

--- a/pkg/funcs/server_boot.go
+++ b/pkg/funcs/server_boot.go
@@ -42,6 +42,7 @@ func ServerBoot(ctx cli.Context, params *params.BootServerParam) error {
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot server[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			errCount := 0

--- a/pkg/funcs/server_build.go
+++ b/pkg/funcs/server_build.go
@@ -265,7 +265,8 @@ func handleDiskEvents(sb serverBuilder, ctx cli.Context, params *params.BuildSer
 		progCreate := internal.NewProgress(
 			"Still creating disk...",
 			"Create disk",
-			ctx.IO().Progress())
+			ctx.IO().Progress(),
+			ctx.Option().NoColor)
 		sb.SetDiskEventHandler(builder.DiskBuildOnCreateDiskBefore, func(value *builder.DiskBuildValue, result *builder.DiskBuildResult) {
 			progCreate.Start()
 		})
@@ -277,7 +278,8 @@ func handleDiskEvents(sb serverBuilder, ctx cli.Context, params *params.BuildSer
 		progCleanupNotes := internal.NewProgress(
 			"Still cleaning StartupScript...",
 			"Cleanup StartupScript",
-			ctx.IO().Progress())
+			ctx.IO().Progress(),
+			ctx.Option().NoColor)
 		sb.SetDiskEventHandler(builder.DiskBuildOnCleanupNoteBefore, func(value *builder.DiskBuildValue, result *builder.DiskBuildResult) {
 			progCleanupNotes.Start()
 		})
@@ -289,7 +291,8 @@ func handleDiskEvents(sb serverBuilder, ctx cli.Context, params *params.BuildSer
 		progCleanupSSHKey := internal.NewProgress(
 			"Still cleaning SSHKey...",
 			"Cleanup SSHKey",
-			ctx.IO().Progress())
+			ctx.IO().Progress(),
+			ctx.Option().NoColor)
 		sb.SetDiskEventHandler(builder.DiskBuildOnCleanupSSHKeyBefore, func(value *builder.DiskBuildValue, result *builder.DiskBuildResult) {
 			progCleanupSSHKey.Start()
 		})
@@ -307,7 +310,8 @@ func handleServerEvents(sb serverBuilder, ctx cli.Context, params *params.BuildS
 		progCreate := internal.NewProgress(
 			"Still creating server...",
 			"Create server",
-			ctx.IO().Progress())
+			ctx.IO().Progress(),
+			ctx.Option().NoColor)
 
 		sb.SetEventHandler(builder.ServerBuildOnCreateServerBefore, func(value *builder.ServerBuildValue, result *builder.ServerBuildResult) {
 			progCreate.Start()
@@ -319,7 +323,8 @@ func handleServerEvents(sb serverBuilder, ctx cli.Context, params *params.BuildS
 		progBoot := internal.NewProgress(
 			"Still booting server...",
 			"Boot server",
-			ctx.IO().Progress())
+			ctx.IO().Progress(),
+			ctx.Option().NoColor)
 
 		sb.SetEventHandler(builder.ServerBuildOnBootBefore, func(value *builder.ServerBuildValue, result *builder.ServerBuildResult) {
 			progBoot.Start()

--- a/pkg/funcs/server_delete.go
+++ b/pkg/funcs/server_delete.go
@@ -41,6 +41,7 @@ func ServerDelete(ctx cli.Context, params *params.DeleteServerParam) error {
 				fmt.Sprintf("Still waiting for Delete[ID:%d]...", params.Id),
 				fmt.Sprintf("Delete server[ID:%d]", params.Id),
 				ctx.IO().Progress(),
+				ctx.Option().NoColor,
 				func(compChan chan bool, errChan chan error) {
 					// call manipurate functions
 					var err error

--- a/pkg/funcs/server_iso_insert.go
+++ b/pkg/funcs/server_iso_insert.go
@@ -64,6 +64,7 @@ func ServerISOInsert(ctx cli.Context, params *usacloud_params.ISOInsertServerPar
 			fmt.Sprintf("Still uploading[ID:%d]...", params.Id),
 			fmt.Sprintf("Upload iso-image[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 
 				file, df, err := fileOrStdin(params.GetISOFile())

--- a/pkg/funcs/server_reset.go
+++ b/pkg/funcs/server_reset.go
@@ -35,6 +35,7 @@ func ServerReset(ctx cli.Context, params *params.ResetServerParam) error {
 		fmt.Sprintf("Still resetting[ID:%d]...", params.Id),
 		fmt.Sprintf("Reset server[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.RebootForce(params.Id)

--- a/pkg/funcs/server_shutdown.go
+++ b/pkg/funcs/server_shutdown.go
@@ -39,6 +39,7 @@ func ServerShutdown(ctx cli.Context, params *params.ShutdownServerParam) error {
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown server[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/server_shutdown_force.go
+++ b/pkg/funcs/server_shutdown_force.go
@@ -39,6 +39,7 @@ func ServerShutdownForce(ctx cli.Context, params *params.ShutdownForceServerPara
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown server[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/server_ssh_exec.go
+++ b/pkg/funcs/server_ssh_exec.go
@@ -113,6 +113,7 @@ func ServerSSHExec(ctx cli.Context, params *params.SSHExecServerParam) error {
 		args = append(args, ctx.Args()[1:]...)
 	}
 
+	printer := printer.Printer{NoColor: ctx.Option().NoColor}
 	if !params.Quiet {
 		printer.Fprintf(ctx.IO().Progress(), color.New(color.FgHiGreen), "=== start | %s ===\n", displayName)
 	}

--- a/pkg/funcs/server_vnc.go
+++ b/pkg/funcs/server_vnc.go
@@ -38,6 +38,7 @@ func ServerVnc(ctx cli.Context, params *params.VncServerParam) error {
 			fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 			fmt.Sprintf("Connect to server[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				// call manipurate functions
 				err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/server_vnc_info.go
+++ b/pkg/funcs/server_vnc_info.go
@@ -38,6 +38,7 @@ func ServerVncInfo(ctx cli.Context, params *params.VncInfoServerParam) error {
 			fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 			fmt.Sprintf("Connect to server[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				// call manipurate functions
 				err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/server_vnc_send.go
+++ b/pkg/funcs/server_vnc_send.go
@@ -40,6 +40,7 @@ func ServerVncSend(ctx cli.Context, params *params.VncSendServerParam) error {
 			fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 			fmt.Sprintf("Connect to server[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				// call manipurate functions
 				err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/server_vnc_snapshot.go
+++ b/pkg/funcs/server_vnc_snapshot.go
@@ -43,6 +43,7 @@ func ServerVncSnapshot(ctx cli.Context, params *params.VncSnapshotServerParam) e
 			fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 			fmt.Sprintf("Connect to server[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				// call manipurate functions
 				err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/server_wait_for_boot.go
+++ b/pkg/funcs/server_wait_for_boot.go
@@ -39,6 +39,7 @@ func ServerWaitForBoot(ctx cli.Context, params *params.WaitForBootServerParam) e
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot server[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/server_wait_for_down.go
+++ b/pkg/funcs/server_wait_for_down.go
@@ -39,6 +39,7 @@ func ServerWaitForDown(ctx cli.Context, params *params.WaitForDownServerParam) e
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown server[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilDown(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/summary_show.go
+++ b/pkg/funcs/summary_show.go
@@ -58,6 +58,7 @@ func SummaryShow(ctx cli.Context, params *params.ShowSummaryParam) error {
 		"Still calculating...",
 		"Calculate resource count",
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 
 			// do count & build result

--- a/pkg/funcs/vpc_router_boot.go
+++ b/pkg/funcs/vpc_router_boot.go
@@ -39,6 +39,7 @@ func VPCRouterBoot(ctx cli.Context, params *params.BootVPCRouterParam) error {
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot vpc-router[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.Boot(params.Id)

--- a/pkg/funcs/vpc_router_create.go
+++ b/pkg/funcs/vpc_router_create.go
@@ -96,6 +96,7 @@ func VPCRouterCreate(ctx cli.Context, params *params.CreateVPCRouterParam) error
 		fmt.Sprintf("Still creating[ID:%d]...", res.ID),
 		fmt.Sprintf("Create vpc-router[ID:%d]", res.ID),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepWhileCopying(res.ID, client.DefaultTimeoutDuration, 20)

--- a/pkg/funcs/vpc_router_delete.go
+++ b/pkg/funcs/vpc_router_delete.go
@@ -39,6 +39,7 @@ func VPCRouterDelete(ctx cli.Context, params *params.DeleteVPCRouterParam) error
 				fmt.Sprintf("Still waiting for delete[ID:%d]...", params.Id),
 				fmt.Sprintf("Delete vpc-router[ID:%d]", params.Id),
 				ctx.IO().Progress(),
+				ctx.Option().NoColor,
 				func(compChan chan bool, errChan chan error) {
 					// call manipurate functions
 					var err error

--- a/pkg/funcs/vpc_router_interface_connect.go
+++ b/pkg/funcs/vpc_router_interface_connect.go
@@ -85,6 +85,7 @@ func VPCRouterInterfaceConnect(ctx cli.Context, params *params.InterfaceConnectV
 			fmt.Sprintf("Still waiting for reboot[ID:%d]...", params.Id),
 			fmt.Sprintf("Connecting interface to switch[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				// call manipurate functions
 				var err error

--- a/pkg/funcs/vpc_router_interface_disconnect.go
+++ b/pkg/funcs/vpc_router_interface_disconnect.go
@@ -52,6 +52,7 @@ func VPCRouterInterfaceDisconnect(ctx cli.Context, params *params.InterfaceDisco
 			fmt.Sprintf("Still waiting for reboot[ID:%d]...", params.Id),
 			fmt.Sprintf("Disconnecting interface to switch[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				// call manipurate functions
 				var err error

--- a/pkg/funcs/vpc_router_interface_update.go
+++ b/pkg/funcs/vpc_router_interface_update.go
@@ -139,6 +139,7 @@ func VPCRouterInterfaceUpdate(ctx cli.Context, params *params.InterfaceUpdateVPC
 			fmt.Sprintf("Still waiting for reboot[ID:%d]...", params.Id),
 			fmt.Sprintf("Connecting interface to switch[ID:%d]", params.Id),
 			ctx.IO().Progress(),
+			ctx.Option().NoColor,
 			func(compChan chan bool, errChan chan error) {
 				// call manipurate functions
 				var err error

--- a/pkg/funcs/vpc_router_logs.go
+++ b/pkg/funcs/vpc_router_logs.go
@@ -71,6 +71,7 @@ func VPCRouterLogs(ctx cli.Context, params *params.LogsVPCRouterParam) error {
 			logs["firewall-receive"] = res.FirewallReceiveLogs
 		}
 
+		printer := printer.Printer{NoColor: ctx.Option().NoColor}
 		for key, lines := range logs {
 			if params.LogName == "all" {
 				printer.Fprintf(out, color.New(color.FgHiGreen), "\n==> [%s]:start\n", key)

--- a/pkg/funcs/vpc_router_reset.go
+++ b/pkg/funcs/vpc_router_reset.go
@@ -35,6 +35,7 @@ func VPCRouterReset(ctx cli.Context, params *params.ResetVPCRouterParam) error {
 		fmt.Sprintf("Still resetting[ID:%d]...", params.Id),
 		fmt.Sprintf("Reset vpc-router[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			_, err := api.RebootForce(params.Id)

--- a/pkg/funcs/vpc_router_shutdown.go
+++ b/pkg/funcs/vpc_router_shutdown.go
@@ -39,6 +39,7 @@ func VPCRouterShutdown(ctx cli.Context, params *params.ShutdownVPCRouterParam) e
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown vpc-router[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/vpc_router_shutdown_force.go
+++ b/pkg/funcs/vpc_router_shutdown_force.go
@@ -39,6 +39,7 @@ func VPCRouterShutdownForce(ctx cli.Context, params *params.ShutdownForceVPCRout
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown vpc-router[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			var err error

--- a/pkg/funcs/vpc_router_wait_for_boot.go
+++ b/pkg/funcs/vpc_router_wait_for_boot.go
@@ -39,6 +39,7 @@ func VPCRouterWaitForBoot(ctx cli.Context, params *params.WaitForBootVPCRouterPa
 		fmt.Sprintf("Still booting[ID:%d]...", params.Id),
 		fmt.Sprintf("Boot vpc-router[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilUp(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/funcs/vpc_router_wait_for_down.go
+++ b/pkg/funcs/vpc_router_wait_for_down.go
@@ -39,6 +39,7 @@ func VPCRouterWaitForDown(ctx cli.Context, params *params.WaitForDownVPCRouterPa
 		fmt.Sprintf("Still waiting for Shutdown[ID:%d]...", params.Id),
 		fmt.Sprintf("Shutdown vpc-router[ID:%d]", params.Id),
 		ctx.IO().Progress(),
+		ctx.Option().NoColor,
 		func(compChan chan bool, errChan chan error) {
 			// call manipurate functions
 			err := api.SleepUntilDown(params.Id, client.DefaultTimeoutDuration)

--- a/pkg/helper/migration/migration.go
+++ b/pkg/helper/migration/migration.go
@@ -22,7 +22,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sacloud/usacloud/pkg/cli"
-	"github.com/sacloud/usacloud/pkg/helper/printer"
 	"github.com/sacloud/usacloud/pkg/profile"
 )
 
@@ -119,6 +118,6 @@ func MigrateConfig() error {
 		return fmt.Errorf("Migrating [%q] to [%q] is failed: %s", src, dest, err)
 	}
 
-	printer.Fprintf(os.Stdout, color.New(color.FgGreen), "\nMigrated: [%q] to [%q]\n", src, dest) // TODO ビルドを通すための仮実装
+	color.New(color.FgGreen).Fprintf(os.Stdout, "\nMigrated: [%q] to [%q]\n", src, dest) // TODO ビルドを通すための仮実装(os.Stdoutで良いか?)
 	return nil
 }

--- a/pkg/helper/migration/migration_test.go
+++ b/pkg/helper/migration/migration_test.go
@@ -19,16 +19,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sacloud/usacloud/pkg/cli"
-
 	"github.com/sacloud/usacloud/pkg/profile"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMigrateConfig(t *testing.T) {
-	// TODO グローバルオプションの扱いが確定したら修正する
-	cli.GlobalOption = &cli.CLIOptions{}
-
 	initFunc := func() func() {
 		confirmMigrateFunc = func() bool { return true }
 		confirmOverwriteFunc = func(s string) bool { return true }

--- a/pkg/helper/printer/printer.go
+++ b/pkg/helper/printer/printer.go
@@ -19,12 +19,15 @@ import (
 	"io"
 
 	"github.com/fatih/color"
-	"github.com/sacloud/usacloud/pkg/cli"
 )
 
+type Printer struct {
+	NoColor bool
+}
+
 // Fprint is delegates to *color.Color or fmt depending on command.GlobalOption.NoColor flag
-func Fprint(w io.Writer, c *color.Color, a ...interface{}) {
-	if cli.GlobalOption.NoColor {
+func (p *Printer) Fprint(w io.Writer, c *color.Color, a ...interface{}) {
+	if p.NoColor {
 		fmt.Fprint(w, a...)
 	} else {
 		c.Fprint(w, a...)
@@ -32,8 +35,8 @@ func Fprint(w io.Writer, c *color.Color, a ...interface{}) {
 }
 
 // Fprintf is delegates to *color.Color or fmt depending on command.GlobalOption.NoColor flag
-func Fprintf(w io.Writer, c *color.Color, format string, a ...interface{}) {
-	if cli.GlobalOption.NoColor {
+func (p *Printer) Fprintf(w io.Writer, c *color.Color, format string, a ...interface{}) {
+	if p.NoColor {
 		fmt.Fprintf(w, format, a...)
 	} else {
 		c.Fprintf(w, format, a...)

--- a/pkg/internal/progress.go
+++ b/pkg/internal/progress.go
@@ -28,6 +28,7 @@ var mutex = sync.Mutex{}
 
 type ProgressWriter struct {
 	out         io.Writer
+	printer     *printer.Printer
 	msgProgress string
 	msgStart    string
 	msgComplete string
@@ -39,9 +40,10 @@ type ProgressWriter struct {
 	wg          sync.WaitGroup
 }
 
-func NewProgress(msgProgress, msgPrefix string, out io.Writer) *ProgressWriter {
+func NewProgress(msgProgress, msgPrefix string, out io.Writer, noColor bool) *ProgressWriter {
 	return &ProgressWriter{
 		out:         out,
+		printer:     &printer.Printer{NoColor: noColor},
 		msgProgress: msgProgress,
 		msgStart:    fmt.Sprintf("%s is started...", msgPrefix),
 		msgComplete: fmt.Sprintf("%s is finished", msgPrefix),
@@ -54,8 +56,8 @@ func NewProgress(msgProgress, msgPrefix string, out io.Writer) *ProgressWriter {
 
 type ProgressWriterFunc func(chan bool, chan error)
 
-func ExecWithProgress(msgProgress, msgPrefix string, out io.Writer, f ProgressWriterFunc) error {
-	spinner := NewProgress(msgProgress, msgPrefix, out)
+func ExecWithProgress(msgProgress, msgPrefix string, out io.Writer, noColor bool, f ProgressWriterFunc) error {
+	spinner := NewProgress(msgProgress, msgPrefix, out, noColor)
 	compChan := make(chan bool)
 	errChan := make(chan error)
 
@@ -116,5 +118,5 @@ func (s *ProgressWriter) Fail(err error) {
 func (s *ProgressWriter) print(clr *color.Color, msg string) {
 	mutex.Lock()
 	defer mutex.Unlock()
-	printer.Fprint(s.out, clr, msg)
+	s.printer.Fprint(s.out, clr, msg)
 }

--- a/pkg/params/validators.go
+++ b/pkg/params/validators.go
@@ -27,6 +27,6 @@ func validateRequired(fieldName string, object interface{}) []error {
 	return cli.ValidateRequired(fieldName, object)
 }
 
-func validateOutputOption(o output.Option) []error {
-	return cli.ValidateOutputOption(o)
+func validateOutputOption(o output.Option, defaultOutputType string) []error {
+	return cli.ValidateOutputOption(o, defaultOutputType)
 }

--- a/pkg/params/zz_archive_gen.go
+++ b/pkg/params/zz_archive_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -51,7 +52,8 @@ type ListArchiveParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListArchiveParam return new ListArchiveParam
@@ -60,8 +62,9 @@ func NewListArchiveParam() *ListArchiveParam {
 }
 
 // Initialize init ListArchiveParam
-func (p *ListArchiveParam) Initialize(in Input, args []string) error {
+func (p *ListArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -218,7 +221,7 @@ func (p *ListArchiveParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -454,7 +457,8 @@ type CreateArchiveParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateArchiveParam return new CreateArchiveParam
@@ -463,8 +467,9 @@ func NewCreateArchiveParam() *CreateArchiveParam {
 }
 
 // Initialize init CreateArchiveParam
-func (p *CreateArchiveParam) Initialize(in Input, args []string) error {
+func (p *CreateArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -675,7 +680,7 @@ func (p *CreateArchiveParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -904,7 +909,8 @@ type ReadArchiveParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadArchiveParam return new ReadArchiveParam
@@ -913,8 +919,9 @@ func NewReadArchiveParam() *ReadArchiveParam {
 }
 
 // Initialize init ReadArchiveParam
-func (p *ReadArchiveParam) Initialize(in Input, args []string) error {
+func (p *ReadArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -999,7 +1006,7 @@ func (p *ReadArchiveParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1184,7 +1191,8 @@ type UpdateArchiveParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateArchiveParam return new UpdateArchiveParam
@@ -1193,8 +1201,9 @@ func NewUpdateArchiveParam() *UpdateArchiveParam {
 }
 
 // Initialize init UpdateArchiveParam
-func (p *UpdateArchiveParam) Initialize(in Input, args []string) error {
+func (p *UpdateArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1326,7 +1335,7 @@ func (p *UpdateArchiveParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1542,7 +1551,8 @@ type DeleteArchiveParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteArchiveParam return new DeleteArchiveParam
@@ -1551,8 +1561,9 @@ func NewDeleteArchiveParam() *DeleteArchiveParam {
 }
 
 // Initialize init DeleteArchiveParam
-func (p *DeleteArchiveParam) Initialize(in Input, args []string) error {
+func (p *DeleteArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1640,7 +1651,7 @@ func (p *DeleteArchiveParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1829,7 +1840,8 @@ type UploadArchiveParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUploadArchiveParam return new UploadArchiveParam
@@ -1838,8 +1850,9 @@ func NewUploadArchiveParam() *UploadArchiveParam {
 }
 
 // Initialize init UploadArchiveParam
-func (p *UploadArchiveParam) Initialize(in Input, args []string) error {
+func (p *UploadArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1938,7 +1951,7 @@ func (p *UploadArchiveParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2127,7 +2140,8 @@ type DownloadArchiveParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDownloadArchiveParam return new DownloadArchiveParam
@@ -2136,8 +2150,9 @@ func NewDownloadArchiveParam() *DownloadArchiveParam {
 }
 
 // Initialize init DownloadArchiveParam
-func (p *DownloadArchiveParam) Initialize(in Input, args []string) error {
+func (p *DownloadArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2339,7 +2354,8 @@ type FTPOpenArchiveParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFTPOpenArchiveParam return new FTPOpenArchiveParam
@@ -2348,8 +2364,9 @@ func NewFTPOpenArchiveParam() *FTPOpenArchiveParam {
 }
 
 // Initialize init FTPOpenArchiveParam
-func (p *FTPOpenArchiveParam) Initialize(in Input, args []string) error {
+func (p *FTPOpenArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2437,7 +2454,7 @@ func (p *FTPOpenArchiveParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2618,7 +2635,8 @@ type FTPCloseArchiveParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFTPCloseArchiveParam return new FTPCloseArchiveParam
@@ -2627,8 +2645,9 @@ func NewFTPCloseArchiveParam() *FTPCloseArchiveParam {
 }
 
 // Initialize init FTPCloseArchiveParam
-func (p *FTPCloseArchiveParam) Initialize(in Input, args []string) error {
+func (p *FTPCloseArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2812,7 +2831,8 @@ type WaitForCopyArchiveParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForCopyArchiveParam return new WaitForCopyArchiveParam
@@ -2821,8 +2841,9 @@ func NewWaitForCopyArchiveParam() *WaitForCopyArchiveParam {
 }
 
 // Initialize init WaitForCopyArchiveParam
-func (p *WaitForCopyArchiveParam) Initialize(in Input, args []string) error {
+func (p *WaitForCopyArchiveParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_auth_status_gen.go
+++ b/pkg/params/zz_auth_status_gen.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -40,7 +41,8 @@ type ShowAuthStatusParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShowAuthStatusParam return new ShowAuthStatusParam
@@ -49,8 +51,9 @@ func NewShowAuthStatusParam() *ShowAuthStatusParam {
 }
 
 // Initialize init ShowAuthStatusParam
-func (p *ShowAuthStatusParam) Initialize(in Input, args []string) error {
+func (p *ShowAuthStatusParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -121,7 +124,7 @@ func (p *ShowAuthStatusParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_auto_backup_gen.go
+++ b/pkg/params/zz_auto_backup_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListAutoBackupParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListAutoBackupParam return new ListAutoBackupParam
@@ -57,8 +59,9 @@ func NewListAutoBackupParam() *ListAutoBackupParam {
 }
 
 // Initialize init ListAutoBackupParam
-func (p *ListAutoBackupParam) Initialize(in Input, args []string) error {
+func (p *ListAutoBackupParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListAutoBackupParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -396,7 +399,8 @@ type CreateAutoBackupParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateAutoBackupParam return new CreateAutoBackupParam
@@ -406,8 +410,9 @@ func NewCreateAutoBackupParam() *CreateAutoBackupParam {
 }
 
 // Initialize init CreateAutoBackupParam
-func (p *CreateAutoBackupParam) Initialize(in Input, args []string) error {
+func (p *CreateAutoBackupParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -586,7 +591,7 @@ func (p *CreateAutoBackupParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -808,7 +813,8 @@ type ReadAutoBackupParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadAutoBackupParam return new ReadAutoBackupParam
@@ -817,8 +823,9 @@ func NewReadAutoBackupParam() *ReadAutoBackupParam {
 }
 
 // Initialize init ReadAutoBackupParam
-func (p *ReadAutoBackupParam) Initialize(in Input, args []string) error {
+func (p *ReadAutoBackupParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -903,7 +910,7 @@ func (p *ReadAutoBackupParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1090,7 +1097,8 @@ type UpdateAutoBackupParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateAutoBackupParam return new UpdateAutoBackupParam
@@ -1099,8 +1107,9 @@ func NewUpdateAutoBackupParam() *UpdateAutoBackupParam {
 }
 
 // Initialize init UpdateAutoBackupParam
-func (p *UpdateAutoBackupParam) Initialize(in Input, args []string) error {
+func (p *UpdateAutoBackupParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1254,7 +1263,7 @@ func (p *UpdateAutoBackupParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1484,7 +1493,8 @@ type DeleteAutoBackupParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteAutoBackupParam return new DeleteAutoBackupParam
@@ -1493,8 +1503,9 @@ func NewDeleteAutoBackupParam() *DeleteAutoBackupParam {
 }
 
 // Initialize init DeleteAutoBackupParam
-func (p *DeleteAutoBackupParam) Initialize(in Input, args []string) error {
+func (p *DeleteAutoBackupParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1582,7 +1593,7 @@ func (p *DeleteAutoBackupParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_bill_gen.go
+++ b/pkg/params/zz_bill_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -37,7 +38,8 @@ type CsvBillParam struct {
 	BillOutput        string
 	BillId            sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCsvBillParam return new CsvBillParam
@@ -46,8 +48,9 @@ func NewCsvBillParam() *CsvBillParam {
 }
 
 // Initialize init CsvBillParam
-func (p *CsvBillParam) Initialize(in Input, args []string) error {
+func (p *CsvBillParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -238,7 +241,8 @@ type ListBillParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListBillParam return new ListBillParam
@@ -247,8 +251,9 @@ func NewListBillParam() *ListBillParam {
 }
 
 // Initialize init ListBillParam
-func (p *ListBillParam) Initialize(in Input, args []string) error {
+func (p *ListBillParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -341,7 +346,7 @@ func (p *ListBillParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_bridge_gen.go
+++ b/pkg/params/zz_bridge_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -47,7 +48,8 @@ type ListBridgeParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListBridgeParam return new ListBridgeParam
@@ -56,8 +58,9 @@ func NewListBridgeParam() *ListBridgeParam {
 }
 
 // Initialize init ListBridgeParam
-func (p *ListBridgeParam) Initialize(in Input, args []string) error {
+func (p *ListBridgeParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (p *ListBridgeParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type CreateBridgeParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateBridgeParam return new CreateBridgeParam
@@ -381,8 +385,9 @@ func NewCreateBridgeParam() *CreateBridgeParam {
 }
 
 // Initialize init CreateBridgeParam
-func (p *CreateBridgeParam) Initialize(in Input, args []string) error {
+func (p *CreateBridgeParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -485,7 +490,7 @@ func (p *CreateBridgeParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -671,7 +676,8 @@ type ReadBridgeParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadBridgeParam return new ReadBridgeParam
@@ -680,8 +686,9 @@ func NewReadBridgeParam() *ReadBridgeParam {
 }
 
 // Initialize init ReadBridgeParam
-func (p *ReadBridgeParam) Initialize(in Input, args []string) error {
+func (p *ReadBridgeParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -763,7 +770,7 @@ func (p *ReadBridgeParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -938,7 +945,8 @@ type UpdateBridgeParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateBridgeParam return new UpdateBridgeParam
@@ -947,8 +955,9 @@ func NewUpdateBridgeParam() *UpdateBridgeParam {
 }
 
 // Initialize init UpdateBridgeParam
-func (p *UpdateBridgeParam) Initialize(in Input, args []string) error {
+func (p *UpdateBridgeParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1055,7 +1064,7 @@ func (p *UpdateBridgeParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1249,7 +1258,8 @@ type DeleteBridgeParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteBridgeParam return new DeleteBridgeParam
@@ -1258,8 +1268,9 @@ func NewDeleteBridgeParam() *DeleteBridgeParam {
 }
 
 // Initialize init DeleteBridgeParam
-func (p *DeleteBridgeParam) Initialize(in Input, args []string) error {
+func (p *DeleteBridgeParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1344,7 +1355,7 @@ func (p *DeleteBridgeParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_config_gen.go
+++ b/pkg/params/zz_config_gen.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -33,7 +34,8 @@ type CurrentConfigParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCurrentConfigParam return new CurrentConfigParam
@@ -42,8 +44,9 @@ func NewCurrentConfigParam() *CurrentConfigParam {
 }
 
 // Initialize init CurrentConfigParam
-func (p *CurrentConfigParam) Initialize(in Input, args []string) error {
+func (p *CurrentConfigParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -188,7 +191,8 @@ type DeleteConfigParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteConfigParam return new DeleteConfigParam
@@ -197,8 +201,9 @@ func NewDeleteConfigParam() *DeleteConfigParam {
 }
 
 // Initialize init DeleteConfigParam
-func (p *DeleteConfigParam) Initialize(in Input, args []string) error {
+func (p *DeleteConfigParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -356,7 +361,8 @@ type EditConfigParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewEditConfigParam return new EditConfigParam
@@ -365,8 +371,9 @@ func NewEditConfigParam() *EditConfigParam {
 }
 
 // Initialize init EditConfigParam
-func (p *EditConfigParam) Initialize(in Input, args []string) error {
+func (p *EditConfigParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -566,7 +573,8 @@ type ListConfigParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListConfigParam return new ListConfigParam
@@ -575,8 +583,9 @@ func NewListConfigParam() *ListConfigParam {
 }
 
 // Initialize init ListConfigParam
-func (p *ListConfigParam) Initialize(in Input, args []string) error {
+func (p *ListConfigParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -720,7 +729,8 @@ type MigrateConfigParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMigrateConfigParam return new MigrateConfigParam
@@ -729,8 +739,9 @@ func NewMigrateConfigParam() *MigrateConfigParam {
 }
 
 // Initialize init MigrateConfigParam
-func (p *MigrateConfigParam) Initialize(in Input, args []string) error {
+func (p *MigrateConfigParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -874,7 +885,8 @@ type ShowConfigParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShowConfigParam return new ShowConfigParam
@@ -883,8 +895,9 @@ func NewShowConfigParam() *ShowConfigParam {
 }
 
 // Initialize init ShowConfigParam
-func (p *ShowConfigParam) Initialize(in Input, args []string) error {
+func (p *ShowConfigParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1028,7 +1041,8 @@ type UseConfigParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUseConfigParam return new UseConfigParam
@@ -1037,8 +1051,9 @@ func NewUseConfigParam() *UseConfigParam {
 }
 
 // Initialize init UseConfigParam
-func (p *UseConfigParam) Initialize(in Input, args []string) error {
+func (p *UseConfigParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_coupon_gen.go
+++ b/pkg/params/zz_coupon_gen.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -41,7 +42,8 @@ type ListCouponParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListCouponParam return new ListCouponParam
@@ -50,8 +52,9 @@ func NewListCouponParam() *ListCouponParam {
 }
 
 // Initialize init ListCouponParam
-func (p *ListCouponParam) Initialize(in Input, args []string) error {
+func (p *ListCouponParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -125,7 +128,7 @@ func (p *ListCouponParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_database_gen.go
+++ b/pkg/params/zz_database_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListDatabaseParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListDatabaseParam return new ListDatabaseParam
@@ -57,8 +59,9 @@ func NewListDatabaseParam() *ListDatabaseParam {
 }
 
 // Initialize init ListDatabaseParam
-func (p *ListDatabaseParam) Initialize(in Input, args []string) error {
+func (p *ListDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -408,7 +411,8 @@ type CreateDatabaseParam struct {
 	Query               string
 	QueryFile           string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateDatabaseParam return new CreateDatabaseParam
@@ -418,8 +422,9 @@ func NewCreateDatabaseParam() *CreateDatabaseParam {
 }
 
 // Initialize init CreateDatabaseParam
-func (p *CreateDatabaseParam) Initialize(in Input, args []string) error {
+func (p *CreateDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -749,7 +754,7 @@ func (p *CreateDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1055,7 +1060,8 @@ type ReadDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadDatabaseParam return new ReadDatabaseParam
@@ -1064,8 +1070,9 @@ func NewReadDatabaseParam() *ReadDatabaseParam {
 }
 
 // Initialize init ReadDatabaseParam
-func (p *ReadDatabaseParam) Initialize(in Input, args []string) error {
+func (p *ReadDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1150,7 +1157,7 @@ func (p *ReadDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1344,7 +1351,8 @@ type UpdateDatabaseParam struct {
 	QueryFile           string
 	Id                  sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateDatabaseParam return new UpdateDatabaseParam
@@ -1354,8 +1362,9 @@ func NewUpdateDatabaseParam() *UpdateDatabaseParam {
 }
 
 // Initialize init UpdateDatabaseParam
-func (p *UpdateDatabaseParam) Initialize(in Input, args []string) error {
+func (p *UpdateDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1562,7 +1571,7 @@ func (p *UpdateDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1842,7 +1851,8 @@ type DeleteDatabaseParam struct {
 	Force             bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteDatabaseParam return new DeleteDatabaseParam
@@ -1851,8 +1861,9 @@ func NewDeleteDatabaseParam() *DeleteDatabaseParam {
 }
 
 // Initialize init DeleteDatabaseParam
-func (p *DeleteDatabaseParam) Initialize(in Input, args []string) error {
+func (p *DeleteDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1943,7 +1954,7 @@ func (p *DeleteDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2131,7 +2142,8 @@ type BootDatabaseParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBootDatabaseParam return new BootDatabaseParam
@@ -2140,8 +2152,9 @@ func NewBootDatabaseParam() *BootDatabaseParam {
 }
 
 // Initialize init BootDatabaseParam
-func (p *BootDatabaseParam) Initialize(in Input, args []string) error {
+func (p *BootDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2326,7 +2339,8 @@ type ShutdownDatabaseParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownDatabaseParam return new ShutdownDatabaseParam
@@ -2335,8 +2349,9 @@ func NewShutdownDatabaseParam() *ShutdownDatabaseParam {
 }
 
 // Initialize init ShutdownDatabaseParam
-func (p *ShutdownDatabaseParam) Initialize(in Input, args []string) error {
+func (p *ShutdownDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2521,7 +2536,8 @@ type ShutdownForceDatabaseParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownForceDatabaseParam return new ShutdownForceDatabaseParam
@@ -2530,8 +2546,9 @@ func NewShutdownForceDatabaseParam() *ShutdownForceDatabaseParam {
 }
 
 // Initialize init ShutdownForceDatabaseParam
-func (p *ShutdownForceDatabaseParam) Initialize(in Input, args []string) error {
+func (p *ShutdownForceDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2716,7 +2733,8 @@ type ResetDatabaseParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResetDatabaseParam return new ResetDatabaseParam
@@ -2725,8 +2743,9 @@ func NewResetDatabaseParam() *ResetDatabaseParam {
 }
 
 // Initialize init ResetDatabaseParam
-func (p *ResetDatabaseParam) Initialize(in Input, args []string) error {
+func (p *ResetDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2910,7 +2929,8 @@ type WaitForBootDatabaseParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForBootDatabaseParam return new WaitForBootDatabaseParam
@@ -2919,8 +2939,9 @@ func NewWaitForBootDatabaseParam() *WaitForBootDatabaseParam {
 }
 
 // Initialize init WaitForBootDatabaseParam
-func (p *WaitForBootDatabaseParam) Initialize(in Input, args []string) error {
+func (p *WaitForBootDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3094,7 +3115,8 @@ type WaitForDownDatabaseParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForDownDatabaseParam return new WaitForDownDatabaseParam
@@ -3103,8 +3125,9 @@ func NewWaitForDownDatabaseParam() *WaitForDownDatabaseParam {
 }
 
 // Initialize init WaitForDownDatabaseParam
-func (p *WaitForDownDatabaseParam) Initialize(in Input, args []string) error {
+func (p *WaitForDownDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3285,7 +3308,8 @@ type BackupInfoDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBackupInfoDatabaseParam return new BackupInfoDatabaseParam
@@ -3294,8 +3318,9 @@ func NewBackupInfoDatabaseParam() *BackupInfoDatabaseParam {
 }
 
 // Initialize init BackupInfoDatabaseParam
-func (p *BackupInfoDatabaseParam) Initialize(in Input, args []string) error {
+func (p *BackupInfoDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3380,7 +3405,7 @@ func (p *BackupInfoDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3560,7 +3585,8 @@ type BackupCreateDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBackupCreateDatabaseParam return new BackupCreateDatabaseParam
@@ -3569,8 +3595,9 @@ func NewBackupCreateDatabaseParam() *BackupCreateDatabaseParam {
 }
 
 // Initialize init BackupCreateDatabaseParam
-func (p *BackupCreateDatabaseParam) Initialize(in Input, args []string) error {
+func (p *BackupCreateDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3655,7 +3682,7 @@ func (p *BackupCreateDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3836,7 +3863,8 @@ type BackupRestoreDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBackupRestoreDatabaseParam return new BackupRestoreDatabaseParam
@@ -3845,8 +3873,9 @@ func NewBackupRestoreDatabaseParam() *BackupRestoreDatabaseParam {
 }
 
 // Initialize init BackupRestoreDatabaseParam
-func (p *BackupRestoreDatabaseParam) Initialize(in Input, args []string) error {
+func (p *BackupRestoreDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3949,7 +3978,7 @@ func (p *BackupRestoreDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4137,7 +4166,8 @@ type BackupLockDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBackupLockDatabaseParam return new BackupLockDatabaseParam
@@ -4146,8 +4176,9 @@ func NewBackupLockDatabaseParam() *BackupLockDatabaseParam {
 }
 
 // Initialize init BackupLockDatabaseParam
-func (p *BackupLockDatabaseParam) Initialize(in Input, args []string) error {
+func (p *BackupLockDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4250,7 +4281,7 @@ func (p *BackupLockDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4438,7 +4469,8 @@ type BackupUnlockDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBackupUnlockDatabaseParam return new BackupUnlockDatabaseParam
@@ -4447,8 +4479,9 @@ func NewBackupUnlockDatabaseParam() *BackupUnlockDatabaseParam {
 }
 
 // Initialize init BackupUnlockDatabaseParam
-func (p *BackupUnlockDatabaseParam) Initialize(in Input, args []string) error {
+func (p *BackupUnlockDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4551,7 +4584,7 @@ func (p *BackupUnlockDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4739,7 +4772,8 @@ type BackupRemoveDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBackupRemoveDatabaseParam return new BackupRemoveDatabaseParam
@@ -4748,8 +4782,9 @@ func NewBackupRemoveDatabaseParam() *BackupRemoveDatabaseParam {
 }
 
 // Initialize init BackupRemoveDatabaseParam
-func (p *BackupRemoveDatabaseParam) Initialize(in Input, args []string) error {
+func (p *BackupRemoveDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4852,7 +4887,7 @@ func (p *BackupRemoveDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5055,7 +5090,8 @@ type CloneDatabaseParam struct {
 	QueryFile           string
 	Id                  sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCloneDatabaseParam return new CloneDatabaseParam
@@ -5065,8 +5101,9 @@ func NewCloneDatabaseParam() *CloneDatabaseParam {
 }
 
 // Initialize init CloneDatabaseParam
-func (p *CloneDatabaseParam) Initialize(in Input, args []string) error {
+func (p *CloneDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5332,7 +5369,7 @@ func (p *CloneDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5632,7 +5669,8 @@ type ReplicaCreateDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReplicaCreateDatabaseParam return new ReplicaCreateDatabaseParam
@@ -5641,8 +5679,9 @@ func NewReplicaCreateDatabaseParam() *ReplicaCreateDatabaseParam {
 }
 
 // Initialize init ReplicaCreateDatabaseParam
-func (p *ReplicaCreateDatabaseParam) Initialize(in Input, args []string) error {
+func (p *ReplicaCreateDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5829,7 +5868,7 @@ func (p *ReplicaCreateDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6068,7 +6107,8 @@ type MonitorCPUDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorCPUDatabaseParam return new MonitorCPUDatabaseParam
@@ -6078,8 +6118,9 @@ func NewMonitorCPUDatabaseParam() *MonitorCPUDatabaseParam {
 }
 
 // Initialize init MonitorCPUDatabaseParam
-func (p *MonitorCPUDatabaseParam) Initialize(in Input, args []string) error {
+func (p *MonitorCPUDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6197,7 +6238,7 @@ func (p *MonitorCPUDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6401,7 +6442,8 @@ type MonitorMemoryDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorMemoryDatabaseParam return new MonitorMemoryDatabaseParam
@@ -6411,8 +6453,9 @@ func NewMonitorMemoryDatabaseParam() *MonitorMemoryDatabaseParam {
 }
 
 // Initialize init MonitorMemoryDatabaseParam
-func (p *MonitorMemoryDatabaseParam) Initialize(in Input, args []string) error {
+func (p *MonitorMemoryDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6530,7 +6573,7 @@ func (p *MonitorMemoryDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6734,7 +6777,8 @@ type MonitorNicDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorNicDatabaseParam return new MonitorNicDatabaseParam
@@ -6744,8 +6788,9 @@ func NewMonitorNicDatabaseParam() *MonitorNicDatabaseParam {
 }
 
 // Initialize init MonitorNicDatabaseParam
-func (p *MonitorNicDatabaseParam) Initialize(in Input, args []string) error {
+func (p *MonitorNicDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6863,7 +6908,7 @@ func (p *MonitorNicDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7067,7 +7112,8 @@ type MonitorSystemDiskDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorSystemDiskDatabaseParam return new MonitorSystemDiskDatabaseParam
@@ -7077,8 +7123,9 @@ func NewMonitorSystemDiskDatabaseParam() *MonitorSystemDiskDatabaseParam {
 }
 
 // Initialize init MonitorSystemDiskDatabaseParam
-func (p *MonitorSystemDiskDatabaseParam) Initialize(in Input, args []string) error {
+func (p *MonitorSystemDiskDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7196,7 +7243,7 @@ func (p *MonitorSystemDiskDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7400,7 +7447,8 @@ type MonitorBackupDiskDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorBackupDiskDatabaseParam return new MonitorBackupDiskDatabaseParam
@@ -7410,8 +7458,9 @@ func NewMonitorBackupDiskDatabaseParam() *MonitorBackupDiskDatabaseParam {
 }
 
 // Initialize init MonitorBackupDiskDatabaseParam
-func (p *MonitorBackupDiskDatabaseParam) Initialize(in Input, args []string) error {
+func (p *MonitorBackupDiskDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7529,7 +7578,7 @@ func (p *MonitorBackupDiskDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7733,7 +7782,8 @@ type MonitorSystemDiskSizeDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorSystemDiskSizeDatabaseParam return new MonitorSystemDiskSizeDatabaseParam
@@ -7743,8 +7793,9 @@ func NewMonitorSystemDiskSizeDatabaseParam() *MonitorSystemDiskSizeDatabaseParam
 }
 
 // Initialize init MonitorSystemDiskSizeDatabaseParam
-func (p *MonitorSystemDiskSizeDatabaseParam) Initialize(in Input, args []string) error {
+func (p *MonitorSystemDiskSizeDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7862,7 +7913,7 @@ func (p *MonitorSystemDiskSizeDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -8066,7 +8117,8 @@ type MonitorBackupDiskSizeDatabaseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorBackupDiskSizeDatabaseParam return new MonitorBackupDiskSizeDatabaseParam
@@ -8076,8 +8128,9 @@ func NewMonitorBackupDiskSizeDatabaseParam() *MonitorBackupDiskSizeDatabaseParam
 }
 
 // Initialize init MonitorBackupDiskSizeDatabaseParam
-func (p *MonitorBackupDiskSizeDatabaseParam) Initialize(in Input, args []string) error {
+func (p *MonitorBackupDiskSizeDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8195,7 +8248,7 @@ func (p *MonitorBackupDiskSizeDatabaseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -8393,7 +8446,8 @@ type LogsDatabaseParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewLogsDatabaseParam return new LogsDatabaseParam
@@ -8403,8 +8457,9 @@ func NewLogsDatabaseParam() *LogsDatabaseParam {
 }
 
 // Initialize init LogsDatabaseParam
-func (p *LogsDatabaseParam) Initialize(in Input, args []string) error {
+func (p *LogsDatabaseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_disk_gen.go
+++ b/pkg/params/zz_disk_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -52,7 +53,8 @@ type ListDiskParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListDiskParam return new ListDiskParam
@@ -61,8 +63,9 @@ func NewListDiskParam() *ListDiskParam {
 }
 
 // Initialize init ListDiskParam
-func (p *ListDiskParam) Initialize(in Input, args []string) error {
+func (p *ListDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -222,7 +225,7 @@ func (p *ListDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -467,7 +470,8 @@ type CreateDiskParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateDiskParam return new CreateDiskParam
@@ -477,8 +481,9 @@ func NewCreateDiskParam() *CreateDiskParam {
 }
 
 // Initialize init CreateDiskParam
-func (p *CreateDiskParam) Initialize(in Input, args []string) error {
+func (p *CreateDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -708,7 +713,7 @@ func (p *CreateDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -951,7 +956,8 @@ type ReadDiskParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadDiskParam return new ReadDiskParam
@@ -960,8 +966,9 @@ func NewReadDiskParam() *ReadDiskParam {
 }
 
 // Initialize init ReadDiskParam
-func (p *ReadDiskParam) Initialize(in Input, args []string) error {
+func (p *ReadDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1046,7 +1053,7 @@ func (p *ReadDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1232,7 +1239,8 @@ type UpdateDiskParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateDiskParam return new UpdateDiskParam
@@ -1241,8 +1249,9 @@ func NewUpdateDiskParam() *UpdateDiskParam {
 }
 
 // Initialize init UpdateDiskParam
-func (p *UpdateDiskParam) Initialize(in Input, args []string) error {
+func (p *UpdateDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1385,7 +1394,7 @@ func (p *UpdateDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1608,7 +1617,8 @@ type DeleteDiskParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteDiskParam return new DeleteDiskParam
@@ -1617,8 +1627,9 @@ func NewDeleteDiskParam() *DeleteDiskParam {
 }
 
 // Initialize init DeleteDiskParam
-func (p *DeleteDiskParam) Initialize(in Input, args []string) error {
+func (p *DeleteDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1706,7 +1717,7 @@ func (p *DeleteDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1902,7 +1913,8 @@ type EditDiskParam struct {
 	QueryFile           string
 	Id                  sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewEditDiskParam return new EditDiskParam
@@ -1912,8 +1924,9 @@ func NewEditDiskParam() *EditDiskParam {
 }
 
 // Initialize init EditDiskParam
-func (p *EditDiskParam) Initialize(in Input, args []string) error {
+func (p *EditDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2049,7 +2062,7 @@ func (p *EditDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2293,7 +2306,8 @@ type ResizePartitionDiskParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResizePartitionDiskParam return new ResizePartitionDiskParam
@@ -2302,8 +2316,9 @@ func NewResizePartitionDiskParam() *ResizePartitionDiskParam {
 }
 
 // Initialize init ResizePartitionDiskParam
-func (p *ResizePartitionDiskParam) Initialize(in Input, args []string) error {
+func (p *ResizePartitionDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2391,7 +2406,7 @@ func (p *ResizePartitionDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2574,7 +2589,8 @@ type ReinstallFromArchiveDiskParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReinstallFromArchiveDiskParam return new ReinstallFromArchiveDiskParam
@@ -2583,8 +2599,9 @@ func NewReinstallFromArchiveDiskParam() *ReinstallFromArchiveDiskParam {
 }
 
 // Initialize init ReinstallFromArchiveDiskParam
-func (p *ReinstallFromArchiveDiskParam) Initialize(in Input, args []string) error {
+func (p *ReinstallFromArchiveDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2814,7 +2831,8 @@ type ReinstallFromDiskDiskParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReinstallFromDiskDiskParam return new ReinstallFromDiskDiskParam
@@ -2823,8 +2841,9 @@ func NewReinstallFromDiskDiskParam() *ReinstallFromDiskDiskParam {
 }
 
 // Initialize init ReinstallFromDiskDiskParam
-func (p *ReinstallFromDiskDiskParam) Initialize(in Input, args []string) error {
+func (p *ReinstallFromDiskDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3053,7 +3072,8 @@ type ReinstallToBlankDiskParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReinstallToBlankDiskParam return new ReinstallToBlankDiskParam
@@ -3062,8 +3082,9 @@ func NewReinstallToBlankDiskParam() *ReinstallToBlankDiskParam {
 }
 
 // Initialize init ReinstallToBlankDiskParam
-func (p *ReinstallToBlankDiskParam) Initialize(in Input, args []string) error {
+func (p *ReinstallToBlankDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3267,7 +3288,8 @@ type ServerConnectDiskParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerConnectDiskParam return new ServerConnectDiskParam
@@ -3276,8 +3298,9 @@ func NewServerConnectDiskParam() *ServerConnectDiskParam {
 }
 
 // Initialize init ServerConnectDiskParam
-func (p *ServerConnectDiskParam) Initialize(in Input, args []string) error {
+func (p *ServerConnectDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3487,7 +3510,8 @@ type ServerDisconnectDiskParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerDisconnectDiskParam return new ServerDisconnectDiskParam
@@ -3496,8 +3520,9 @@ func NewServerDisconnectDiskParam() *ServerDisconnectDiskParam {
 }
 
 // Initialize init ServerDisconnectDiskParam
-func (p *ServerDisconnectDiskParam) Initialize(in Input, args []string) error {
+func (p *ServerDisconnectDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3691,7 +3716,8 @@ type MonitorDiskParam struct {
 	KeyFormat         string
 	Start             string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorDiskParam return new MonitorDiskParam
@@ -3701,8 +3727,9 @@ func NewMonitorDiskParam() *MonitorDiskParam {
 }
 
 // Initialize init MonitorDiskParam
-func (p *MonitorDiskParam) Initialize(in Input, args []string) error {
+func (p *MonitorDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3820,7 +3847,7 @@ func (p *MonitorDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4014,7 +4041,8 @@ type WaitForCopyDiskParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForCopyDiskParam return new WaitForCopyDiskParam
@@ -4023,8 +4051,9 @@ func NewWaitForCopyDiskParam() *WaitForCopyDiskParam {
 }
 
 // Initialize init WaitForCopyDiskParam
-func (p *WaitForCopyDiskParam) Initialize(in Input, args []string) error {
+func (p *WaitForCopyDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_dns_gen.go
+++ b/pkg/params/zz_dns_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListDNSParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListDNSParam return new ListDNSParam
@@ -57,8 +59,9 @@ func NewListDNSParam() *ListDNSParam {
 }
 
 // Initialize init ListDNSParam
-func (p *ListDNSParam) Initialize(in Input, args []string) error {
+func (p *ListDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -392,7 +395,8 @@ type RecordInfoDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRecordInfoDNSParam return new RecordInfoDNSParam
@@ -401,8 +405,9 @@ func NewRecordInfoDNSParam() *RecordInfoDNSParam {
 }
 
 // Initialize init RecordInfoDNSParam
-func (p *RecordInfoDNSParam) Initialize(in Input, args []string) error {
+func (p *RecordInfoDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -509,7 +514,7 @@ func (p *RecordInfoDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -706,7 +711,8 @@ type RecordBulkUpdateDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRecordBulkUpdateDNSParam return new RecordBulkUpdateDNSParam
@@ -716,8 +722,9 @@ func NewRecordBulkUpdateDNSParam() *RecordBulkUpdateDNSParam {
 }
 
 // Initialize init RecordBulkUpdateDNSParam
-func (p *RecordBulkUpdateDNSParam) Initialize(in Input, args []string) error {
+func (p *RecordBulkUpdateDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -841,7 +848,7 @@ func (p *RecordBulkUpdateDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1045,7 +1052,8 @@ type CreateDNSParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateDNSParam return new CreateDNSParam
@@ -1054,8 +1062,9 @@ func NewCreateDNSParam() *CreateDNSParam {
 }
 
 // Initialize init CreateDNSParam
-func (p *CreateDNSParam) Initialize(in Input, args []string) error {
+func (p *CreateDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1180,7 +1189,7 @@ func (p *CreateDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1391,7 +1400,8 @@ type RecordAddDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRecordAddDNSParam return new RecordAddDNSParam
@@ -1401,8 +1411,9 @@ func NewRecordAddDNSParam() *RecordAddDNSParam {
 }
 
 // Initialize init RecordAddDNSParam
-func (p *RecordAddDNSParam) Initialize(in Input, args []string) error {
+func (p *RecordAddDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1595,7 +1606,7 @@ func (p *RecordAddDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1845,7 +1856,8 @@ type ReadDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadDNSParam return new ReadDNSParam
@@ -1854,8 +1866,9 @@ func NewReadDNSParam() *ReadDNSParam {
 }
 
 // Initialize init ReadDNSParam
-func (p *ReadDNSParam) Initialize(in Input, args []string) error {
+func (p *ReadDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1940,7 +1953,7 @@ func (p *ReadDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2131,7 +2144,8 @@ type RecordUpdateDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRecordUpdateDNSParam return new RecordUpdateDNSParam
@@ -2140,8 +2154,9 @@ func NewRecordUpdateDNSParam() *RecordUpdateDNSParam {
 }
 
 // Initialize init RecordUpdateDNSParam
-func (p *RecordUpdateDNSParam) Initialize(in Input, args []string) error {
+func (p *RecordUpdateDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2331,7 +2346,7 @@ func (p *RecordUpdateDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2590,7 +2605,8 @@ type RecordDeleteDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRecordDeleteDNSParam return new RecordDeleteDNSParam
@@ -2599,8 +2615,9 @@ func NewRecordDeleteDNSParam() *RecordDeleteDNSParam {
 }
 
 // Initialize init RecordDeleteDNSParam
-func (p *RecordDeleteDNSParam) Initialize(in Input, args []string) error {
+func (p *RecordDeleteDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2699,7 +2716,7 @@ func (p *RecordDeleteDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2897,7 +2914,8 @@ type UpdateDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateDNSParam return new UpdateDNSParam
@@ -2906,8 +2924,9 @@ func NewUpdateDNSParam() *UpdateDNSParam {
 }
 
 // Initialize init UpdateDNSParam
-func (p *UpdateDNSParam) Initialize(in Input, args []string) error {
+func (p *UpdateDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3028,7 +3047,7 @@ func (p *UpdateDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3237,7 +3256,8 @@ type DeleteDNSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteDNSParam return new DeleteDNSParam
@@ -3246,8 +3266,9 @@ func NewDeleteDNSParam() *DeleteDNSParam {
 }
 
 // Initialize init DeleteDNSParam
-func (p *DeleteDNSParam) Initialize(in Input, args []string) error {
+func (p *DeleteDNSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3335,7 +3356,7 @@ func (p *DeleteDNSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_gslb_gen.go
+++ b/pkg/params/zz_gslb_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListGSLBParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListGSLBParam return new ListGSLBParam
@@ -57,8 +59,9 @@ func NewListGSLBParam() *ListGSLBParam {
 }
 
 // Initialize init ListGSLBParam
-func (p *ListGSLBParam) Initialize(in Input, args []string) error {
+func (p *ListGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -390,7 +393,8 @@ type ServerInfoGSLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerInfoGSLBParam return new ServerInfoGSLBParam
@@ -399,8 +403,9 @@ func NewServerInfoGSLBParam() *ServerInfoGSLBParam {
 }
 
 // Initialize init ServerInfoGSLBParam
-func (p *ServerInfoGSLBParam) Initialize(in Input, args []string) error {
+func (p *ServerInfoGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -485,7 +490,7 @@ func (p *ServerInfoGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -676,7 +681,8 @@ type CreateGSLBParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateGSLBParam return new CreateGSLBParam
@@ -686,8 +692,9 @@ func NewCreateGSLBParam() *CreateGSLBParam {
 }
 
 // Initialize init CreateGSLBParam
-func (p *CreateGSLBParam) Initialize(in Input, args []string) error {
+func (p *CreateGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -874,7 +881,7 @@ func (p *CreateGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1135,7 +1142,8 @@ type ServerAddGSLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerAddGSLBParam return new ServerAddGSLBParam
@@ -1144,8 +1152,9 @@ func NewServerAddGSLBParam() *ServerAddGSLBParam {
 }
 
 // Initialize init ServerAddGSLBParam
-func (p *ServerAddGSLBParam) Initialize(in Input, args []string) error {
+func (p *ServerAddGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1258,7 +1267,7 @@ func (p *ServerAddGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1466,7 +1475,8 @@ type ReadGSLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadGSLBParam return new ReadGSLBParam
@@ -1475,8 +1485,9 @@ func NewReadGSLBParam() *ReadGSLBParam {
 }
 
 // Initialize init ReadGSLBParam
-func (p *ReadGSLBParam) Initialize(in Input, args []string) error {
+func (p *ReadGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1561,7 +1572,7 @@ func (p *ReadGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1746,7 +1757,8 @@ type ServerUpdateGSLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerUpdateGSLBParam return new ServerUpdateGSLBParam
@@ -1755,8 +1767,9 @@ func NewServerUpdateGSLBParam() *ServerUpdateGSLBParam {
 }
 
 // Initialize init ServerUpdateGSLBParam
-func (p *ServerUpdateGSLBParam) Initialize(in Input, args []string) error {
+func (p *ServerUpdateGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1880,7 +1893,7 @@ func (p *ServerUpdateGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2097,7 +2110,8 @@ type ServerDeleteGSLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerDeleteGSLBParam return new ServerDeleteGSLBParam
@@ -2106,8 +2120,9 @@ func NewServerDeleteGSLBParam() *ServerDeleteGSLBParam {
 }
 
 // Initialize init ServerDeleteGSLBParam
-func (p *ServerDeleteGSLBParam) Initialize(in Input, args []string) error {
+func (p *ServerDeleteGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2206,7 +2221,7 @@ func (p *ServerDeleteGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2413,7 +2428,8 @@ type UpdateGSLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateGSLBParam return new UpdateGSLBParam
@@ -2422,8 +2438,9 @@ func NewUpdateGSLBParam() *UpdateGSLBParam {
 }
 
 // Initialize init UpdateGSLBParam
-func (p *UpdateGSLBParam) Initialize(in Input, args []string) error {
+func (p *UpdateGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2603,7 +2620,7 @@ func (p *UpdateGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2875,7 +2892,8 @@ type DeleteGSLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteGSLBParam return new DeleteGSLBParam
@@ -2884,8 +2902,9 @@ func NewDeleteGSLBParam() *DeleteGSLBParam {
 }
 
 // Initialize init DeleteGSLBParam
-func (p *DeleteGSLBParam) Initialize(in Input, args []string) error {
+func (p *DeleteGSLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2973,7 +2992,7 @@ func (p *DeleteGSLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_icon_gen.go
+++ b/pkg/params/zz_icon_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -49,7 +50,8 @@ type ListIconParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListIconParam return new ListIconParam
@@ -58,8 +60,9 @@ func NewListIconParam() *ListIconParam {
 }
 
 // Initialize init ListIconParam
-func (p *ListIconParam) Initialize(in Input, args []string) error {
+func (p *ListIconParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -194,7 +197,7 @@ func (p *ListIconParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -411,7 +414,8 @@ type CreateIconParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateIconParam return new CreateIconParam
@@ -420,8 +424,9 @@ func NewCreateIconParam() *CreateIconParam {
 }
 
 // Initialize init CreateIconParam
-func (p *CreateIconParam) Initialize(in Input, args []string) error {
+func (p *CreateIconParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -542,7 +547,7 @@ func (p *CreateIconParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -736,7 +741,8 @@ type ReadIconParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadIconParam return new ReadIconParam
@@ -745,8 +751,9 @@ func NewReadIconParam() *ReadIconParam {
 }
 
 // Initialize init ReadIconParam
-func (p *ReadIconParam) Initialize(in Input, args []string) error {
+func (p *ReadIconParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -831,7 +838,7 @@ func (p *ReadIconParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1014,7 +1021,8 @@ type UpdateIconParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateIconParam return new UpdateIconParam
@@ -1023,8 +1031,9 @@ func NewUpdateIconParam() *UpdateIconParam {
 }
 
 // Initialize init UpdateIconParam
-func (p *UpdateIconParam) Initialize(in Input, args []string) error {
+func (p *UpdateIconParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1134,7 +1143,7 @@ func (p *UpdateIconParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1336,7 +1345,8 @@ type DeleteIconParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteIconParam return new DeleteIconParam
@@ -1345,8 +1355,9 @@ func NewDeleteIconParam() *DeleteIconParam {
 }
 
 // Initialize init DeleteIconParam
-func (p *DeleteIconParam) Initialize(in Input, args []string) error {
+func (p *DeleteIconParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1434,7 +1445,7 @@ func (p *DeleteIconParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_interface_gen.go
+++ b/pkg/params/zz_interface_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -47,7 +48,8 @@ type ListInterfaceParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListInterfaceParam return new ListInterfaceParam
@@ -56,8 +58,9 @@ func NewListInterfaceParam() *ListInterfaceParam {
 }
 
 // Initialize init ListInterfaceParam
-func (p *ListInterfaceParam) Initialize(in Input, args []string) error {
+func (p *ListInterfaceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (p *ListInterfaceParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -365,7 +368,8 @@ type PacketFilterConnectInterfaceParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPacketFilterConnectInterfaceParam return new PacketFilterConnectInterfaceParam
@@ -374,8 +378,9 @@ func NewPacketFilterConnectInterfaceParam() *PacketFilterConnectInterfaceParam {
 }
 
 // Initialize init PacketFilterConnectInterfaceParam
-func (p *PacketFilterConnectInterfaceParam) Initialize(in Input, args []string) error {
+func (p *PacketFilterConnectInterfaceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -581,7 +586,8 @@ type CreateInterfaceParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateInterfaceParam return new CreateInterfaceParam
@@ -590,8 +596,9 @@ func NewCreateInterfaceParam() *CreateInterfaceParam {
 }
 
 // Initialize init CreateInterfaceParam
-func (p *CreateInterfaceParam) Initialize(in Input, args []string) error {
+func (p *CreateInterfaceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -683,7 +690,7 @@ func (p *CreateInterfaceParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -857,7 +864,8 @@ type PacketFilterDisconnectInterfaceParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPacketFilterDisconnectInterfaceParam return new PacketFilterDisconnectInterfaceParam
@@ -866,8 +874,9 @@ func NewPacketFilterDisconnectInterfaceParam() *PacketFilterDisconnectInterfaceP
 }
 
 // Initialize init PacketFilterDisconnectInterfaceParam
-func (p *PacketFilterDisconnectInterfaceParam) Initialize(in Input, args []string) error {
+func (p *PacketFilterDisconnectInterfaceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1072,7 +1081,8 @@ type ReadInterfaceParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadInterfaceParam return new ReadInterfaceParam
@@ -1081,8 +1091,9 @@ func NewReadInterfaceParam() *ReadInterfaceParam {
 }
 
 // Initialize init ReadInterfaceParam
-func (p *ReadInterfaceParam) Initialize(in Input, args []string) error {
+func (p *ReadInterfaceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1164,7 +1175,7 @@ func (p *ReadInterfaceParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1338,7 +1349,8 @@ type UpdateInterfaceParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateInterfaceParam return new UpdateInterfaceParam
@@ -1347,8 +1359,9 @@ func NewUpdateInterfaceParam() *UpdateInterfaceParam {
 }
 
 // Initialize init UpdateInterfaceParam
-func (p *UpdateInterfaceParam) Initialize(in Input, args []string) error {
+func (p *UpdateInterfaceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1444,7 +1457,7 @@ func (p *UpdateInterfaceParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1631,7 +1644,8 @@ type DeleteInterfaceParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteInterfaceParam return new DeleteInterfaceParam
@@ -1640,8 +1654,9 @@ func NewDeleteInterfaceParam() *DeleteInterfaceParam {
 }
 
 // Initialize init DeleteInterfaceParam
-func (p *DeleteInterfaceParam) Initialize(in Input, args []string) error {
+func (p *DeleteInterfaceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1726,7 +1741,7 @@ func (p *DeleteInterfaceParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_internet_gen.go
+++ b/pkg/params/zz_internet_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListInternetParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListInternetParam return new ListInternetParam
@@ -57,8 +59,9 @@ func NewListInternetParam() *ListInternetParam {
 }
 
 // Initialize init ListInternetParam
-func (p *ListInternetParam) Initialize(in Input, args []string) error {
+func (p *ListInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -395,7 +398,8 @@ type CreateInternetParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateInternetParam return new CreateInternetParam
@@ -405,8 +409,9 @@ func NewCreateInternetParam() *CreateInternetParam {
 }
 
 // Initialize init CreateInternetParam
-func (p *CreateInternetParam) Initialize(in Input, args []string) error {
+func (p *CreateInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -567,7 +572,7 @@ func (p *CreateInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -782,7 +787,8 @@ type ReadInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadInternetParam return new ReadInternetParam
@@ -791,8 +797,9 @@ func NewReadInternetParam() *ReadInternetParam {
 }
 
 // Initialize init ReadInternetParam
-func (p *ReadInternetParam) Initialize(in Input, args []string) error {
+func (p *ReadInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -877,7 +884,7 @@ func (p *ReadInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1063,7 +1070,8 @@ type UpdateInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateInternetParam return new UpdateInternetParam
@@ -1072,8 +1080,9 @@ func NewUpdateInternetParam() *UpdateInternetParam {
 }
 
 // Initialize init UpdateInternetParam
-func (p *UpdateInternetParam) Initialize(in Input, args []string) error {
+func (p *UpdateInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1216,7 +1225,7 @@ func (p *UpdateInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1439,7 +1448,8 @@ type DeleteInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteInternetParam return new DeleteInternetParam
@@ -1448,8 +1458,9 @@ func NewDeleteInternetParam() *DeleteInternetParam {
 }
 
 // Initialize init DeleteInternetParam
-func (p *DeleteInternetParam) Initialize(in Input, args []string) error {
+func (p *DeleteInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1537,7 +1548,7 @@ func (p *DeleteInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1726,7 +1737,8 @@ type UpdateBandwidthInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateBandwidthInternetParam return new UpdateBandwidthInternetParam
@@ -1736,8 +1748,9 @@ func NewUpdateBandwidthInternetParam() *UpdateBandwidthInternetParam {
 }
 
 // Initialize init UpdateBandwidthInternetParam
-func (p *UpdateBandwidthInternetParam) Initialize(in Input, args []string) error {
+func (p *UpdateBandwidthInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1843,7 +1856,7 @@ func (p *UpdateBandwidthInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2037,7 +2050,8 @@ type SubnetInfoInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSubnetInfoInternetParam return new SubnetInfoInternetParam
@@ -2046,8 +2060,9 @@ func NewSubnetInfoInternetParam() *SubnetInfoInternetParam {
 }
 
 // Initialize init SubnetInfoInternetParam
-func (p *SubnetInfoInternetParam) Initialize(in Input, args []string) error {
+func (p *SubnetInfoInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2132,7 +2147,7 @@ func (p *SubnetInfoInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2315,7 +2330,8 @@ type SubnetAddInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSubnetAddInternetParam return new SubnetAddInternetParam
@@ -2325,8 +2341,9 @@ func NewSubnetAddInternetParam() *SubnetAddInternetParam {
 }
 
 // Initialize init SubnetAddInternetParam
-func (p *SubnetAddInternetParam) Initialize(in Input, args []string) error {
+func (p *SubnetAddInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2450,7 +2467,7 @@ func (p *SubnetAddInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2646,7 +2663,8 @@ type SubnetDeleteInternetParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSubnetDeleteInternetParam return new SubnetDeleteInternetParam
@@ -2655,8 +2673,9 @@ func NewSubnetDeleteInternetParam() *SubnetDeleteInternetParam {
 }
 
 // Initialize init SubnetDeleteInternetParam
-func (p *SubnetDeleteInternetParam) Initialize(in Input, args []string) error {
+func (p *SubnetDeleteInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2868,7 +2887,8 @@ type SubnetUpdateInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSubnetUpdateInternetParam return new SubnetUpdateInternetParam
@@ -2877,8 +2897,9 @@ func NewSubnetUpdateInternetParam() *SubnetUpdateInternetParam {
 }
 
 // Initialize init SubnetUpdateInternetParam
-func (p *SubnetUpdateInternetParam) Initialize(in Input, args []string) error {
+func (p *SubnetUpdateInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2995,7 +3016,7 @@ func (p *SubnetUpdateInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3196,7 +3217,8 @@ type IPv6InfoInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewIPv6InfoInternetParam return new IPv6InfoInternetParam
@@ -3205,8 +3227,9 @@ func NewIPv6InfoInternetParam() *IPv6InfoInternetParam {
 }
 
 // Initialize init IPv6InfoInternetParam
-func (p *IPv6InfoInternetParam) Initialize(in Input, args []string) error {
+func (p *IPv6InfoInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3291,7 +3314,7 @@ func (p *IPv6InfoInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3472,7 +3495,8 @@ type IPv6EnableInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewIPv6EnableInternetParam return new IPv6EnableInternetParam
@@ -3481,8 +3505,9 @@ func NewIPv6EnableInternetParam() *IPv6EnableInternetParam {
 }
 
 // Initialize init IPv6EnableInternetParam
-func (p *IPv6EnableInternetParam) Initialize(in Input, args []string) error {
+func (p *IPv6EnableInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3570,7 +3595,7 @@ func (p *IPv6EnableInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3751,7 +3776,8 @@ type IPv6DisableInternetParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewIPv6DisableInternetParam return new IPv6DisableInternetParam
@@ -3760,8 +3786,9 @@ func NewIPv6DisableInternetParam() *IPv6DisableInternetParam {
 }
 
 // Initialize init IPv6DisableInternetParam
-func (p *IPv6DisableInternetParam) Initialize(in Input, args []string) error {
+func (p *IPv6DisableInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3955,7 +3982,8 @@ type MonitorInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorInternetParam return new MonitorInternetParam
@@ -3965,8 +3993,9 @@ func NewMonitorInternetParam() *MonitorInternetParam {
 }
 
 // Initialize init MonitorInternetParam
-func (p *MonitorInternetParam) Initialize(in Input, args []string) error {
+func (p *MonitorInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4084,7 +4113,7 @@ func (p *MonitorInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_ipv4_gen.go
+++ b/pkg/params/zz_ipv4_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -47,7 +48,8 @@ type ListIPv4Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListIPv4Param return new ListIPv4Param
@@ -56,8 +58,9 @@ func NewListIPv4Param() *ListIPv4Param {
 }
 
 // Initialize init ListIPv4Param
-func (p *ListIPv4Param) Initialize(in Input, args []string) error {
+func (p *ListIPv4Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (p *ListIPv4Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -371,7 +374,8 @@ type PtrAddIPv4Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrAddIPv4Param return new PtrAddIPv4Param
@@ -380,8 +384,9 @@ func NewPtrAddIPv4Param() *PtrAddIPv4Param {
 }
 
 // Initialize init PtrAddIPv4Param
-func (p *PtrAddIPv4Param) Initialize(in Input, args []string) error {
+func (p *PtrAddIPv4Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -466,7 +471,7 @@ func (p *PtrAddIPv4Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -644,7 +649,8 @@ type PtrReadIPv4Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrReadIPv4Param return new PtrReadIPv4Param
@@ -653,8 +659,9 @@ func NewPtrReadIPv4Param() *PtrReadIPv4Param {
 }
 
 // Initialize init PtrReadIPv4Param
-func (p *PtrReadIPv4Param) Initialize(in Input, args []string) error {
+func (p *PtrReadIPv4Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -725,7 +732,7 @@ func (p *PtrReadIPv4Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -891,7 +898,8 @@ type PtrUpdateIPv4Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrUpdateIPv4Param return new PtrUpdateIPv4Param
@@ -900,8 +908,9 @@ func NewPtrUpdateIPv4Param() *PtrUpdateIPv4Param {
 }
 
 // Initialize init PtrUpdateIPv4Param
-func (p *PtrUpdateIPv4Param) Initialize(in Input, args []string) error {
+func (p *PtrUpdateIPv4Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -986,7 +995,7 @@ func (p *PtrUpdateIPv4Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1165,7 +1174,8 @@ type PtrDeleteIPv4Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrDeleteIPv4Param return new PtrDeleteIPv4Param
@@ -1174,8 +1184,9 @@ func NewPtrDeleteIPv4Param() *PtrDeleteIPv4Param {
 }
 
 // Initialize init PtrDeleteIPv4Param
-func (p *PtrDeleteIPv4Param) Initialize(in Input, args []string) error {
+func (p *PtrDeleteIPv4Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1249,7 +1260,7 @@ func (p *PtrDeleteIPv4Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_ipv6_gen.go
+++ b/pkg/params/zz_ipv6_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -49,7 +50,8 @@ type ListIPv6Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListIPv6Param return new ListIPv6Param
@@ -58,8 +60,9 @@ func NewListIPv6Param() *ListIPv6Param {
 }
 
 // Initialize init ListIPv6Param
-func (p *ListIPv6Param) Initialize(in Input, args []string) error {
+func (p *ListIPv6Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -194,7 +197,7 @@ func (p *ListIPv6Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -409,7 +412,8 @@ type PtrAddIPv6Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrAddIPv6Param return new PtrAddIPv6Param
@@ -418,8 +422,9 @@ func NewPtrAddIPv6Param() *PtrAddIPv6Param {
 }
 
 // Initialize init PtrAddIPv6Param
-func (p *PtrAddIPv6Param) Initialize(in Input, args []string) error {
+func (p *PtrAddIPv6Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -504,7 +509,7 @@ func (p *PtrAddIPv6Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -682,7 +687,8 @@ type PtrReadIPv6Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrReadIPv6Param return new PtrReadIPv6Param
@@ -691,8 +697,9 @@ func NewPtrReadIPv6Param() *PtrReadIPv6Param {
 }
 
 // Initialize init PtrReadIPv6Param
-func (p *PtrReadIPv6Param) Initialize(in Input, args []string) error {
+func (p *PtrReadIPv6Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -763,7 +770,7 @@ func (p *PtrReadIPv6Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -929,7 +936,8 @@ type PtrUpdateIPv6Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrUpdateIPv6Param return new PtrUpdateIPv6Param
@@ -938,8 +946,9 @@ func NewPtrUpdateIPv6Param() *PtrUpdateIPv6Param {
 }
 
 // Initialize init PtrUpdateIPv6Param
-func (p *PtrUpdateIPv6Param) Initialize(in Input, args []string) error {
+func (p *PtrUpdateIPv6Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1024,7 +1033,7 @@ func (p *PtrUpdateIPv6Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1203,7 +1212,8 @@ type PtrDeleteIPv6Param struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPtrDeleteIPv6Param return new PtrDeleteIPv6Param
@@ -1212,8 +1222,9 @@ func NewPtrDeleteIPv6Param() *PtrDeleteIPv6Param {
 }
 
 // Initialize init PtrDeleteIPv6Param
-func (p *PtrDeleteIPv6Param) Initialize(in Input, args []string) error {
+func (p *PtrDeleteIPv6Param) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1287,7 +1298,7 @@ func (p *PtrDeleteIPv6Param) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_iso_image_gen.go
+++ b/pkg/params/zz_iso_image_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -49,7 +50,8 @@ type ListISOImageParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListISOImageParam return new ListISOImageParam
@@ -58,8 +60,9 @@ func NewListISOImageParam() *ListISOImageParam {
 }
 
 // Initialize init ListISOImageParam
-func (p *ListISOImageParam) Initialize(in Input, args []string) error {
+func (p *ListISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -194,7 +197,7 @@ func (p *ListISOImageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -414,7 +417,8 @@ type CreateISOImageParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateISOImageParam return new CreateISOImageParam
@@ -424,8 +428,9 @@ func NewCreateISOImageParam() *CreateISOImageParam {
 }
 
 // Initialize init CreateISOImageParam
-func (p *CreateISOImageParam) Initialize(in Input, args []string) error {
+func (p *CreateISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -579,7 +584,7 @@ func (p *CreateISOImageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -794,7 +799,8 @@ type ReadISOImageParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadISOImageParam return new ReadISOImageParam
@@ -803,8 +809,9 @@ func NewReadISOImageParam() *ReadISOImageParam {
 }
 
 // Initialize init ReadISOImageParam
-func (p *ReadISOImageParam) Initialize(in Input, args []string) error {
+func (p *ReadISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -889,7 +896,7 @@ func (p *ReadISOImageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1074,7 +1081,8 @@ type UpdateISOImageParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateISOImageParam return new UpdateISOImageParam
@@ -1083,8 +1091,9 @@ func NewUpdateISOImageParam() *UpdateISOImageParam {
 }
 
 // Initialize init UpdateISOImageParam
-func (p *UpdateISOImageParam) Initialize(in Input, args []string) error {
+func (p *UpdateISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1216,7 +1225,7 @@ func (p *UpdateISOImageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1432,7 +1441,8 @@ type DeleteISOImageParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteISOImageParam return new DeleteISOImageParam
@@ -1441,8 +1451,9 @@ func NewDeleteISOImageParam() *DeleteISOImageParam {
 }
 
 // Initialize init DeleteISOImageParam
-func (p *DeleteISOImageParam) Initialize(in Input, args []string) error {
+func (p *DeleteISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1530,7 +1541,7 @@ func (p *DeleteISOImageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1719,7 +1730,8 @@ type UploadISOImageParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUploadISOImageParam return new UploadISOImageParam
@@ -1728,8 +1740,9 @@ func NewUploadISOImageParam() *UploadISOImageParam {
 }
 
 // Initialize init UploadISOImageParam
-func (p *UploadISOImageParam) Initialize(in Input, args []string) error {
+func (p *UploadISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1828,7 +1841,7 @@ func (p *UploadISOImageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2017,7 +2030,8 @@ type DownloadISOImageParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDownloadISOImageParam return new DownloadISOImageParam
@@ -2026,8 +2040,9 @@ func NewDownloadISOImageParam() *DownloadISOImageParam {
 }
 
 // Initialize init DownloadISOImageParam
-func (p *DownloadISOImageParam) Initialize(in Input, args []string) error {
+func (p *DownloadISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2229,7 +2244,8 @@ type FTPOpenISOImageParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFTPOpenISOImageParam return new FTPOpenISOImageParam
@@ -2238,8 +2254,9 @@ func NewFTPOpenISOImageParam() *FTPOpenISOImageParam {
 }
 
 // Initialize init FTPOpenISOImageParam
-func (p *FTPOpenISOImageParam) Initialize(in Input, args []string) error {
+func (p *FTPOpenISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2327,7 +2344,7 @@ func (p *FTPOpenISOImageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2508,7 +2525,8 @@ type FTPCloseISOImageParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFTPCloseISOImageParam return new FTPCloseISOImageParam
@@ -2517,8 +2535,9 @@ func NewFTPCloseISOImageParam() *FTPCloseISOImageParam {
 }
 
 // Initialize init FTPCloseISOImageParam
-func (p *FTPCloseISOImageParam) Initialize(in Input, args []string) error {
+func (p *FTPCloseISOImageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_license_gen.go
+++ b/pkg/params/zz_license_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -47,7 +48,8 @@ type ListLicenseParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListLicenseParam return new ListLicenseParam
@@ -56,8 +58,9 @@ func NewListLicenseParam() *ListLicenseParam {
 }
 
 // Initialize init ListLicenseParam
-func (p *ListLicenseParam) Initialize(in Input, args []string) error {
+func (p *ListLicenseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (p *ListLicenseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type CreateLicenseParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateLicenseParam return new CreateLicenseParam
@@ -381,8 +385,9 @@ func NewCreateLicenseParam() *CreateLicenseParam {
 }
 
 // Initialize init CreateLicenseParam
-func (p *CreateLicenseParam) Initialize(in Input, args []string) error {
+func (p *CreateLicenseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -477,7 +482,7 @@ func (p *CreateLicenseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -663,7 +668,8 @@ type ReadLicenseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadLicenseParam return new ReadLicenseParam
@@ -672,8 +678,9 @@ func NewReadLicenseParam() *ReadLicenseParam {
 }
 
 // Initialize init ReadLicenseParam
-func (p *ReadLicenseParam) Initialize(in Input, args []string) error {
+func (p *ReadLicenseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -755,7 +762,7 @@ func (p *ReadLicenseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -929,7 +936,8 @@ type UpdateLicenseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateLicenseParam return new UpdateLicenseParam
@@ -938,8 +946,9 @@ func NewUpdateLicenseParam() *UpdateLicenseParam {
 }
 
 // Initialize init UpdateLicenseParam
-func (p *UpdateLicenseParam) Initialize(in Input, args []string) error {
+func (p *UpdateLicenseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1035,7 +1044,7 @@ func (p *UpdateLicenseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1222,7 +1231,8 @@ type DeleteLicenseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteLicenseParam return new DeleteLicenseParam
@@ -1231,8 +1241,9 @@ func NewDeleteLicenseParam() *DeleteLicenseParam {
 }
 
 // Initialize init DeleteLicenseParam
-func (p *DeleteLicenseParam) Initialize(in Input, args []string) error {
+func (p *DeleteLicenseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1317,7 +1328,7 @@ func (p *DeleteLicenseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_load_balancer_gen.go
+++ b/pkg/params/zz_load_balancer_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListLoadBalancerParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListLoadBalancerParam return new ListLoadBalancerParam
@@ -57,8 +59,9 @@ func NewListLoadBalancerParam() *ListLoadBalancerParam {
 }
 
 // Initialize init ListLoadBalancerParam
-func (p *ListLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ListLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -401,7 +404,8 @@ type CreateLoadBalancerParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateLoadBalancerParam return new CreateLoadBalancerParam
@@ -411,8 +415,9 @@ func NewCreateLoadBalancerParam() *CreateLoadBalancerParam {
 }
 
 // Initialize init CreateLoadBalancerParam
-func (p *CreateLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *CreateLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -638,7 +643,7 @@ func (p *CreateLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -895,7 +900,8 @@ type ReadLoadBalancerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadLoadBalancerParam return new ReadLoadBalancerParam
@@ -904,8 +910,9 @@ func NewReadLoadBalancerParam() *ReadLoadBalancerParam {
 }
 
 // Initialize init ReadLoadBalancerParam
-func (p *ReadLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ReadLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -990,7 +997,7 @@ func (p *ReadLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1175,7 +1182,8 @@ type UpdateLoadBalancerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateLoadBalancerParam return new UpdateLoadBalancerParam
@@ -1184,8 +1192,9 @@ func NewUpdateLoadBalancerParam() *UpdateLoadBalancerParam {
 }
 
 // Initialize init UpdateLoadBalancerParam
-func (p *UpdateLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *UpdateLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1317,7 +1326,7 @@ func (p *UpdateLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1534,7 +1543,8 @@ type DeleteLoadBalancerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteLoadBalancerParam return new DeleteLoadBalancerParam
@@ -1543,8 +1553,9 @@ func NewDeleteLoadBalancerParam() *DeleteLoadBalancerParam {
 }
 
 // Initialize init DeleteLoadBalancerParam
-func (p *DeleteLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *DeleteLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1635,7 +1646,7 @@ func (p *DeleteLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1823,7 +1834,8 @@ type BootLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBootLoadBalancerParam return new BootLoadBalancerParam
@@ -1832,8 +1844,9 @@ func NewBootLoadBalancerParam() *BootLoadBalancerParam {
 }
 
 // Initialize init BootLoadBalancerParam
-func (p *BootLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *BootLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2018,7 +2031,8 @@ type ShutdownLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownLoadBalancerParam return new ShutdownLoadBalancerParam
@@ -2027,8 +2041,9 @@ func NewShutdownLoadBalancerParam() *ShutdownLoadBalancerParam {
 }
 
 // Initialize init ShutdownLoadBalancerParam
-func (p *ShutdownLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ShutdownLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2213,7 +2228,8 @@ type ShutdownForceLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownForceLoadBalancerParam return new ShutdownForceLoadBalancerParam
@@ -2222,8 +2238,9 @@ func NewShutdownForceLoadBalancerParam() *ShutdownForceLoadBalancerParam {
 }
 
 // Initialize init ShutdownForceLoadBalancerParam
-func (p *ShutdownForceLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ShutdownForceLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2408,7 +2425,8 @@ type ResetLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResetLoadBalancerParam return new ResetLoadBalancerParam
@@ -2417,8 +2435,9 @@ func NewResetLoadBalancerParam() *ResetLoadBalancerParam {
 }
 
 // Initialize init ResetLoadBalancerParam
-func (p *ResetLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ResetLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2602,7 +2621,8 @@ type WaitForBootLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForBootLoadBalancerParam return new WaitForBootLoadBalancerParam
@@ -2611,8 +2631,9 @@ func NewWaitForBootLoadBalancerParam() *WaitForBootLoadBalancerParam {
 }
 
 // Initialize init WaitForBootLoadBalancerParam
-func (p *WaitForBootLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *WaitForBootLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2786,7 +2807,8 @@ type WaitForDownLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForDownLoadBalancerParam return new WaitForDownLoadBalancerParam
@@ -2795,8 +2817,9 @@ func NewWaitForDownLoadBalancerParam() *WaitForDownLoadBalancerParam {
 }
 
 // Initialize init WaitForDownLoadBalancerParam
-func (p *WaitForDownLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *WaitForDownLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2977,7 +3000,8 @@ type VipInfoLoadBalancerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVipInfoLoadBalancerParam return new VipInfoLoadBalancerParam
@@ -2986,8 +3010,9 @@ func NewVipInfoLoadBalancerParam() *VipInfoLoadBalancerParam {
 }
 
 // Initialize init VipInfoLoadBalancerParam
-func (p *VipInfoLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *VipInfoLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3072,7 +3097,7 @@ func (p *VipInfoLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3251,7 +3276,8 @@ type VipAddLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVipAddLoadBalancerParam return new VipAddLoadBalancerParam
@@ -3261,8 +3287,9 @@ func NewVipAddLoadBalancerParam() *VipAddLoadBalancerParam {
 }
 
 // Initialize init VipAddLoadBalancerParam
-func (p *VipAddLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *VipAddLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3549,7 +3576,8 @@ type VipUpdateLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVipUpdateLoadBalancerParam return new VipUpdateLoadBalancerParam
@@ -3559,8 +3587,9 @@ func NewVipUpdateLoadBalancerParam() *VipUpdateLoadBalancerParam {
 }
 
 // Initialize init VipUpdateLoadBalancerParam
-func (p *VipUpdateLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *VipUpdateLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3846,7 +3875,8 @@ type VipDeleteLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVipDeleteLoadBalancerParam return new VipDeleteLoadBalancerParam
@@ -3855,8 +3885,9 @@ func NewVipDeleteLoadBalancerParam() *VipDeleteLoadBalancerParam {
 }
 
 // Initialize init VipDeleteLoadBalancerParam
-func (p *VipDeleteLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *VipDeleteLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4068,7 +4099,8 @@ type ServerInfoLoadBalancerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerInfoLoadBalancerParam return new ServerInfoLoadBalancerParam
@@ -4077,8 +4109,9 @@ func NewServerInfoLoadBalancerParam() *ServerInfoLoadBalancerParam {
 }
 
 // Initialize init ServerInfoLoadBalancerParam
-func (p *ServerInfoLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ServerInfoLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4217,7 +4250,7 @@ func (p *ServerInfoLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4420,7 +4453,8 @@ type ServerAddLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerAddLoadBalancerParam return new ServerAddLoadBalancerParam
@@ -4430,8 +4464,9 @@ func NewServerAddLoadBalancerParam() *ServerAddLoadBalancerParam {
 }
 
 // Initialize init ServerAddLoadBalancerParam
-func (p *ServerAddLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ServerAddLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4779,7 +4814,8 @@ type ServerUpdateLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerUpdateLoadBalancerParam return new ServerUpdateLoadBalancerParam
@@ -4788,8 +4824,9 @@ func NewServerUpdateLoadBalancerParam() *ServerUpdateLoadBalancerParam {
 }
 
 // Initialize init ServerUpdateLoadBalancerParam
-func (p *ServerUpdateLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ServerUpdateLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5126,7 +5163,8 @@ type ServerDeleteLoadBalancerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerDeleteLoadBalancerParam return new ServerDeleteLoadBalancerParam
@@ -5135,8 +5173,9 @@ func NewServerDeleteLoadBalancerParam() *ServerDeleteLoadBalancerParam {
 }
 
 // Initialize init ServerDeleteLoadBalancerParam
-func (p *ServerDeleteLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *ServerDeleteLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5430,7 +5469,8 @@ type MonitorLoadBalancerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorLoadBalancerParam return new MonitorLoadBalancerParam
@@ -5440,8 +5480,9 @@ func NewMonitorLoadBalancerParam() *MonitorLoadBalancerParam {
 }
 
 // Initialize init MonitorLoadBalancerParam
-func (p *MonitorLoadBalancerParam) Initialize(in Input, args []string) error {
+func (p *MonitorLoadBalancerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5559,7 +5600,7 @@ func (p *MonitorLoadBalancerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_mobile_gateway_gen.go
+++ b/pkg/params/zz_mobile_gateway_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListMobileGatewayParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListMobileGatewayParam return new ListMobileGatewayParam
@@ -57,8 +59,9 @@ func NewListMobileGatewayParam() *ListMobileGatewayParam {
 }
 
 // Initialize init ListMobileGatewayParam
-func (p *ListMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *ListMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -394,7 +397,8 @@ type CreateMobileGatewayParam struct {
 	Query              string
 	QueryFile          string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateMobileGatewayParam return new CreateMobileGatewayParam
@@ -403,8 +407,9 @@ func NewCreateMobileGatewayParam() *CreateMobileGatewayParam {
 }
 
 // Initialize init CreateMobileGatewayParam
-func (p *CreateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *CreateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -532,7 +537,7 @@ func (p *CreateMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -740,7 +745,8 @@ type ReadMobileGatewayParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadMobileGatewayParam return new ReadMobileGatewayParam
@@ -749,8 +755,9 @@ func NewReadMobileGatewayParam() *ReadMobileGatewayParam {
 }
 
 // Initialize init ReadMobileGatewayParam
-func (p *ReadMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *ReadMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -835,7 +842,7 @@ func (p *ReadMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1021,7 +1028,8 @@ type UpdateMobileGatewayParam struct {
 	QueryFile          string
 	Id                 sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateMobileGatewayParam return new UpdateMobileGatewayParam
@@ -1030,8 +1038,9 @@ func NewUpdateMobileGatewayParam() *UpdateMobileGatewayParam {
 }
 
 // Initialize init UpdateMobileGatewayParam
-func (p *UpdateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *UpdateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1166,7 +1175,7 @@ func (p *UpdateMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1390,7 +1399,8 @@ type DeleteMobileGatewayParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteMobileGatewayParam return new DeleteMobileGatewayParam
@@ -1399,8 +1409,9 @@ func NewDeleteMobileGatewayParam() *DeleteMobileGatewayParam {
 }
 
 // Initialize init DeleteMobileGatewayParam
-func (p *DeleteMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *DeleteMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1491,7 +1502,7 @@ func (p *DeleteMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1679,7 +1690,8 @@ type BootMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBootMobileGatewayParam return new BootMobileGatewayParam
@@ -1688,8 +1700,9 @@ func NewBootMobileGatewayParam() *BootMobileGatewayParam {
 }
 
 // Initialize init BootMobileGatewayParam
-func (p *BootMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *BootMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1874,7 +1887,8 @@ type ShutdownMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownMobileGatewayParam return new ShutdownMobileGatewayParam
@@ -1883,8 +1897,9 @@ func NewShutdownMobileGatewayParam() *ShutdownMobileGatewayParam {
 }
 
 // Initialize init ShutdownMobileGatewayParam
-func (p *ShutdownMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *ShutdownMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2069,7 +2084,8 @@ type ShutdownForceMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownForceMobileGatewayParam return new ShutdownForceMobileGatewayParam
@@ -2078,8 +2094,9 @@ func NewShutdownForceMobileGatewayParam() *ShutdownForceMobileGatewayParam {
 }
 
 // Initialize init ShutdownForceMobileGatewayParam
-func (p *ShutdownForceMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *ShutdownForceMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2264,7 +2281,8 @@ type ResetMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResetMobileGatewayParam return new ResetMobileGatewayParam
@@ -2273,8 +2291,9 @@ func NewResetMobileGatewayParam() *ResetMobileGatewayParam {
 }
 
 // Initialize init ResetMobileGatewayParam
-func (p *ResetMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *ResetMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2458,7 +2477,8 @@ type WaitForBootMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForBootMobileGatewayParam return new WaitForBootMobileGatewayParam
@@ -2467,8 +2487,9 @@ func NewWaitForBootMobileGatewayParam() *WaitForBootMobileGatewayParam {
 }
 
 // Initialize init WaitForBootMobileGatewayParam
-func (p *WaitForBootMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *WaitForBootMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2642,7 +2663,8 @@ type WaitForDownMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForDownMobileGatewayParam return new WaitForDownMobileGatewayParam
@@ -2651,8 +2673,9 @@ func NewWaitForDownMobileGatewayParam() *WaitForDownMobileGatewayParam {
 }
 
 // Initialize init WaitForDownMobileGatewayParam
-func (p *WaitForDownMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *WaitForDownMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2833,7 +2856,8 @@ type InterfaceInfoMobileGatewayParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceInfoMobileGatewayParam return new InterfaceInfoMobileGatewayParam
@@ -2842,8 +2866,9 @@ func NewInterfaceInfoMobileGatewayParam() *InterfaceInfoMobileGatewayParam {
 }
 
 // Initialize init InterfaceInfoMobileGatewayParam
-func (p *InterfaceInfoMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *InterfaceInfoMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2928,7 +2953,7 @@ func (p *InterfaceInfoMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3105,7 +3130,8 @@ type InterfaceConnectMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceConnectMobileGatewayParam return new InterfaceConnectMobileGatewayParam
@@ -3115,8 +3141,9 @@ func NewInterfaceConnectMobileGatewayParam() *InterfaceConnectMobileGatewayParam
 }
 
 // Initialize init InterfaceConnectMobileGatewayParam
-func (p *InterfaceConnectMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *InterfaceConnectMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3371,7 +3398,8 @@ type InterfaceUpdateMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceUpdateMobileGatewayParam return new InterfaceUpdateMobileGatewayParam
@@ -3381,8 +3409,9 @@ func NewInterfaceUpdateMobileGatewayParam() *InterfaceUpdateMobileGatewayParam {
 }
 
 // Initialize init InterfaceUpdateMobileGatewayParam
-func (p *InterfaceUpdateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *InterfaceUpdateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3603,7 +3632,8 @@ type InterfaceDisconnectMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceDisconnectMobileGatewayParam return new InterfaceDisconnectMobileGatewayParam
@@ -3612,8 +3642,9 @@ func NewInterfaceDisconnectMobileGatewayParam() *InterfaceDisconnectMobileGatewa
 }
 
 // Initialize init InterfaceDisconnectMobileGatewayParam
-func (p *InterfaceDisconnectMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *InterfaceDisconnectMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3804,7 +3835,8 @@ type TrafficControlInfoMobileGatewayParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewTrafficControlInfoMobileGatewayParam return new TrafficControlInfoMobileGatewayParam
@@ -3813,8 +3845,9 @@ func NewTrafficControlInfoMobileGatewayParam() *TrafficControlInfoMobileGatewayP
 }
 
 // Initialize init TrafficControlInfoMobileGatewayParam
-func (p *TrafficControlInfoMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *TrafficControlInfoMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3899,7 +3932,7 @@ func (p *TrafficControlInfoMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4078,7 +4111,8 @@ type TrafficControlEnableMobileGatewayParam struct {
 	GenerateSkeleton   bool
 	Id                 sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewTrafficControlEnableMobileGatewayParam return new TrafficControlEnableMobileGatewayParam
@@ -4088,8 +4122,9 @@ func NewTrafficControlEnableMobileGatewayParam() *TrafficControlEnableMobileGate
 }
 
 // Initialize init TrafficControlEnableMobileGatewayParam
-func (p *TrafficControlEnableMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *TrafficControlEnableMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4360,7 +4395,8 @@ type TrafficControlUpdateMobileGatewayParam struct {
 	GenerateSkeleton   bool
 	Id                 sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewTrafficControlUpdateMobileGatewayParam return new TrafficControlUpdateMobileGatewayParam
@@ -4369,8 +4405,9 @@ func NewTrafficControlUpdateMobileGatewayParam() *TrafficControlUpdateMobileGate
 }
 
 // Initialize init TrafficControlUpdateMobileGatewayParam
-func (p *TrafficControlUpdateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *TrafficControlUpdateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4629,7 +4666,8 @@ type TrafficControlDisableMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewTrafficControlDisableMobileGatewayParam return new TrafficControlDisableMobileGatewayParam
@@ -4638,8 +4676,9 @@ func NewTrafficControlDisableMobileGatewayParam() *TrafficControlDisableMobileGa
 }
 
 // Initialize init TrafficControlDisableMobileGatewayParam
-func (p *TrafficControlDisableMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *TrafficControlDisableMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4830,7 +4869,8 @@ type StaticRouteInfoMobileGatewayParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteInfoMobileGatewayParam return new StaticRouteInfoMobileGatewayParam
@@ -4839,8 +4879,9 @@ func NewStaticRouteInfoMobileGatewayParam() *StaticRouteInfoMobileGatewayParam {
 }
 
 // Initialize init StaticRouteInfoMobileGatewayParam
-func (p *StaticRouteInfoMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteInfoMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4925,7 +4966,7 @@ func (p *StaticRouteInfoMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5101,7 +5142,8 @@ type StaticRouteAddMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteAddMobileGatewayParam return new StaticRouteAddMobileGatewayParam
@@ -5110,8 +5152,9 @@ func NewStaticRouteAddMobileGatewayParam() *StaticRouteAddMobileGatewayParam {
 }
 
 // Initialize init StaticRouteAddMobileGatewayParam
-func (p *StaticRouteAddMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteAddMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5349,7 +5392,8 @@ type StaticRouteUpdateMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteUpdateMobileGatewayParam return new StaticRouteUpdateMobileGatewayParam
@@ -5358,8 +5402,9 @@ func NewStaticRouteUpdateMobileGatewayParam() *StaticRouteUpdateMobileGatewayPar
 }
 
 // Initialize init StaticRouteUpdateMobileGatewayParam
-func (p *StaticRouteUpdateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteUpdateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5599,7 +5644,8 @@ type StaticRouteDeleteMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteDeleteMobileGatewayParam return new StaticRouteDeleteMobileGatewayParam
@@ -5608,8 +5654,9 @@ func NewStaticRouteDeleteMobileGatewayParam() *StaticRouteDeleteMobileGatewayPar
 }
 
 // Initialize init StaticRouteDeleteMobileGatewayParam
-func (p *StaticRouteDeleteMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteDeleteMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5818,7 +5865,8 @@ type SIMInfoMobileGatewayParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMInfoMobileGatewayParam return new SIMInfoMobileGatewayParam
@@ -5827,8 +5875,9 @@ func NewSIMInfoMobileGatewayParam() *SIMInfoMobileGatewayParam {
 }
 
 // Initialize init SIMInfoMobileGatewayParam
-func (p *SIMInfoMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMInfoMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5913,7 +5962,7 @@ func (p *SIMInfoMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6089,7 +6138,8 @@ type SIMAddMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMAddMobileGatewayParam return new SIMAddMobileGatewayParam
@@ -6098,8 +6148,9 @@ func NewSIMAddMobileGatewayParam() *SIMAddMobileGatewayParam {
 }
 
 // Initialize init SIMAddMobileGatewayParam
-func (p *SIMAddMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMAddMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6336,7 +6387,8 @@ type SIMUpdateMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMUpdateMobileGatewayParam return new SIMUpdateMobileGatewayParam
@@ -6345,8 +6397,9 @@ func NewSIMUpdateMobileGatewayParam() *SIMUpdateMobileGatewayParam {
 }
 
 // Initialize init SIMUpdateMobileGatewayParam
-func (p *SIMUpdateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMUpdateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6575,7 +6628,8 @@ type SIMDeleteMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMDeleteMobileGatewayParam return new SIMDeleteMobileGatewayParam
@@ -6584,8 +6638,9 @@ func NewSIMDeleteMobileGatewayParam() *SIMDeleteMobileGatewayParam {
 }
 
 // Initialize init SIMDeleteMobileGatewayParam
-func (p *SIMDeleteMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMDeleteMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6801,7 +6856,8 @@ type SIMRouteInfoMobileGatewayParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMRouteInfoMobileGatewayParam return new SIMRouteInfoMobileGatewayParam
@@ -6810,8 +6866,9 @@ func NewSIMRouteInfoMobileGatewayParam() *SIMRouteInfoMobileGatewayParam {
 }
 
 // Initialize init SIMRouteInfoMobileGatewayParam
-func (p *SIMRouteInfoMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMRouteInfoMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6896,7 +6953,7 @@ func (p *SIMRouteInfoMobileGatewayParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7072,7 +7129,8 @@ type SIMRouteAddMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMRouteAddMobileGatewayParam return new SIMRouteAddMobileGatewayParam
@@ -7081,8 +7139,9 @@ func NewSIMRouteAddMobileGatewayParam() *SIMRouteAddMobileGatewayParam {
 }
 
 // Initialize init SIMRouteAddMobileGatewayParam
-func (p *SIMRouteAddMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMRouteAddMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7320,7 +7379,8 @@ type SIMRouteUpdateMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMRouteUpdateMobileGatewayParam return new SIMRouteUpdateMobileGatewayParam
@@ -7329,8 +7389,9 @@ func NewSIMRouteUpdateMobileGatewayParam() *SIMRouteUpdateMobileGatewayParam {
 }
 
 // Initialize init SIMRouteUpdateMobileGatewayParam
-func (p *SIMRouteUpdateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMRouteUpdateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7570,7 +7631,8 @@ type SIMRouteDeleteMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSIMRouteDeleteMobileGatewayParam return new SIMRouteDeleteMobileGatewayParam
@@ -7579,8 +7641,9 @@ func NewSIMRouteDeleteMobileGatewayParam() *SIMRouteDeleteMobileGatewayParam {
 }
 
 // Initialize init SIMRouteDeleteMobileGatewayParam
-func (p *SIMRouteDeleteMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *SIMRouteDeleteMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7785,7 +7848,8 @@ type DNSUpdateMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDNSUpdateMobileGatewayParam return new DNSUpdateMobileGatewayParam
@@ -7794,8 +7858,9 @@ func NewDNSUpdateMobileGatewayParam() *DNSUpdateMobileGatewayParam {
 }
 
 // Initialize init DNSUpdateMobileGatewayParam
-func (p *DNSUpdateMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *DNSUpdateMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8031,7 +8096,8 @@ type LogsMobileGatewayParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewLogsMobileGatewayParam return new LogsMobileGatewayParam
@@ -8041,8 +8107,9 @@ func NewLogsMobileGatewayParam() *LogsMobileGatewayParam {
 }
 
 // Initialize init LogsMobileGatewayParam
-func (p *LogsMobileGatewayParam) Initialize(in Input, args []string) error {
+func (p *LogsMobileGatewayParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_nfs_gen.go
+++ b/pkg/params/zz_nfs_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListNFSParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListNFSParam return new ListNFSParam
@@ -57,8 +59,9 @@ func NewListNFSParam() *ListNFSParam {
 }
 
 // Initialize init ListNFSParam
-func (p *ListNFSParam) Initialize(in Input, args []string) error {
+func (p *ListNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListNFSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -399,7 +402,8 @@ type CreateNFSParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateNFSParam return new CreateNFSParam
@@ -409,8 +413,9 @@ func NewCreateNFSParam() *CreateNFSParam {
 }
 
 // Initialize init CreateNFSParam
-func (p *CreateNFSParam) Initialize(in Input, args []string) error {
+func (p *CreateNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -636,7 +641,7 @@ func (p *CreateNFSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -879,7 +884,8 @@ type ReadNFSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadNFSParam return new ReadNFSParam
@@ -888,8 +894,9 @@ func NewReadNFSParam() *ReadNFSParam {
 }
 
 // Initialize init ReadNFSParam
-func (p *ReadNFSParam) Initialize(in Input, args []string) error {
+func (p *ReadNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -974,7 +981,7 @@ func (p *ReadNFSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1159,7 +1166,8 @@ type UpdateNFSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateNFSParam return new UpdateNFSParam
@@ -1168,8 +1176,9 @@ func NewUpdateNFSParam() *UpdateNFSParam {
 }
 
 // Initialize init UpdateNFSParam
-func (p *UpdateNFSParam) Initialize(in Input, args []string) error {
+func (p *UpdateNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1301,7 +1310,7 @@ func (p *UpdateNFSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1518,7 +1527,8 @@ type DeleteNFSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteNFSParam return new DeleteNFSParam
@@ -1527,8 +1537,9 @@ func NewDeleteNFSParam() *DeleteNFSParam {
 }
 
 // Initialize init DeleteNFSParam
-func (p *DeleteNFSParam) Initialize(in Input, args []string) error {
+func (p *DeleteNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1619,7 +1630,7 @@ func (p *DeleteNFSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1807,7 +1818,8 @@ type BootNFSParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBootNFSParam return new BootNFSParam
@@ -1816,8 +1828,9 @@ func NewBootNFSParam() *BootNFSParam {
 }
 
 // Initialize init BootNFSParam
-func (p *BootNFSParam) Initialize(in Input, args []string) error {
+func (p *BootNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2002,7 +2015,8 @@ type ShutdownNFSParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownNFSParam return new ShutdownNFSParam
@@ -2011,8 +2025,9 @@ func NewShutdownNFSParam() *ShutdownNFSParam {
 }
 
 // Initialize init ShutdownNFSParam
-func (p *ShutdownNFSParam) Initialize(in Input, args []string) error {
+func (p *ShutdownNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2197,7 +2212,8 @@ type ShutdownForceNFSParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownForceNFSParam return new ShutdownForceNFSParam
@@ -2206,8 +2222,9 @@ func NewShutdownForceNFSParam() *ShutdownForceNFSParam {
 }
 
 // Initialize init ShutdownForceNFSParam
-func (p *ShutdownForceNFSParam) Initialize(in Input, args []string) error {
+func (p *ShutdownForceNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2392,7 +2409,8 @@ type ResetNFSParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResetNFSParam return new ResetNFSParam
@@ -2401,8 +2419,9 @@ func NewResetNFSParam() *ResetNFSParam {
 }
 
 // Initialize init ResetNFSParam
-func (p *ResetNFSParam) Initialize(in Input, args []string) error {
+func (p *ResetNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2586,7 +2605,8 @@ type WaitForBootNFSParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForBootNFSParam return new WaitForBootNFSParam
@@ -2595,8 +2615,9 @@ func NewWaitForBootNFSParam() *WaitForBootNFSParam {
 }
 
 // Initialize init WaitForBootNFSParam
-func (p *WaitForBootNFSParam) Initialize(in Input, args []string) error {
+func (p *WaitForBootNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2770,7 +2791,8 @@ type WaitForDownNFSParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForDownNFSParam return new WaitForDownNFSParam
@@ -2779,8 +2801,9 @@ func NewWaitForDownNFSParam() *WaitForDownNFSParam {
 }
 
 // Initialize init WaitForDownNFSParam
-func (p *WaitForDownNFSParam) Initialize(in Input, args []string) error {
+func (p *WaitForDownNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2964,7 +2987,8 @@ type MonitorNicNFSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorNicNFSParam return new MonitorNicNFSParam
@@ -2974,8 +2998,9 @@ func NewMonitorNicNFSParam() *MonitorNicNFSParam {
 }
 
 // Initialize init MonitorNicNFSParam
-func (p *MonitorNicNFSParam) Initialize(in Input, args []string) error {
+func (p *MonitorNicNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3093,7 +3118,7 @@ func (p *MonitorNicNFSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3297,7 +3322,8 @@ type MonitorFreeDiskSizeNFSParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorFreeDiskSizeNFSParam return new MonitorFreeDiskSizeNFSParam
@@ -3307,8 +3333,9 @@ func NewMonitorFreeDiskSizeNFSParam() *MonitorFreeDiskSizeNFSParam {
 }
 
 // Initialize init MonitorFreeDiskSizeNFSParam
-func (p *MonitorFreeDiskSizeNFSParam) Initialize(in Input, args []string) error {
+func (p *MonitorFreeDiskSizeNFSParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3426,7 +3453,7 @@ func (p *MonitorFreeDiskSizeNFSParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_object_storage_gen.go
+++ b/pkg/params/zz_object_storage_gen.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -43,7 +44,8 @@ type ListObjectStorageParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListObjectStorageParam return new ListObjectStorageParam
@@ -52,8 +54,9 @@ func NewListObjectStorageParam() *ListObjectStorageParam {
 }
 
 // Initialize init ListObjectStorageParam
-func (p *ListObjectStorageParam) Initialize(in Input, args []string) error {
+func (p *ListObjectStorageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -149,7 +152,7 @@ func (p *ListObjectStorageParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -333,7 +336,8 @@ type PutObjectStorageParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPutObjectStorageParam return new PutObjectStorageParam
@@ -343,8 +347,9 @@ func NewPutObjectStorageParam() *PutObjectStorageParam {
 }
 
 // Initialize init PutObjectStorageParam
-func (p *PutObjectStorageParam) Initialize(in Input, args []string) error {
+func (p *PutObjectStorageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -568,7 +573,8 @@ type GetObjectStorageParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewGetObjectStorageParam return new GetObjectStorageParam
@@ -577,8 +583,9 @@ func NewGetObjectStorageParam() *GetObjectStorageParam {
 }
 
 // Initialize init GetObjectStorageParam
-func (p *GetObjectStorageParam) Initialize(in Input, args []string) error {
+func (p *GetObjectStorageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -783,7 +790,8 @@ type DeleteObjectStorageParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteObjectStorageParam return new DeleteObjectStorageParam
@@ -792,8 +800,9 @@ func NewDeleteObjectStorageParam() *DeleteObjectStorageParam {
 }
 
 // Initialize init DeleteObjectStorageParam
-func (p *DeleteObjectStorageParam) Initialize(in Input, args []string) error {
+func (p *DeleteObjectStorageParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_packet_filter_gen.go
+++ b/pkg/params/zz_packet_filter_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -47,7 +48,8 @@ type ListPacketFilterParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListPacketFilterParam return new ListPacketFilterParam
@@ -56,8 +58,9 @@ func NewListPacketFilterParam() *ListPacketFilterParam {
 }
 
 // Initialize init ListPacketFilterParam
-func (p *ListPacketFilterParam) Initialize(in Input, args []string) error {
+func (p *ListPacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (p *ListPacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type CreatePacketFilterParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreatePacketFilterParam return new CreatePacketFilterParam
@@ -381,8 +385,9 @@ func NewCreatePacketFilterParam() *CreatePacketFilterParam {
 }
 
 // Initialize init CreatePacketFilterParam
-func (p *CreatePacketFilterParam) Initialize(in Input, args []string) error {
+func (p *CreatePacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -485,7 +490,7 @@ func (p *CreatePacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -671,7 +676,8 @@ type ReadPacketFilterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadPacketFilterParam return new ReadPacketFilterParam
@@ -680,8 +686,9 @@ func NewReadPacketFilterParam() *ReadPacketFilterParam {
 }
 
 // Initialize init ReadPacketFilterParam
-func (p *ReadPacketFilterParam) Initialize(in Input, args []string) error {
+func (p *ReadPacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -763,7 +770,7 @@ func (p *ReadPacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -938,7 +945,8 @@ type UpdatePacketFilterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdatePacketFilterParam return new UpdatePacketFilterParam
@@ -947,8 +955,9 @@ func NewUpdatePacketFilterParam() *UpdatePacketFilterParam {
 }
 
 // Initialize init UpdatePacketFilterParam
-func (p *UpdatePacketFilterParam) Initialize(in Input, args []string) error {
+func (p *UpdatePacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1055,7 +1064,7 @@ func (p *UpdatePacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1249,7 +1258,8 @@ type DeletePacketFilterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeletePacketFilterParam return new DeletePacketFilterParam
@@ -1258,8 +1268,9 @@ func NewDeletePacketFilterParam() *DeletePacketFilterParam {
 }
 
 // Initialize init DeletePacketFilterParam
-func (p *DeletePacketFilterParam) Initialize(in Input, args []string) error {
+func (p *DeletePacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1344,7 +1355,7 @@ func (p *DeletePacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1523,7 +1534,8 @@ type RuleInfoPacketFilterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRuleInfoPacketFilterParam return new RuleInfoPacketFilterParam
@@ -1532,8 +1544,9 @@ func NewRuleInfoPacketFilterParam() *RuleInfoPacketFilterParam {
 }
 
 // Initialize init RuleInfoPacketFilterParam
-func (p *RuleInfoPacketFilterParam) Initialize(in Input, args []string) error {
+func (p *RuleInfoPacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1615,7 +1628,7 @@ func (p *RuleInfoPacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1795,7 +1808,8 @@ type RuleAddPacketFilterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRuleAddPacketFilterParam return new RuleAddPacketFilterParam
@@ -1805,8 +1819,9 @@ func NewRuleAddPacketFilterParam() *RuleAddPacketFilterParam {
 }
 
 // Initialize init RuleAddPacketFilterParam
-func (p *RuleAddPacketFilterParam) Initialize(in Input, args []string) error {
+func (p *RuleAddPacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1960,7 +1975,7 @@ func (p *RuleAddPacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2196,7 +2211,8 @@ type RuleUpdatePacketFilterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRuleUpdatePacketFilterParam return new RuleUpdatePacketFilterParam
@@ -2205,8 +2221,9 @@ func NewRuleUpdatePacketFilterParam() *RuleUpdatePacketFilterParam {
 }
 
 // Initialize init RuleUpdatePacketFilterParam
-func (p *RuleUpdatePacketFilterParam) Initialize(in Input, args []string) error {
+func (p *RuleUpdatePacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2368,7 +2385,7 @@ func (p *RuleUpdatePacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2598,7 +2615,8 @@ type RuleDeletePacketFilterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRuleDeletePacketFilterParam return new RuleDeletePacketFilterParam
@@ -2607,8 +2625,9 @@ func NewRuleDeletePacketFilterParam() *RuleDeletePacketFilterParam {
 }
 
 // Initialize init RuleDeletePacketFilterParam
-func (p *RuleDeletePacketFilterParam) Initialize(in Input, args []string) error {
+func (p *RuleDeletePacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2704,7 +2723,7 @@ func (p *RuleDeletePacketFilterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2885,7 +2904,8 @@ type InterfaceConnectPacketFilterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceConnectPacketFilterParam return new InterfaceConnectPacketFilterParam
@@ -2894,8 +2914,9 @@ func NewInterfaceConnectPacketFilterParam() *InterfaceConnectPacketFilterParam {
 }
 
 // Initialize init InterfaceConnectPacketFilterParam
-func (p *InterfaceConnectPacketFilterParam) Initialize(in Input, args []string) error {
+func (p *InterfaceConnectPacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3095,7 +3116,8 @@ type InterfaceDisconnectPacketFilterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceDisconnectPacketFilterParam return new InterfaceDisconnectPacketFilterParam
@@ -3104,8 +3126,9 @@ func NewInterfaceDisconnectPacketFilterParam() *InterfaceDisconnectPacketFilterP
 }
 
 // Initialize init InterfaceDisconnectPacketFilterParam
-func (p *InterfaceDisconnectPacketFilterParam) Initialize(in Input, args []string) error {
+func (p *InterfaceDisconnectPacketFilterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_price_gen.go
+++ b/pkg/params/zz_price_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -47,7 +48,8 @@ type ListPriceParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListPriceParam return new ListPriceParam
@@ -56,8 +58,9 @@ func NewListPriceParam() *ListPriceParam {
 }
 
 // Initialize init ListPriceParam
-func (p *ListPriceParam) Initialize(in Input, args []string) error {
+func (p *ListPriceParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (p *ListPriceParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_private_host_gen.go
+++ b/pkg/params/zz_private_host_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListPrivateHostParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListPrivateHostParam return new ListPrivateHostParam
@@ -57,8 +59,9 @@ func NewListPrivateHostParam() *ListPrivateHostParam {
 }
 
 // Initialize init ListPrivateHostParam
-func (p *ListPrivateHostParam) Initialize(in Input, args []string) error {
+func (p *ListPrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListPrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -393,7 +396,8 @@ type CreatePrivateHostParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreatePrivateHostParam return new CreatePrivateHostParam
@@ -402,8 +406,9 @@ func NewCreatePrivateHostParam() *CreatePrivateHostParam {
 }
 
 // Initialize init CreatePrivateHostParam
-func (p *CreatePrivateHostParam) Initialize(in Input, args []string) error {
+func (p *CreatePrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -528,7 +533,7 @@ func (p *CreatePrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -729,7 +734,8 @@ type ReadPrivateHostParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadPrivateHostParam return new ReadPrivateHostParam
@@ -738,8 +744,9 @@ func NewReadPrivateHostParam() *ReadPrivateHostParam {
 }
 
 // Initialize init ReadPrivateHostParam
-func (p *ReadPrivateHostParam) Initialize(in Input, args []string) error {
+func (p *ReadPrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -824,7 +831,7 @@ func (p *ReadPrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1009,7 +1016,8 @@ type UpdatePrivateHostParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdatePrivateHostParam return new UpdatePrivateHostParam
@@ -1018,8 +1026,9 @@ func NewUpdatePrivateHostParam() *UpdatePrivateHostParam {
 }
 
 // Initialize init UpdatePrivateHostParam
-func (p *UpdatePrivateHostParam) Initialize(in Input, args []string) error {
+func (p *UpdatePrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1151,7 +1160,7 @@ func (p *UpdatePrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1367,7 +1376,8 @@ type DeletePrivateHostParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeletePrivateHostParam return new DeletePrivateHostParam
@@ -1376,8 +1386,9 @@ func NewDeletePrivateHostParam() *DeletePrivateHostParam {
 }
 
 // Initialize init DeletePrivateHostParam
-func (p *DeletePrivateHostParam) Initialize(in Input, args []string) error {
+func (p *DeletePrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1465,7 +1476,7 @@ func (p *DeletePrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1652,7 +1663,8 @@ type ServerInfoPrivateHostParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerInfoPrivateHostParam return new ServerInfoPrivateHostParam
@@ -1661,8 +1673,9 @@ func NewServerInfoPrivateHostParam() *ServerInfoPrivateHostParam {
 }
 
 // Initialize init ServerInfoPrivateHostParam
-func (p *ServerInfoPrivateHostParam) Initialize(in Input, args []string) error {
+func (p *ServerInfoPrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1747,7 +1760,7 @@ func (p *ServerInfoPrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1929,7 +1942,8 @@ type ServerAddPrivateHostParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerAddPrivateHostParam return new ServerAddPrivateHostParam
@@ -1938,8 +1952,9 @@ func NewServerAddPrivateHostParam() *ServerAddPrivateHostParam {
 }
 
 // Initialize init ServerAddPrivateHostParam
-func (p *ServerAddPrivateHostParam) Initialize(in Input, args []string) error {
+func (p *ServerAddPrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2045,7 +2060,7 @@ func (p *ServerAddPrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2241,7 +2256,8 @@ type ServerDeletePrivateHostParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerDeletePrivateHostParam return new ServerDeletePrivateHostParam
@@ -2250,8 +2266,9 @@ func NewServerDeletePrivateHostParam() *ServerDeletePrivateHostParam {
 }
 
 // Initialize init ServerDeletePrivateHostParam
-func (p *ServerDeletePrivateHostParam) Initialize(in Input, args []string) error {
+func (p *ServerDeletePrivateHostParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2357,7 +2374,7 @@ func (p *ServerDeletePrivateHostParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_product_disk_gen.go
+++ b/pkg/params/zz_product_disk_gen.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListProductDiskParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListProductDiskParam return new ListProductDiskParam
@@ -57,8 +59,9 @@ func NewListProductDiskParam() *ListProductDiskParam {
 }
 
 // Initialize init ListProductDiskParam
-func (p *ListProductDiskParam) Initialize(in Input, args []string) error {
+func (p *ListProductDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -171,7 +174,7 @@ func (p *ListProductDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type ReadProductDiskParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadProductDiskParam return new ReadProductDiskParam
@@ -381,8 +385,9 @@ func NewReadProductDiskParam() *ReadProductDiskParam {
 }
 
 // Initialize init ReadProductDiskParam
-func (p *ReadProductDiskParam) Initialize(in Input, args []string) error {
+func (p *ReadProductDiskParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 
 	if len(args) == 0 {
 		return fmt.Errorf("argument <ID> is required")
@@ -482,7 +487,7 @@ func (p *ReadProductDiskParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_product_internet_gen.go
+++ b/pkg/params/zz_product_internet_gen.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListProductInternetParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListProductInternetParam return new ListProductInternetParam
@@ -57,8 +59,9 @@ func NewListProductInternetParam() *ListProductInternetParam {
 }
 
 // Initialize init ListProductInternetParam
-func (p *ListProductInternetParam) Initialize(in Input, args []string) error {
+func (p *ListProductInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -171,7 +174,7 @@ func (p *ListProductInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type ReadProductInternetParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadProductInternetParam return new ReadProductInternetParam
@@ -381,8 +385,9 @@ func NewReadProductInternetParam() *ReadProductInternetParam {
 }
 
 // Initialize init ReadProductInternetParam
-func (p *ReadProductInternetParam) Initialize(in Input, args []string) error {
+func (p *ReadProductInternetParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 
 	if len(args) == 0 {
 		return fmt.Errorf("argument <ID> is required")
@@ -482,7 +487,7 @@ func (p *ReadProductInternetParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_product_license_gen.go
+++ b/pkg/params/zz_product_license_gen.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListProductLicenseParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListProductLicenseParam return new ListProductLicenseParam
@@ -57,8 +59,9 @@ func NewListProductLicenseParam() *ListProductLicenseParam {
 }
 
 // Initialize init ListProductLicenseParam
-func (p *ListProductLicenseParam) Initialize(in Input, args []string) error {
+func (p *ListProductLicenseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -171,7 +174,7 @@ func (p *ListProductLicenseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type ReadProductLicenseParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadProductLicenseParam return new ReadProductLicenseParam
@@ -381,8 +385,9 @@ func NewReadProductLicenseParam() *ReadProductLicenseParam {
 }
 
 // Initialize init ReadProductLicenseParam
-func (p *ReadProductLicenseParam) Initialize(in Input, args []string) error {
+func (p *ReadProductLicenseParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 
 	if len(args) == 0 {
 		return fmt.Errorf("argument <ID> is required")
@@ -482,7 +487,7 @@ func (p *ReadProductLicenseParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_product_server_gen.go
+++ b/pkg/params/zz_product_server_gen.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListProductServerParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListProductServerParam return new ListProductServerParam
@@ -57,8 +59,9 @@ func NewListProductServerParam() *ListProductServerParam {
 }
 
 // Initialize init ListProductServerParam
-func (p *ListProductServerParam) Initialize(in Input, args []string) error {
+func (p *ListProductServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -171,7 +174,7 @@ func (p *ListProductServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type ReadProductServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadProductServerParam return new ReadProductServerParam
@@ -381,8 +385,9 @@ func NewReadProductServerParam() *ReadProductServerParam {
 }
 
 // Initialize init ReadProductServerParam
-func (p *ReadProductServerParam) Initialize(in Input, args []string) error {
+func (p *ReadProductServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 
 	if len(args) == 0 {
 		return fmt.Errorf("argument <ID> is required")
@@ -482,7 +487,7 @@ func (p *ReadProductServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_proxy_lb_gen.go
+++ b/pkg/params/zz_proxy_lb_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListProxyLBParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListProxyLBParam return new ListProxyLBParam
@@ -57,8 +59,9 @@ func NewListProxyLBParam() *ListProxyLBParam {
 }
 
 // Initialize init ListProxyLBParam
-func (p *ListProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ListProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -402,7 +405,8 @@ type CreateProxyLBParam struct {
 	Query                string
 	QueryFile            string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateProxyLBParam return new CreateProxyLBParam
@@ -412,8 +416,9 @@ func NewCreateProxyLBParam() *CreateProxyLBParam {
 }
 
 // Initialize init CreateProxyLBParam
-func (p *CreateProxyLBParam) Initialize(in Input, args []string) error {
+func (p *CreateProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -619,7 +624,7 @@ func (p *CreateProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -883,7 +888,8 @@ type ReadProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadProxyLBParam return new ReadProxyLBParam
@@ -892,8 +898,9 @@ func NewReadProxyLBParam() *ReadProxyLBParam {
 }
 
 // Initialize init ReadProxyLBParam
-func (p *ReadProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ReadProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -978,7 +985,7 @@ func (p *ReadProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1171,7 +1178,8 @@ type UpdateProxyLBParam struct {
 	QueryFile            string
 	Id                   sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateProxyLBParam return new UpdateProxyLBParam
@@ -1181,8 +1189,9 @@ func NewUpdateProxyLBParam() *UpdateProxyLBParam {
 }
 
 // Initialize init UpdateProxyLBParam
-func (p *UpdateProxyLBParam) Initialize(in Input, args []string) error {
+func (p *UpdateProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1370,7 +1379,7 @@ func (p *UpdateProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1642,7 +1651,8 @@ type DeleteProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteProxyLBParam return new DeleteProxyLBParam
@@ -1651,8 +1661,9 @@ func NewDeleteProxyLBParam() *DeleteProxyLBParam {
 }
 
 // Initialize init DeleteProxyLBParam
-func (p *DeleteProxyLBParam) Initialize(in Input, args []string) error {
+func (p *DeleteProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1740,7 +1751,7 @@ func (p *DeleteProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1929,7 +1940,8 @@ type PlanChangeProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPlanChangeProxyLBParam return new PlanChangeProxyLBParam
@@ -1938,8 +1950,9 @@ func NewPlanChangeProxyLBParam() *PlanChangeProxyLBParam {
 }
 
 // Initialize init PlanChangeProxyLBParam
-func (p *PlanChangeProxyLBParam) Initialize(in Input, args []string) error {
+func (p *PlanChangeProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2045,7 +2058,7 @@ func (p *PlanChangeProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2239,7 +2252,8 @@ type BindPortInfoProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBindPortInfoProxyLBParam return new BindPortInfoProxyLBParam
@@ -2248,8 +2262,9 @@ func NewBindPortInfoProxyLBParam() *BindPortInfoProxyLBParam {
 }
 
 // Initialize init BindPortInfoProxyLBParam
-func (p *BindPortInfoProxyLBParam) Initialize(in Input, args []string) error {
+func (p *BindPortInfoProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2334,7 +2349,7 @@ func (p *BindPortInfoProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2519,7 +2534,8 @@ type BindPortAddProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBindPortAddProxyLBParam return new BindPortAddProxyLBParam
@@ -2528,8 +2544,9 @@ func NewBindPortAddProxyLBParam() *BindPortAddProxyLBParam {
 }
 
 // Initialize init BindPortAddProxyLBParam
-func (p *BindPortAddProxyLBParam) Initialize(in Input, args []string) error {
+func (p *BindPortAddProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2659,7 +2676,7 @@ func (p *BindPortAddProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2880,7 +2897,8 @@ type BindPortUpdateProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBindPortUpdateProxyLBParam return new BindPortUpdateProxyLBParam
@@ -2889,8 +2907,9 @@ func NewBindPortUpdateProxyLBParam() *BindPortUpdateProxyLBParam {
 }
 
 // Initialize init BindPortUpdateProxyLBParam
-func (p *BindPortUpdateProxyLBParam) Initialize(in Input, args []string) error {
+func (p *BindPortUpdateProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3017,7 +3036,7 @@ func (p *BindPortUpdateProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3241,7 +3260,8 @@ type BindPortDeleteProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBindPortDeleteProxyLBParam return new BindPortDeleteProxyLBParam
@@ -3250,8 +3270,9 @@ func NewBindPortDeleteProxyLBParam() *BindPortDeleteProxyLBParam {
 }
 
 // Initialize init BindPortDeleteProxyLBParam
-func (p *BindPortDeleteProxyLBParam) Initialize(in Input, args []string) error {
+func (p *BindPortDeleteProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3350,7 +3371,7 @@ func (p *BindPortDeleteProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3545,7 +3566,8 @@ type ResponseHeaderInfoProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResponseHeaderInfoProxyLBParam return new ResponseHeaderInfoProxyLBParam
@@ -3554,8 +3576,9 @@ func NewResponseHeaderInfoProxyLBParam() *ResponseHeaderInfoProxyLBParam {
 }
 
 // Initialize init ResponseHeaderInfoProxyLBParam
-func (p *ResponseHeaderInfoProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ResponseHeaderInfoProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3651,7 +3674,7 @@ func (p *ResponseHeaderInfoProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3842,7 +3865,8 @@ type ResponseHeaderAddProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResponseHeaderAddProxyLBParam return new ResponseHeaderAddProxyLBParam
@@ -3851,8 +3875,9 @@ func NewResponseHeaderAddProxyLBParam() *ResponseHeaderAddProxyLBParam {
 }
 
 // Initialize init ResponseHeaderAddProxyLBParam
-func (p *ResponseHeaderAddProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ResponseHeaderAddProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3973,7 +3998,7 @@ func (p *ResponseHeaderAddProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4186,7 +4211,8 @@ type ResponseHeaderUpdateProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResponseHeaderUpdateProxyLBParam return new ResponseHeaderUpdateProxyLBParam
@@ -4195,8 +4221,9 @@ func NewResponseHeaderUpdateProxyLBParam() *ResponseHeaderUpdateProxyLBParam {
 }
 
 // Initialize init ResponseHeaderUpdateProxyLBParam
-func (p *ResponseHeaderUpdateProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ResponseHeaderUpdateProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4312,7 +4339,7 @@ func (p *ResponseHeaderUpdateProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4530,7 +4557,8 @@ type ResponseHeaderDeleteProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResponseHeaderDeleteProxyLBParam return new ResponseHeaderDeleteProxyLBParam
@@ -4539,8 +4567,9 @@ func NewResponseHeaderDeleteProxyLBParam() *ResponseHeaderDeleteProxyLBParam {
 }
 
 // Initialize init ResponseHeaderDeleteProxyLBParam
-func (p *ResponseHeaderDeleteProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ResponseHeaderDeleteProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4650,7 +4679,7 @@ func (p *ResponseHeaderDeleteProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4851,7 +4880,8 @@ type ACMEInfoProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewACMEInfoProxyLBParam return new ACMEInfoProxyLBParam
@@ -4860,8 +4890,9 @@ func NewACMEInfoProxyLBParam() *ACMEInfoProxyLBParam {
 }
 
 // Initialize init ACMEInfoProxyLBParam
-func (p *ACMEInfoProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ACMEInfoProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4946,7 +4977,7 @@ func (p *ACMEInfoProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5130,7 +5161,8 @@ type ACMESettingProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewACMESettingProxyLBParam return new ACMESettingProxyLBParam
@@ -5139,8 +5171,9 @@ func NewACMESettingProxyLBParam() *ACMESettingProxyLBParam {
 }
 
 // Initialize init ACMESettingProxyLBParam
-func (p *ACMESettingProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ACMESettingProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5237,7 +5270,7 @@ func (p *ACMESettingProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5439,7 +5472,8 @@ type ACMERenewProxyLBParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewACMERenewProxyLBParam return new ACMERenewProxyLBParam
@@ -5448,8 +5482,9 @@ func NewACMERenewProxyLBParam() *ACMERenewProxyLBParam {
 }
 
 // Initialize init ACMERenewProxyLBParam
-func (p *ACMERenewProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ACMERenewProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5640,7 +5675,8 @@ type ServerInfoProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerInfoProxyLBParam return new ServerInfoProxyLBParam
@@ -5649,8 +5685,9 @@ func NewServerInfoProxyLBParam() *ServerInfoProxyLBParam {
 }
 
 // Initialize init ServerInfoProxyLBParam
-func (p *ServerInfoProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ServerInfoProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5735,7 +5772,7 @@ func (p *ServerInfoProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5919,7 +5956,8 @@ type ServerAddProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerAddProxyLBParam return new ServerAddProxyLBParam
@@ -5928,8 +5966,9 @@ func NewServerAddProxyLBParam() *ServerAddProxyLBParam {
 }
 
 // Initialize init ServerAddProxyLBParam
-func (p *ServerAddProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ServerAddProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6056,7 +6095,7 @@ func (p *ServerAddProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6269,7 +6308,8 @@ type ServerUpdateProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerUpdateProxyLBParam return new ServerUpdateProxyLBParam
@@ -6278,8 +6318,9 @@ func NewServerUpdateProxyLBParam() *ServerUpdateProxyLBParam {
 }
 
 // Initialize init ServerUpdateProxyLBParam
-func (p *ServerUpdateProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ServerUpdateProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6403,7 +6444,7 @@ func (p *ServerUpdateProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6620,7 +6661,8 @@ type ServerDeleteProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewServerDeleteProxyLBParam return new ServerDeleteProxyLBParam
@@ -6629,8 +6671,9 @@ func NewServerDeleteProxyLBParam() *ServerDeleteProxyLBParam {
 }
 
 // Initialize init ServerDeleteProxyLBParam
-func (p *ServerDeleteProxyLBParam) Initialize(in Input, args []string) error {
+func (p *ServerDeleteProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6729,7 +6772,7 @@ func (p *ServerDeleteProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6923,7 +6966,8 @@ type CertificateInfoProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCertificateInfoProxyLBParam return new CertificateInfoProxyLBParam
@@ -6932,8 +6976,9 @@ func NewCertificateInfoProxyLBParam() *CertificateInfoProxyLBParam {
 }
 
 // Initialize init CertificateInfoProxyLBParam
-func (p *CertificateInfoProxyLBParam) Initialize(in Input, args []string) error {
+func (p *CertificateInfoProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7018,7 +7063,7 @@ func (p *CertificateInfoProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7202,7 +7247,8 @@ type CertificateAddProxyLBParam struct {
 	QueryFile               string
 	Id                      sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCertificateAddProxyLBParam return new CertificateAddProxyLBParam
@@ -7211,8 +7257,9 @@ func NewCertificateAddProxyLBParam() *CertificateAddProxyLBParam {
 }
 
 // Initialize init CertificateAddProxyLBParam
-func (p *CertificateAddProxyLBParam) Initialize(in Input, args []string) error {
+func (p *CertificateAddProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7325,7 +7372,7 @@ func (p *CertificateAddProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7537,7 +7584,8 @@ type CertificateUpdateProxyLBParam struct {
 	QueryFile               string
 	Id                      sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCertificateUpdateProxyLBParam return new CertificateUpdateProxyLBParam
@@ -7546,8 +7594,9 @@ func NewCertificateUpdateProxyLBParam() *CertificateUpdateProxyLBParam {
 }
 
 // Initialize init CertificateUpdateProxyLBParam
-func (p *CertificateUpdateProxyLBParam) Initialize(in Input, args []string) error {
+func (p *CertificateUpdateProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7644,7 +7693,7 @@ func (p *CertificateUpdateProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7853,7 +7902,8 @@ type CertificateDeleteProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCertificateDeleteProxyLBParam return new CertificateDeleteProxyLBParam
@@ -7862,8 +7912,9 @@ func NewCertificateDeleteProxyLBParam() *CertificateDeleteProxyLBParam {
 }
 
 // Initialize init CertificateDeleteProxyLBParam
-func (p *CertificateDeleteProxyLBParam) Initialize(in Input, args []string) error {
+func (p *CertificateDeleteProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7951,7 +8002,7 @@ func (p *CertificateDeleteProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -8141,7 +8192,8 @@ type MonitorProxyLBParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorProxyLBParam return new MonitorProxyLBParam
@@ -8151,8 +8203,9 @@ func NewMonitorProxyLBParam() *MonitorProxyLBParam {
 }
 
 // Initialize init MonitorProxyLBParam
-func (p *MonitorProxyLBParam) Initialize(in Input, args []string) error {
+func (p *MonitorProxyLBParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8270,7 +8323,7 @@ func (p *MonitorProxyLBParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_region_gen.go
+++ b/pkg/params/zz_region_gen.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListRegionParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListRegionParam return new ListRegionParam
@@ -57,8 +59,9 @@ func NewListRegionParam() *ListRegionParam {
 }
 
 // Initialize init ListRegionParam
-func (p *ListRegionParam) Initialize(in Input, args []string) error {
+func (p *ListRegionParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -171,7 +174,7 @@ func (p *ListRegionParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type ReadRegionParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadRegionParam return new ReadRegionParam
@@ -381,8 +385,9 @@ func NewReadRegionParam() *ReadRegionParam {
 }
 
 // Initialize init ReadRegionParam
-func (p *ReadRegionParam) Initialize(in Input, args []string) error {
+func (p *ReadRegionParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 
 	if len(args) == 0 {
 		return fmt.Errorf("argument <ID> is required")
@@ -482,7 +487,7 @@ func (p *ReadRegionParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_self_gen.go
+++ b/pkg/params/zz_self_gen.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -33,7 +34,8 @@ type InfoSelfParam struct {
 	ParameterFile     string
 	GenerateSkeleton  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInfoSelfParam return new InfoSelfParam
@@ -42,8 +44,9 @@ func NewInfoSelfParam() *InfoSelfParam {
 }
 
 // Initialize init InfoSelfParam
-func (p *InfoSelfParam) Initialize(in Input, args []string) error {
+func (p *InfoSelfParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_server_gen.go
+++ b/pkg/params/zz_server_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListServerParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListServerParam return new ListServerParam
@@ -57,8 +59,9 @@ func NewListServerParam() *ListServerParam {
 }
 
 // Initialize init ListServerParam
-func (p *ListServerParam) Initialize(in Input, args []string) error {
+func (p *ListServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -431,7 +434,8 @@ type BuildServerParam struct {
 	UsKeyboard              bool
 	DisableBootAfterCreate  bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBuildServerParam return new BuildServerParam
@@ -441,8 +445,9 @@ func NewBuildServerParam() *BuildServerParam {
 }
 
 // Initialize init BuildServerParam
-func (p *BuildServerParam) Initialize(in Input, args []string) error {
+func (p *BuildServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -903,7 +908,7 @@ func (p *BuildServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1370,7 +1375,8 @@ type ReadServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadServerParam return new ReadServerParam
@@ -1379,8 +1385,9 @@ func NewReadServerParam() *ReadServerParam {
 }
 
 // Initialize init ReadServerParam
-func (p *ReadServerParam) Initialize(in Input, args []string) error {
+func (p *ReadServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1465,7 +1472,7 @@ func (p *ReadServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1651,7 +1658,8 @@ type UpdateServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateServerParam return new UpdateServerParam
@@ -1661,8 +1669,9 @@ func NewUpdateServerParam() *UpdateServerParam {
 }
 
 // Initialize init UpdateServerParam
-func (p *UpdateServerParam) Initialize(in Input, args []string) error {
+func (p *UpdateServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1805,7 +1814,7 @@ func (p *UpdateServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2030,7 +2039,8 @@ type DeleteServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteServerParam return new DeleteServerParam
@@ -2039,8 +2049,9 @@ func NewDeleteServerParam() *DeleteServerParam {
 }
 
 // Initialize init DeleteServerParam
-func (p *DeleteServerParam) Initialize(in Input, args []string) error {
+func (p *DeleteServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2134,7 +2145,7 @@ func (p *DeleteServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2339,7 +2350,8 @@ type PlanChangeServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPlanChangeServerParam return new PlanChangeServerParam
@@ -2349,8 +2361,9 @@ func NewPlanChangeServerParam() *PlanChangeServerParam {
 }
 
 // Initialize init PlanChangeServerParam
-func (p *PlanChangeServerParam) Initialize(in Input, args []string) error {
+func (p *PlanChangeServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2471,7 +2484,7 @@ func (p *PlanChangeServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2673,7 +2686,8 @@ type BootServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBootServerParam return new BootServerParam
@@ -2682,8 +2696,9 @@ func NewBootServerParam() *BootServerParam {
 }
 
 // Initialize init BootServerParam
-func (p *BootServerParam) Initialize(in Input, args []string) error {
+func (p *BootServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2868,7 +2883,8 @@ type ShutdownServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownServerParam return new ShutdownServerParam
@@ -2877,8 +2893,9 @@ func NewShutdownServerParam() *ShutdownServerParam {
 }
 
 // Initialize init ShutdownServerParam
-func (p *ShutdownServerParam) Initialize(in Input, args []string) error {
+func (p *ShutdownServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3063,7 +3080,8 @@ type ShutdownForceServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownForceServerParam return new ShutdownForceServerParam
@@ -3072,8 +3090,9 @@ func NewShutdownForceServerParam() *ShutdownForceServerParam {
 }
 
 // Initialize init ShutdownForceServerParam
-func (p *ShutdownForceServerParam) Initialize(in Input, args []string) error {
+func (p *ShutdownForceServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3258,7 +3277,8 @@ type ResetServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResetServerParam return new ResetServerParam
@@ -3267,8 +3287,9 @@ func NewResetServerParam() *ResetServerParam {
 }
 
 // Initialize init ResetServerParam
-func (p *ResetServerParam) Initialize(in Input, args []string) error {
+func (p *ResetServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3452,7 +3473,8 @@ type WaitForBootServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForBootServerParam return new WaitForBootServerParam
@@ -3461,8 +3483,9 @@ func NewWaitForBootServerParam() *WaitForBootServerParam {
 }
 
 // Initialize init WaitForBootServerParam
-func (p *WaitForBootServerParam) Initialize(in Input, args []string) error {
+func (p *WaitForBootServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3636,7 +3659,8 @@ type WaitForDownServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForDownServerParam return new WaitForDownServerParam
@@ -3645,8 +3669,9 @@ func NewWaitForDownServerParam() *WaitForDownServerParam {
 }
 
 // Initialize init WaitForDownServerParam
-func (p *WaitForDownServerParam) Initialize(in Input, args []string) error {
+func (p *WaitForDownServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3825,7 +3850,8 @@ type SSHServerParam struct {
 	Quiet             bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSSHServerParam return new SSHServerParam
@@ -3835,8 +3861,9 @@ func NewSSHServerParam() *SSHServerParam {
 }
 
 // Initialize init SSHServerParam
-func (p *SSHServerParam) Initialize(in Input, args []string) error {
+func (p *SSHServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4080,7 +4107,8 @@ type SSHExecServerParam struct {
 	Quiet             bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSSHExecServerParam return new SSHExecServerParam
@@ -4090,8 +4118,9 @@ func NewSSHExecServerParam() *SSHExecServerParam {
 }
 
 // Initialize init SSHExecServerParam
-func (p *SSHExecServerParam) Initialize(in Input, args []string) error {
+func (p *SSHExecServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4326,7 +4355,8 @@ type ScpServerParam struct {
 	GenerateSkeleton  bool
 	Quiet             bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewScpServerParam return new ScpServerParam
@@ -4336,8 +4366,9 @@ func NewScpServerParam() *ScpServerParam {
 }
 
 // Initialize init ScpServerParam
-func (p *ScpServerParam) Initialize(in Input, args []string) error {
+func (p *ScpServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4570,7 +4601,8 @@ type VncServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVncServerParam return new VncServerParam
@@ -4579,8 +4611,9 @@ func NewVncServerParam() *VncServerParam {
 }
 
 // Initialize init VncServerParam
-func (p *VncServerParam) Initialize(in Input, args []string) error {
+func (p *VncServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4772,7 +4805,8 @@ type VncInfoServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVncInfoServerParam return new VncInfoServerParam
@@ -4781,8 +4815,9 @@ func NewVncInfoServerParam() *VncInfoServerParam {
 }
 
 // Initialize init VncInfoServerParam
-func (p *VncInfoServerParam) Initialize(in Input, args []string) error {
+func (p *VncInfoServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4870,7 +4905,7 @@ func (p *VncInfoServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5063,7 +5098,8 @@ type VncSendServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVncSendServerParam return new VncSendServerParam
@@ -5072,8 +5108,9 @@ func NewVncSendServerParam() *VncSendServerParam {
 }
 
 // Initialize init VncSendServerParam
-func (p *VncSendServerParam) Initialize(in Input, args []string) error {
+func (p *VncSendServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5194,7 +5231,7 @@ func (p *VncSendServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5419,7 +5456,8 @@ type VncSnapshotServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewVncSnapshotServerParam return new VncSnapshotServerParam
@@ -5428,8 +5466,9 @@ func NewVncSnapshotServerParam() *VncSnapshotServerParam {
 }
 
 // Initialize init VncSnapshotServerParam
-func (p *VncSnapshotServerParam) Initialize(in Input, args []string) error {
+func (p *VncSnapshotServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5523,7 +5562,7 @@ func (p *VncSnapshotServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5719,7 +5758,8 @@ type RemoteDesktopServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRemoteDesktopServerParam return new RemoteDesktopServerParam
@@ -5729,8 +5769,9 @@ func NewRemoteDesktopServerParam() *RemoteDesktopServerParam {
 }
 
 // Initialize init RemoteDesktopServerParam
-func (p *RemoteDesktopServerParam) Initialize(in Input, args []string) error {
+func (p *RemoteDesktopServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5949,7 +5990,8 @@ type RemoteDesktopInfoServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewRemoteDesktopInfoServerParam return new RemoteDesktopInfoServerParam
@@ -5959,8 +6001,9 @@ func NewRemoteDesktopInfoServerParam() *RemoteDesktopInfoServerParam {
 }
 
 // Initialize init RemoteDesktopInfoServerParam
-func (p *RemoteDesktopInfoServerParam) Initialize(in Input, args []string) error {
+func (p *RemoteDesktopInfoServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6067,7 +6110,7 @@ func (p *RemoteDesktopInfoServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6261,7 +6304,8 @@ type DiskInfoServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDiskInfoServerParam return new DiskInfoServerParam
@@ -6270,8 +6314,9 @@ func NewDiskInfoServerParam() *DiskInfoServerParam {
 }
 
 // Initialize init DiskInfoServerParam
-func (p *DiskInfoServerParam) Initialize(in Input, args []string) error {
+func (p *DiskInfoServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6356,7 +6401,7 @@ func (p *DiskInfoServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -6531,7 +6576,8 @@ type DiskConnectServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDiskConnectServerParam return new DiskConnectServerParam
@@ -6540,8 +6586,9 @@ func NewDiskConnectServerParam() *DiskConnectServerParam {
 }
 
 // Initialize init DiskConnectServerParam
-func (p *DiskConnectServerParam) Initialize(in Input, args []string) error {
+func (p *DiskConnectServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6752,7 +6799,8 @@ type DiskDisconnectServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDiskDisconnectServerParam return new DiskDisconnectServerParam
@@ -6761,8 +6809,9 @@ func NewDiskDisconnectServerParam() *DiskDisconnectServerParam {
 }
 
 // Initialize init DiskDisconnectServerParam
-func (p *DiskDisconnectServerParam) Initialize(in Input, args []string) error {
+func (p *DiskDisconnectServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6978,7 +7027,8 @@ type InterfaceInfoServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceInfoServerParam return new InterfaceInfoServerParam
@@ -6987,8 +7037,9 @@ func NewInterfaceInfoServerParam() *InterfaceInfoServerParam {
 }
 
 // Initialize init InterfaceInfoServerParam
-func (p *InterfaceInfoServerParam) Initialize(in Input, args []string) error {
+func (p *InterfaceInfoServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7073,7 +7124,7 @@ func (p *InterfaceInfoServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7248,7 +7299,8 @@ type InterfaceAddForInternetServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceAddForInternetServerParam return new InterfaceAddForInternetServerParam
@@ -7257,8 +7309,9 @@ func NewInterfaceAddForInternetServerParam() *InterfaceAddForInternetServerParam
 }
 
 // Initialize init InterfaceAddForInternetServerParam
-func (p *InterfaceAddForInternetServerParam) Initialize(in Input, args []string) error {
+func (p *InterfaceAddForInternetServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7458,7 +7511,8 @@ type InterfaceAddForRouterServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceAddForRouterServerParam return new InterfaceAddForRouterServerParam
@@ -7468,8 +7522,9 @@ func NewInterfaceAddForRouterServerParam() *InterfaceAddForRouterServerParam {
 }
 
 // Initialize init InterfaceAddForRouterServerParam
-func (p *InterfaceAddForRouterServerParam) Initialize(in Input, args []string) error {
+func (p *InterfaceAddForRouterServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7748,7 +7803,8 @@ type InterfaceAddForSwitchServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceAddForSwitchServerParam return new InterfaceAddForSwitchServerParam
@@ -7758,8 +7814,9 @@ func NewInterfaceAddForSwitchServerParam() *InterfaceAddForSwitchServerParam {
 }
 
 // Initialize init InterfaceAddForSwitchServerParam
-func (p *InterfaceAddForSwitchServerParam) Initialize(in Input, args []string) error {
+func (p *InterfaceAddForSwitchServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8033,7 +8090,8 @@ type InterfaceAddDisconnectedServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceAddDisconnectedServerParam return new InterfaceAddDisconnectedServerParam
@@ -8042,8 +8100,9 @@ func NewInterfaceAddDisconnectedServerParam() *InterfaceAddDisconnectedServerPar
 }
 
 // Initialize init InterfaceAddDisconnectedServerParam
-func (p *InterfaceAddDisconnectedServerParam) Initialize(in Input, args []string) error {
+func (p *InterfaceAddDisconnectedServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8234,7 +8293,8 @@ type ISOInfoServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewISOInfoServerParam return new ISOInfoServerParam
@@ -8243,8 +8303,9 @@ func NewISOInfoServerParam() *ISOInfoServerParam {
 }
 
 // Initialize init ISOInfoServerParam
-func (p *ISOInfoServerParam) Initialize(in Input, args []string) error {
+func (p *ISOInfoServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8329,7 +8390,7 @@ func (p *ISOInfoServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -8510,7 +8571,8 @@ type ISOInsertServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewISOInsertServerParam return new ISOInsertServerParam
@@ -8520,8 +8582,9 @@ func NewISOInsertServerParam() *ISOInsertServerParam {
 }
 
 // Initialize init ISOInsertServerParam
-func (p *ISOInsertServerParam) Initialize(in Input, args []string) error {
+func (p *ISOInsertServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8824,7 +8887,8 @@ type ISOEjectServerParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewISOEjectServerParam return new ISOEjectServerParam
@@ -8833,8 +8897,9 @@ func NewISOEjectServerParam() *ISOEjectServerParam {
 }
 
 // Initialize init ISOEjectServerParam
-func (p *ISOEjectServerParam) Initialize(in Input, args []string) error {
+func (p *ISOEjectServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9028,7 +9093,8 @@ type MonitorCPUServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorCPUServerParam return new MonitorCPUServerParam
@@ -9038,8 +9104,9 @@ func NewMonitorCPUServerParam() *MonitorCPUServerParam {
 }
 
 // Initialize init MonitorCPUServerParam
-func (p *MonitorCPUServerParam) Initialize(in Input, args []string) error {
+func (p *MonitorCPUServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9157,7 +9224,7 @@ func (p *MonitorCPUServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -9362,7 +9429,8 @@ type MonitorNicServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorNicServerParam return new MonitorNicServerParam
@@ -9372,8 +9440,9 @@ func NewMonitorNicServerParam() *MonitorNicServerParam {
 }
 
 // Initialize init MonitorNicServerParam
-func (p *MonitorNicServerParam) Initialize(in Input, args []string) error {
+func (p *MonitorNicServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9494,7 +9563,7 @@ func (p *MonitorNicServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -9706,7 +9775,8 @@ type MonitorDiskServerParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorDiskServerParam return new MonitorDiskServerParam
@@ -9716,8 +9786,9 @@ func NewMonitorDiskServerParam() *MonitorDiskServerParam {
 }
 
 // Initialize init MonitorDiskServerParam
-func (p *MonitorDiskServerParam) Initialize(in Input, args []string) error {
+func (p *MonitorDiskServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9838,7 +9909,7 @@ func (p *MonitorDiskServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -10044,7 +10115,8 @@ type MaintenanceInfoServerParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMaintenanceInfoServerParam return new MaintenanceInfoServerParam
@@ -10053,8 +10125,9 @@ func NewMaintenanceInfoServerParam() *MaintenanceInfoServerParam {
 }
 
 // Initialize init MaintenanceInfoServerParam
-func (p *MaintenanceInfoServerParam) Initialize(in Input, args []string) error {
+func (p *MaintenanceInfoServerParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -10125,7 +10198,7 @@ func (p *MaintenanceInfoServerParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_sim_gen.go
+++ b/pkg/params/zz_sim_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListSIMParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListSIMParam return new ListSIMParam
@@ -57,8 +59,9 @@ func NewListSIMParam() *ListSIMParam {
 }
 
 // Initialize init ListSIMParam
-func (p *ListSIMParam) Initialize(in Input, args []string) error {
+func (p *ListSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListSIMParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -398,7 +401,8 @@ type CreateSIMParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateSIMParam return new CreateSIMParam
@@ -407,8 +411,9 @@ func NewCreateSIMParam() *CreateSIMParam {
 }
 
 // Initialize init CreateSIMParam
-func (p *CreateSIMParam) Initialize(in Input, args []string) error {
+func (p *CreateSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -585,7 +590,7 @@ func (p *CreateSIMParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -821,7 +826,8 @@ type ReadSIMParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadSIMParam return new ReadSIMParam
@@ -830,8 +836,9 @@ func NewReadSIMParam() *ReadSIMParam {
 }
 
 // Initialize init ReadSIMParam
-func (p *ReadSIMParam) Initialize(in Input, args []string) error {
+func (p *ReadSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -916,7 +923,7 @@ func (p *ReadSIMParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1101,7 +1108,8 @@ type UpdateSIMParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateSIMParam return new UpdateSIMParam
@@ -1110,8 +1118,9 @@ func NewUpdateSIMParam() *UpdateSIMParam {
 }
 
 // Initialize init UpdateSIMParam
-func (p *UpdateSIMParam) Initialize(in Input, args []string) error {
+func (p *UpdateSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1243,7 +1252,7 @@ func (p *UpdateSIMParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1453,7 +1462,8 @@ type DeleteSIMParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteSIMParam return new DeleteSIMParam
@@ -1462,8 +1472,9 @@ func NewDeleteSIMParam() *DeleteSIMParam {
 }
 
 // Initialize init DeleteSIMParam
-func (p *DeleteSIMParam) Initialize(in Input, args []string) error {
+func (p *DeleteSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1664,7 +1675,8 @@ type CarrierInfoSIMParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCarrierInfoSIMParam return new CarrierInfoSIMParam
@@ -1673,8 +1685,9 @@ func NewCarrierInfoSIMParam() *CarrierInfoSIMParam {
 }
 
 // Initialize init CarrierInfoSIMParam
-func (p *CarrierInfoSIMParam) Initialize(in Input, args []string) error {
+func (p *CarrierInfoSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1759,7 +1772,7 @@ func (p *CarrierInfoSIMParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1934,7 +1947,8 @@ type CarrierUpdateSIMParam struct {
 	Id                sacloud.ID
 	Carrier           []string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCarrierUpdateSIMParam return new CarrierUpdateSIMParam
@@ -1943,8 +1957,9 @@ func NewCarrierUpdateSIMParam() *CarrierUpdateSIMParam {
 }
 
 // Initialize init CarrierUpdateSIMParam
-func (p *CarrierUpdateSIMParam) Initialize(in Input, args []string) error {
+func (p *CarrierUpdateSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2160,7 +2175,8 @@ type ActivateSIMParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewActivateSIMParam return new ActivateSIMParam
@@ -2169,8 +2185,9 @@ func NewActivateSIMParam() *ActivateSIMParam {
 }
 
 // Initialize init ActivateSIMParam
-func (p *ActivateSIMParam) Initialize(in Input, args []string) error {
+func (p *ActivateSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2355,7 +2372,8 @@ type DeactivateSIMParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeactivateSIMParam return new DeactivateSIMParam
@@ -2364,8 +2382,9 @@ func NewDeactivateSIMParam() *DeactivateSIMParam {
 }
 
 // Initialize init DeactivateSIMParam
-func (p *DeactivateSIMParam) Initialize(in Input, args []string) error {
+func (p *DeactivateSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2551,7 +2570,8 @@ type ImeiLockSIMParam struct {
 	Id                sacloud.ID
 	Imei              string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewImeiLockSIMParam return new ImeiLockSIMParam
@@ -2560,8 +2580,9 @@ func NewImeiLockSIMParam() *ImeiLockSIMParam {
 }
 
 // Initialize init ImeiLockSIMParam
-func (p *ImeiLockSIMParam) Initialize(in Input, args []string) error {
+func (p *ImeiLockSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2765,7 +2786,8 @@ type IpAddSIMParam struct {
 	Id                sacloud.ID
 	Ip                string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewIpAddSIMParam return new IpAddSIMParam
@@ -2774,8 +2796,9 @@ func NewIpAddSIMParam() *IpAddSIMParam {
 }
 
 // Initialize init IpAddSIMParam
-func (p *IpAddSIMParam) Initialize(in Input, args []string) error {
+func (p *IpAddSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2985,7 +3008,8 @@ type ImeiUnlockSIMParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewImeiUnlockSIMParam return new ImeiUnlockSIMParam
@@ -2994,8 +3018,9 @@ func NewImeiUnlockSIMParam() *ImeiUnlockSIMParam {
 }
 
 // Initialize init ImeiUnlockSIMParam
-func (p *ImeiUnlockSIMParam) Initialize(in Input, args []string) error {
+func (p *ImeiUnlockSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3180,7 +3205,8 @@ type IpDeleteSIMParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewIpDeleteSIMParam return new IpDeleteSIMParam
@@ -3189,8 +3215,9 @@ func NewIpDeleteSIMParam() *IpDeleteSIMParam {
 }
 
 // Initialize init IpDeleteSIMParam
-func (p *IpDeleteSIMParam) Initialize(in Input, args []string) error {
+func (p *IpDeleteSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3383,7 +3410,8 @@ type LogsSIMParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewLogsSIMParam return new LogsSIMParam
@@ -3393,8 +3421,9 @@ func NewLogsSIMParam() *LogsSIMParam {
 }
 
 // Initialize init LogsSIMParam
-func (p *LogsSIMParam) Initialize(in Input, args []string) error {
+func (p *LogsSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3493,7 +3522,7 @@ func (p *LogsSIMParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3690,7 +3719,8 @@ type MonitorSIMParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorSIMParam return new MonitorSIMParam
@@ -3700,8 +3730,9 @@ func NewMonitorSIMParam() *MonitorSIMParam {
 }
 
 // Initialize init MonitorSIMParam
-func (p *MonitorSIMParam) Initialize(in Input, args []string) error {
+func (p *MonitorSIMParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3819,7 +3850,7 @@ func (p *MonitorSIMParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_simple_monitor_gen.go
+++ b/pkg/params/zz_simple_monitor_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -49,7 +50,8 @@ type ListSimpleMonitorParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListSimpleMonitorParam return new ListSimpleMonitorParam
@@ -58,8 +60,9 @@ func NewListSimpleMonitorParam() *ListSimpleMonitorParam {
 }
 
 // Initialize init ListSimpleMonitorParam
-func (p *ListSimpleMonitorParam) Initialize(in Input, args []string) error {
+func (p *ListSimpleMonitorParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -194,7 +197,7 @@ func (p *ListSimpleMonitorParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -429,7 +432,8 @@ type CreateSimpleMonitorParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateSimpleMonitorParam return new CreateSimpleMonitorParam
@@ -439,8 +443,9 @@ func NewCreateSimpleMonitorParam() *CreateSimpleMonitorParam {
 }
 
 // Initialize init CreateSimpleMonitorParam
-func (p *CreateSimpleMonitorParam) Initialize(in Input, args []string) error {
+func (p *CreateSimpleMonitorParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -671,7 +676,7 @@ func (p *CreateSimpleMonitorParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -991,7 +996,8 @@ type ReadSimpleMonitorParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadSimpleMonitorParam return new ReadSimpleMonitorParam
@@ -1000,8 +1006,9 @@ func NewReadSimpleMonitorParam() *ReadSimpleMonitorParam {
 }
 
 // Initialize init ReadSimpleMonitorParam
-func (p *ReadSimpleMonitorParam) Initialize(in Input, args []string) error {
+func (p *ReadSimpleMonitorParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1086,7 +1093,7 @@ func (p *ReadSimpleMonitorParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1287,7 +1294,8 @@ type UpdateSimpleMonitorParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateSimpleMonitorParam return new UpdateSimpleMonitorParam
@@ -1297,8 +1305,9 @@ func NewUpdateSimpleMonitorParam() *UpdateSimpleMonitorParam {
 }
 
 // Initialize init UpdateSimpleMonitorParam
-func (p *UpdateSimpleMonitorParam) Initialize(in Input, args []string) error {
+func (p *UpdateSimpleMonitorParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1518,7 +1527,7 @@ func (p *UpdateSimpleMonitorParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1846,7 +1855,8 @@ type DeleteSimpleMonitorParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteSimpleMonitorParam return new DeleteSimpleMonitorParam
@@ -1855,8 +1865,9 @@ func NewDeleteSimpleMonitorParam() *DeleteSimpleMonitorParam {
 }
 
 // Initialize init DeleteSimpleMonitorParam
-func (p *DeleteSimpleMonitorParam) Initialize(in Input, args []string) error {
+func (p *DeleteSimpleMonitorParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1944,7 +1955,7 @@ func (p *DeleteSimpleMonitorParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -2131,7 +2142,8 @@ type HealthSimpleMonitorParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewHealthSimpleMonitorParam return new HealthSimpleMonitorParam
@@ -2140,8 +2152,9 @@ func NewHealthSimpleMonitorParam() *HealthSimpleMonitorParam {
 }
 
 // Initialize init HealthSimpleMonitorParam
-func (p *HealthSimpleMonitorParam) Initialize(in Input, args []string) error {
+func (p *HealthSimpleMonitorParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2226,7 +2239,7 @@ func (p *HealthSimpleMonitorParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_ssh_key_gen.go
+++ b/pkg/params/zz_ssh_key_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -47,7 +48,8 @@ type ListSSHKeyParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListSSHKeyParam return new ListSSHKeyParam
@@ -56,8 +58,9 @@ func NewListSSHKeyParam() *ListSSHKeyParam {
 }
 
 // Initialize init ListSSHKeyParam
-func (p *ListSSHKeyParam) Initialize(in Input, args []string) error {
+func (p *ListSSHKeyParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (p *ListSSHKeyParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -374,7 +377,8 @@ type CreateSSHKeyParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateSSHKeyParam return new CreateSSHKeyParam
@@ -383,8 +387,9 @@ func NewCreateSSHKeyParam() *CreateSSHKeyParam {
 }
 
 // Initialize init CreateSSHKeyParam
-func (p *CreateSSHKeyParam) Initialize(in Input, args []string) error {
+func (p *CreateSSHKeyParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -511,7 +516,7 @@ func (p *CreateSSHKeyParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -711,7 +716,8 @@ type ReadSSHKeyParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadSSHKeyParam return new ReadSSHKeyParam
@@ -720,8 +726,9 @@ func NewReadSSHKeyParam() *ReadSSHKeyParam {
 }
 
 // Initialize init ReadSSHKeyParam
-func (p *ReadSSHKeyParam) Initialize(in Input, args []string) error {
+func (p *ReadSSHKeyParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -803,7 +810,7 @@ func (p *ReadSSHKeyParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -978,7 +985,8 @@ type UpdateSSHKeyParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateSSHKeyParam return new UpdateSSHKeyParam
@@ -987,8 +995,9 @@ func NewUpdateSSHKeyParam() *UpdateSSHKeyParam {
 }
 
 // Initialize init UpdateSSHKeyParam
-func (p *UpdateSSHKeyParam) Initialize(in Input, args []string) error {
+func (p *UpdateSSHKeyParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1095,7 +1104,7 @@ func (p *UpdateSSHKeyParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1289,7 +1298,8 @@ type DeleteSSHKeyParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteSSHKeyParam return new DeleteSSHKeyParam
@@ -1298,8 +1308,9 @@ func NewDeleteSSHKeyParam() *DeleteSSHKeyParam {
 }
 
 // Initialize init DeleteSSHKeyParam
-func (p *DeleteSSHKeyParam) Initialize(in Input, args []string) error {
+func (p *DeleteSSHKeyParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1384,7 +1395,7 @@ func (p *DeleteSSHKeyParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1567,7 +1578,8 @@ type GenerateSSHKeyParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewGenerateSSHKeyParam return new GenerateSSHKeyParam
@@ -1576,8 +1588,9 @@ func NewGenerateSSHKeyParam() *GenerateSSHKeyParam {
 }
 
 // Initialize init GenerateSSHKeyParam
-func (p *GenerateSSHKeyParam) Initialize(in Input, args []string) error {
+func (p *GenerateSSHKeyParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1694,7 +1707,7 @@ func (p *GenerateSSHKeyParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_startup_script_gen.go
+++ b/pkg/params/zz_startup_script_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -50,7 +51,8 @@ type ListStartupScriptParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListStartupScriptParam return new ListStartupScriptParam
@@ -59,8 +61,9 @@ func NewListStartupScriptParam() *ListStartupScriptParam {
 }
 
 // Initialize init ListStartupScriptParam
-func (p *ListStartupScriptParam) Initialize(in Input, args []string) error {
+func (p *ListStartupScriptParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -198,7 +201,7 @@ func (p *ListStartupScriptParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -425,7 +428,8 @@ type CreateStartupScriptParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateStartupScriptParam return new CreateStartupScriptParam
@@ -435,8 +439,9 @@ func NewCreateStartupScriptParam() *CreateStartupScriptParam {
 }
 
 // Initialize init CreateStartupScriptParam
-func (p *CreateStartupScriptParam) Initialize(in Input, args []string) error {
+func (p *CreateStartupScriptParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -592,7 +597,7 @@ func (p *CreateStartupScriptParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -807,7 +812,8 @@ type ReadStartupScriptParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadStartupScriptParam return new ReadStartupScriptParam
@@ -816,8 +822,9 @@ func NewReadStartupScriptParam() *ReadStartupScriptParam {
 }
 
 // Initialize init ReadStartupScriptParam
-func (p *ReadStartupScriptParam) Initialize(in Input, args []string) error {
+func (p *ReadStartupScriptParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -902,7 +909,7 @@ func (p *ReadStartupScriptParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1089,7 +1096,8 @@ type UpdateStartupScriptParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateStartupScriptParam return new UpdateStartupScriptParam
@@ -1098,8 +1106,9 @@ func NewUpdateStartupScriptParam() *UpdateStartupScriptParam {
 }
 
 // Initialize init UpdateStartupScriptParam
-func (p *UpdateStartupScriptParam) Initialize(in Input, args []string) error {
+func (p *UpdateStartupScriptParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1255,7 +1264,7 @@ func (p *UpdateStartupScriptParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1485,7 +1494,8 @@ type DeleteStartupScriptParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteStartupScriptParam return new DeleteStartupScriptParam
@@ -1494,8 +1504,9 @@ func NewDeleteStartupScriptParam() *DeleteStartupScriptParam {
 }
 
 // Initialize init DeleteStartupScriptParam
-func (p *DeleteStartupScriptParam) Initialize(in Input, args []string) error {
+func (p *DeleteStartupScriptParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1583,7 +1594,7 @@ func (p *DeleteStartupScriptParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_summary_gen.go
+++ b/pkg/params/zz_summary_gen.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -41,7 +42,8 @@ type ShowSummaryParam struct {
 	QueryFile         string
 	PaidResourcesOnly bool
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShowSummaryParam return new ShowSummaryParam
@@ -50,8 +52,9 @@ func NewShowSummaryParam() *ShowSummaryParam {
 }
 
 // Initialize init ShowSummaryParam
-func (p *ShowSummaryParam) Initialize(in Input, args []string) error {
+func (p *ShowSummaryParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -125,7 +128,7 @@ func (p *ShowSummaryParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_switch_gen.go
+++ b/pkg/params/zz_switch_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListSwitchParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListSwitchParam return new ListSwitchParam
@@ -57,8 +59,9 @@ func NewListSwitchParam() *ListSwitchParam {
 }
 
 // Initialize init ListSwitchParam
-func (p *ListSwitchParam) Initialize(in Input, args []string) error {
+func (p *ListSwitchParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListSwitchParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -393,7 +396,8 @@ type CreateSwitchParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateSwitchParam return new CreateSwitchParam
@@ -402,8 +406,9 @@ func NewCreateSwitchParam() *CreateSwitchParam {
 }
 
 // Initialize init CreateSwitchParam
-func (p *CreateSwitchParam) Initialize(in Input, args []string) error {
+func (p *CreateSwitchParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -528,7 +533,7 @@ func (p *CreateSwitchParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -729,7 +734,8 @@ type ReadSwitchParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadSwitchParam return new ReadSwitchParam
@@ -738,8 +744,9 @@ func NewReadSwitchParam() *ReadSwitchParam {
 }
 
 // Initialize init ReadSwitchParam
-func (p *ReadSwitchParam) Initialize(in Input, args []string) error {
+func (p *ReadSwitchParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -824,7 +831,7 @@ func (p *ReadSwitchParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1009,7 +1016,8 @@ type UpdateSwitchParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateSwitchParam return new UpdateSwitchParam
@@ -1018,8 +1026,9 @@ func NewUpdateSwitchParam() *UpdateSwitchParam {
 }
 
 // Initialize init UpdateSwitchParam
-func (p *UpdateSwitchParam) Initialize(in Input, args []string) error {
+func (p *UpdateSwitchParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1151,7 +1160,7 @@ func (p *UpdateSwitchParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1367,7 +1376,8 @@ type DeleteSwitchParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteSwitchParam return new DeleteSwitchParam
@@ -1376,8 +1386,9 @@ func NewDeleteSwitchParam() *DeleteSwitchParam {
 }
 
 // Initialize init DeleteSwitchParam
-func (p *DeleteSwitchParam) Initialize(in Input, args []string) error {
+func (p *DeleteSwitchParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1465,7 +1476,7 @@ func (p *DeleteSwitchParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1647,7 +1658,8 @@ type BridgeConnectSwitchParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBridgeConnectSwitchParam return new BridgeConnectSwitchParam
@@ -1656,8 +1668,9 @@ func NewBridgeConnectSwitchParam() *BridgeConnectSwitchParam {
 }
 
 // Initialize init BridgeConnectSwitchParam
-func (p *BridgeConnectSwitchParam) Initialize(in Input, args []string) error {
+func (p *BridgeConnectSwitchParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1867,7 +1880,8 @@ type BridgeDisconnectSwitchParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBridgeDisconnectSwitchParam return new BridgeDisconnectSwitchParam
@@ -1876,8 +1890,9 @@ func NewBridgeDisconnectSwitchParam() *BridgeDisconnectSwitchParam {
 }
 
 // Initialize init BridgeDisconnectSwitchParam
-func (p *BridgeDisconnectSwitchParam) Initialize(in Input, args []string) error {
+func (p *BridgeDisconnectSwitchParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_vpc_router_gen.go
+++ b/pkg/params/zz_vpc_router_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListVPCRouterParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListVPCRouterParam return new ListVPCRouterParam
@@ -57,8 +59,9 @@ func NewListVPCRouterParam() *ListVPCRouterParam {
 }
 
 // Initialize init ListVPCRouterParam
-func (p *ListVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *ListVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -182,7 +185,7 @@ func (p *ListVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -401,7 +404,8 @@ type CreateVPCRouterParam struct {
 	Query                     string
 	QueryFile                 string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCreateVPCRouterParam return new CreateVPCRouterParam
@@ -411,8 +415,9 @@ func NewCreateVPCRouterParam() *CreateVPCRouterParam {
 }
 
 // Initialize init CreateVPCRouterParam
-func (p *CreateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *CreateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -616,7 +621,7 @@ func (p *CreateVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -873,7 +878,8 @@ type ReadVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadVPCRouterParam return new ReadVPCRouterParam
@@ -882,8 +888,9 @@ func NewReadVPCRouterParam() *ReadVPCRouterParam {
 }
 
 // Initialize init ReadVPCRouterParam
-func (p *ReadVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *ReadVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -968,7 +975,7 @@ func (p *ReadVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1155,7 +1162,8 @@ type UpdateVPCRouterParam struct {
 	QueryFile          string
 	Id                 sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUpdateVPCRouterParam return new UpdateVPCRouterParam
@@ -1164,8 +1172,9 @@ func NewUpdateVPCRouterParam() *UpdateVPCRouterParam {
 }
 
 // Initialize init UpdateVPCRouterParam
-func (p *UpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *UpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1311,7 +1320,7 @@ func (p *UpdateVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1542,7 +1551,8 @@ type DeleteVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteVPCRouterParam return new DeleteVPCRouterParam
@@ -1551,8 +1561,9 @@ func NewDeleteVPCRouterParam() *DeleteVPCRouterParam {
 }
 
 // Initialize init DeleteVPCRouterParam
-func (p *DeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1643,7 +1654,7 @@ func (p *DeleteVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1831,7 +1842,8 @@ type BootVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewBootVPCRouterParam return new BootVPCRouterParam
@@ -1840,8 +1852,9 @@ func NewBootVPCRouterParam() *BootVPCRouterParam {
 }
 
 // Initialize init BootVPCRouterParam
-func (p *BootVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *BootVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2026,7 +2039,8 @@ type ShutdownVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownVPCRouterParam return new ShutdownVPCRouterParam
@@ -2035,8 +2049,9 @@ func NewShutdownVPCRouterParam() *ShutdownVPCRouterParam {
 }
 
 // Initialize init ShutdownVPCRouterParam
-func (p *ShutdownVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *ShutdownVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2221,7 +2236,8 @@ type ShutdownForceVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewShutdownForceVPCRouterParam return new ShutdownForceVPCRouterParam
@@ -2230,8 +2246,9 @@ func NewShutdownForceVPCRouterParam() *ShutdownForceVPCRouterParam {
 }
 
 // Initialize init ShutdownForceVPCRouterParam
-func (p *ShutdownForceVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *ShutdownForceVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2416,7 +2433,8 @@ type ResetVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewResetVPCRouterParam return new ResetVPCRouterParam
@@ -2425,8 +2443,9 @@ func NewResetVPCRouterParam() *ResetVPCRouterParam {
 }
 
 // Initialize init ResetVPCRouterParam
-func (p *ResetVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *ResetVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2610,7 +2629,8 @@ type WaitForBootVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForBootVPCRouterParam return new WaitForBootVPCRouterParam
@@ -2619,8 +2639,9 @@ func NewWaitForBootVPCRouterParam() *WaitForBootVPCRouterParam {
 }
 
 // Initialize init WaitForBootVPCRouterParam
-func (p *WaitForBootVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *WaitForBootVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2794,7 +2815,8 @@ type WaitForDownVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewWaitForDownVPCRouterParam return new WaitForDownVPCRouterParam
@@ -2803,8 +2825,9 @@ func NewWaitForDownVPCRouterParam() *WaitForDownVPCRouterParam {
 }
 
 // Initialize init WaitForDownVPCRouterParam
-func (p *WaitForDownVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *WaitForDownVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -2979,7 +3002,8 @@ type EnableInternetConnectionVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewEnableInternetConnectionVPCRouterParam return new EnableInternetConnectionVPCRouterParam
@@ -2988,8 +3012,9 @@ func NewEnableInternetConnectionVPCRouterParam() *EnableInternetConnectionVPCRou
 }
 
 // Initialize init EnableInternetConnectionVPCRouterParam
-func (p *EnableInternetConnectionVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *EnableInternetConnectionVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3174,7 +3199,8 @@ type DisableInternetConnectionVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDisableInternetConnectionVPCRouterParam return new DisableInternetConnectionVPCRouterParam
@@ -3183,8 +3209,9 @@ func NewDisableInternetConnectionVPCRouterParam() *DisableInternetConnectionVPCR
 }
 
 // Initialize init DisableInternetConnectionVPCRouterParam
-func (p *DisableInternetConnectionVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DisableInternetConnectionVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3375,7 +3402,8 @@ type InterfaceInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceInfoVPCRouterParam return new InterfaceInfoVPCRouterParam
@@ -3384,8 +3412,9 @@ func NewInterfaceInfoVPCRouterParam() *InterfaceInfoVPCRouterParam {
 }
 
 // Initialize init InterfaceInfoVPCRouterParam
-func (p *InterfaceInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *InterfaceInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3470,7 +3499,7 @@ func (p *InterfaceInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -3651,7 +3680,8 @@ type InterfaceConnectVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceConnectVPCRouterParam return new InterfaceConnectVPCRouterParam
@@ -3661,8 +3691,9 @@ func NewInterfaceConnectVPCRouterParam() *InterfaceConnectVPCRouterParam {
 }
 
 // Initialize init InterfaceConnectVPCRouterParam
-func (p *InterfaceConnectVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *InterfaceConnectVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -3994,7 +4025,8 @@ type InterfaceUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceUpdateVPCRouterParam return new InterfaceUpdateVPCRouterParam
@@ -4004,8 +4036,9 @@ func NewInterfaceUpdateVPCRouterParam() *InterfaceUpdateVPCRouterParam {
 }
 
 // Initialize init InterfaceUpdateVPCRouterParam
-func (p *InterfaceUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *InterfaceUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4335,7 +4368,8 @@ type InterfaceDisconnectVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewInterfaceDisconnectVPCRouterParam return new InterfaceDisconnectVPCRouterParam
@@ -4344,8 +4378,9 @@ func NewInterfaceDisconnectVPCRouterParam() *InterfaceDisconnectVPCRouterParam {
 }
 
 // Initialize init InterfaceDisconnectVPCRouterParam
-func (p *InterfaceDisconnectVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *InterfaceDisconnectVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4571,7 +4606,8 @@ type StaticNatInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticNatInfoVPCRouterParam return new StaticNatInfoVPCRouterParam
@@ -4580,8 +4616,9 @@ func NewStaticNatInfoVPCRouterParam() *StaticNatInfoVPCRouterParam {
 }
 
 // Initialize init StaticNatInfoVPCRouterParam
-func (p *StaticNatInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticNatInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -4666,7 +4703,7 @@ func (p *StaticNatInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -4843,7 +4880,8 @@ type StaticNatAddVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticNatAddVPCRouterParam return new StaticNatAddVPCRouterParam
@@ -4852,8 +4890,9 @@ func NewStaticNatAddVPCRouterParam() *StaticNatAddVPCRouterParam {
 }
 
 // Initialize init StaticNatAddVPCRouterParam
-func (p *StaticNatAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticNatAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5110,7 +5149,8 @@ type StaticNatUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticNatUpdateVPCRouterParam return new StaticNatUpdateVPCRouterParam
@@ -5119,8 +5159,9 @@ func NewStaticNatUpdateVPCRouterParam() *StaticNatUpdateVPCRouterParam {
 }
 
 // Initialize init StaticNatUpdateVPCRouterParam
-func (p *StaticNatUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticNatUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5378,7 +5419,8 @@ type StaticNatDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticNatDeleteVPCRouterParam return new StaticNatDeleteVPCRouterParam
@@ -5387,8 +5429,9 @@ func NewStaticNatDeleteVPCRouterParam() *StaticNatDeleteVPCRouterParam {
 }
 
 // Initialize init StaticNatDeleteVPCRouterParam
-func (p *StaticNatDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticNatDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5597,7 +5640,8 @@ type PortForwardingInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPortForwardingInfoVPCRouterParam return new PortForwardingInfoVPCRouterParam
@@ -5606,8 +5650,9 @@ func NewPortForwardingInfoVPCRouterParam() *PortForwardingInfoVPCRouterParam {
 }
 
 // Initialize init PortForwardingInfoVPCRouterParam
-func (p *PortForwardingInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *PortForwardingInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -5692,7 +5737,7 @@ func (p *PortForwardingInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -5871,7 +5916,8 @@ type PortForwardingAddVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPortForwardingAddVPCRouterParam return new PortForwardingAddVPCRouterParam
@@ -5880,8 +5926,9 @@ func NewPortForwardingAddVPCRouterParam() *PortForwardingAddVPCRouterParam {
 }
 
 // Initialize init PortForwardingAddVPCRouterParam
-func (p *PortForwardingAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *PortForwardingAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6190,7 +6237,8 @@ type PortForwardingUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPortForwardingUpdateVPCRouterParam return new PortForwardingUpdateVPCRouterParam
@@ -6199,8 +6247,9 @@ func NewPortForwardingUpdateVPCRouterParam() *PortForwardingUpdateVPCRouterParam
 }
 
 // Initialize init PortForwardingUpdateVPCRouterParam
-func (p *PortForwardingUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *PortForwardingUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6494,7 +6543,8 @@ type PortForwardingDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPortForwardingDeleteVPCRouterParam return new PortForwardingDeleteVPCRouterParam
@@ -6503,8 +6553,9 @@ func NewPortForwardingDeleteVPCRouterParam() *PortForwardingDeleteVPCRouterParam
 }
 
 // Initialize init PortForwardingDeleteVPCRouterParam
-func (p *PortForwardingDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *PortForwardingDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6715,7 +6766,8 @@ type FirewallInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFirewallInfoVPCRouterParam return new FirewallInfoVPCRouterParam
@@ -6725,8 +6777,9 @@ func NewFirewallInfoVPCRouterParam() *FirewallInfoVPCRouterParam {
 }
 
 // Initialize init FirewallInfoVPCRouterParam
-func (p *FirewallInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *FirewallInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -6840,7 +6893,7 @@ func (p *FirewallInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -7038,7 +7091,8 @@ type FirewallAddVPCRouterParam struct {
 	GenerateSkeleton   bool
 	Id                 sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFirewallAddVPCRouterParam return new FirewallAddVPCRouterParam
@@ -7048,8 +7102,9 @@ func NewFirewallAddVPCRouterParam() *FirewallAddVPCRouterParam {
 }
 
 // Initialize init FirewallAddVPCRouterParam
-func (p *FirewallAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *FirewallAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7438,7 +7493,8 @@ type FirewallUpdateVPCRouterParam struct {
 	GenerateSkeleton   bool
 	Id                 sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFirewallUpdateVPCRouterParam return new FirewallUpdateVPCRouterParam
@@ -7448,8 +7504,9 @@ func NewFirewallUpdateVPCRouterParam() *FirewallUpdateVPCRouterParam {
 }
 
 // Initialize init FirewallUpdateVPCRouterParam
-func (p *FirewallUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *FirewallUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -7834,7 +7891,8 @@ type FirewallDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewFirewallDeleteVPCRouterParam return new FirewallDeleteVPCRouterParam
@@ -7844,8 +7902,9 @@ func NewFirewallDeleteVPCRouterParam() *FirewallDeleteVPCRouterParam {
 }
 
 // Initialize init FirewallDeleteVPCRouterParam
-func (p *FirewallDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *FirewallDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8097,7 +8156,8 @@ type DhcpServerInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpServerInfoVPCRouterParam return new DhcpServerInfoVPCRouterParam
@@ -8106,8 +8166,9 @@ func NewDhcpServerInfoVPCRouterParam() *DhcpServerInfoVPCRouterParam {
 }
 
 // Initialize init DhcpServerInfoVPCRouterParam
-func (p *DhcpServerInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpServerInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8192,7 +8253,7 @@ func (p *DhcpServerInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -8370,7 +8431,8 @@ type DhcpServerAddVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpServerAddVPCRouterParam return new DhcpServerAddVPCRouterParam
@@ -8379,8 +8441,9 @@ func NewDhcpServerAddVPCRouterParam() *DhcpServerAddVPCRouterParam {
 }
 
 // Initialize init DhcpServerAddVPCRouterParam
-func (p *DhcpServerAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpServerAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8662,7 +8725,8 @@ type DhcpServerUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpServerUpdateVPCRouterParam return new DhcpServerUpdateVPCRouterParam
@@ -8671,8 +8735,9 @@ func NewDhcpServerUpdateVPCRouterParam() *DhcpServerUpdateVPCRouterParam {
 }
 
 // Initialize init DhcpServerUpdateVPCRouterParam
-func (p *DhcpServerUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpServerUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -8937,7 +9002,8 @@ type DhcpServerDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpServerDeleteVPCRouterParam return new DhcpServerDeleteVPCRouterParam
@@ -8946,8 +9012,9 @@ func NewDhcpServerDeleteVPCRouterParam() *DhcpServerDeleteVPCRouterParam {
 }
 
 // Initialize init DhcpServerDeleteVPCRouterParam
-func (p *DhcpServerDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpServerDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9163,7 +9230,8 @@ type DhcpStaticMappingInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpStaticMappingInfoVPCRouterParam return new DhcpStaticMappingInfoVPCRouterParam
@@ -9172,8 +9240,9 @@ func NewDhcpStaticMappingInfoVPCRouterParam() *DhcpStaticMappingInfoVPCRouterPar
 }
 
 // Initialize init DhcpStaticMappingInfoVPCRouterParam
-func (p *DhcpStaticMappingInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpStaticMappingInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9258,7 +9327,7 @@ func (p *DhcpStaticMappingInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -9434,7 +9503,8 @@ type DhcpStaticMappingAddVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpStaticMappingAddVPCRouterParam return new DhcpStaticMappingAddVPCRouterParam
@@ -9443,8 +9513,9 @@ func NewDhcpStaticMappingAddVPCRouterParam() *DhcpStaticMappingAddVPCRouterParam
 }
 
 // Initialize init DhcpStaticMappingAddVPCRouterParam
-func (p *DhcpStaticMappingAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpStaticMappingAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9682,7 +9753,8 @@ type DhcpStaticMappingUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpStaticMappingUpdateVPCRouterParam return new DhcpStaticMappingUpdateVPCRouterParam
@@ -9691,8 +9763,9 @@ func NewDhcpStaticMappingUpdateVPCRouterParam() *DhcpStaticMappingUpdateVPCRoute
 }
 
 // Initialize init DhcpStaticMappingUpdateVPCRouterParam
-func (p *DhcpStaticMappingUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpStaticMappingUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -9932,7 +10005,8 @@ type DhcpStaticMappingDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDhcpStaticMappingDeleteVPCRouterParam return new DhcpStaticMappingDeleteVPCRouterParam
@@ -9941,8 +10015,9 @@ func NewDhcpStaticMappingDeleteVPCRouterParam() *DhcpStaticMappingDeleteVPCRoute
 }
 
 // Initialize init DhcpStaticMappingDeleteVPCRouterParam
-func (p *DhcpStaticMappingDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *DhcpStaticMappingDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -10151,7 +10226,8 @@ type PptpServerInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPptpServerInfoVPCRouterParam return new PptpServerInfoVPCRouterParam
@@ -10160,8 +10236,9 @@ func NewPptpServerInfoVPCRouterParam() *PptpServerInfoVPCRouterParam {
 }
 
 // Initialize init PptpServerInfoVPCRouterParam
-func (p *PptpServerInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *PptpServerInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -10246,7 +10323,7 @@ func (p *PptpServerInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -10423,7 +10500,8 @@ type PptpServerUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewPptpServerUpdateVPCRouterParam return new PptpServerUpdateVPCRouterParam
@@ -10432,8 +10510,9 @@ func NewPptpServerUpdateVPCRouterParam() *PptpServerUpdateVPCRouterParam {
 }
 
 // Initialize init PptpServerUpdateVPCRouterParam
-func (p *PptpServerUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *PptpServerUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -10670,7 +10749,8 @@ type L2TPServerInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewL2TPServerInfoVPCRouterParam return new L2TPServerInfoVPCRouterParam
@@ -10679,8 +10759,9 @@ func NewL2TPServerInfoVPCRouterParam() *L2TPServerInfoVPCRouterParam {
 }
 
 // Initialize init L2TPServerInfoVPCRouterParam
-func (p *L2TPServerInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *L2TPServerInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -10765,7 +10846,7 @@ func (p *L2TPServerInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -10943,7 +11024,8 @@ type L2TPServerUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewL2TPServerUpdateVPCRouterParam return new L2TPServerUpdateVPCRouterParam
@@ -10952,8 +11034,9 @@ func NewL2TPServerUpdateVPCRouterParam() *L2TPServerUpdateVPCRouterParam {
 }
 
 // Initialize init L2TPServerUpdateVPCRouterParam
-func (p *L2TPServerUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *L2TPServerUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -11208,7 +11291,8 @@ type UserInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUserInfoVPCRouterParam return new UserInfoVPCRouterParam
@@ -11217,8 +11301,9 @@ func NewUserInfoVPCRouterParam() *UserInfoVPCRouterParam {
 }
 
 // Initialize init UserInfoVPCRouterParam
-func (p *UserInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *UserInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -11303,7 +11388,7 @@ func (p *UserInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -11479,7 +11564,8 @@ type UserAddVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUserAddVPCRouterParam return new UserAddVPCRouterParam
@@ -11488,8 +11574,9 @@ func NewUserAddVPCRouterParam() *UserAddVPCRouterParam {
 }
 
 // Initialize init UserAddVPCRouterParam
-func (p *UserAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *UserAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -11727,7 +11814,8 @@ type UserUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUserUpdateVPCRouterParam return new UserUpdateVPCRouterParam
@@ -11736,8 +11824,9 @@ func NewUserUpdateVPCRouterParam() *UserUpdateVPCRouterParam {
 }
 
 // Initialize init UserUpdateVPCRouterParam
-func (p *UserUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *UserUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -11977,7 +12066,8 @@ type UserDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewUserDeleteVPCRouterParam return new UserDeleteVPCRouterParam
@@ -11986,8 +12076,9 @@ func NewUserDeleteVPCRouterParam() *UserDeleteVPCRouterParam {
 }
 
 // Initialize init UserDeleteVPCRouterParam
-func (p *UserDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *UserDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -12196,7 +12287,8 @@ type SiteToSiteVPNInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSiteToSiteVPNInfoVPCRouterParam return new SiteToSiteVPNInfoVPCRouterParam
@@ -12205,8 +12297,9 @@ func NewSiteToSiteVPNInfoVPCRouterParam() *SiteToSiteVPNInfoVPCRouterParam {
 }
 
 // Initialize init SiteToSiteVPNInfoVPCRouterParam
-func (p *SiteToSiteVPNInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *SiteToSiteVPNInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -12291,7 +12384,7 @@ func (p *SiteToSiteVPNInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -12470,7 +12563,8 @@ type SiteToSiteVPNAddVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSiteToSiteVPNAddVPCRouterParam return new SiteToSiteVPNAddVPCRouterParam
@@ -12479,8 +12573,9 @@ func NewSiteToSiteVPNAddVPCRouterParam() *SiteToSiteVPNAddVPCRouterParam {
 }
 
 // Initialize init SiteToSiteVPNAddVPCRouterParam
-func (p *SiteToSiteVPNAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *SiteToSiteVPNAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -12789,7 +12884,8 @@ type SiteToSiteVPNUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSiteToSiteVPNUpdateVPCRouterParam return new SiteToSiteVPNUpdateVPCRouterParam
@@ -12798,8 +12894,9 @@ func NewSiteToSiteVPNUpdateVPCRouterParam() *SiteToSiteVPNUpdateVPCRouterParam {
 }
 
 // Initialize init SiteToSiteVPNUpdateVPCRouterParam
-func (p *SiteToSiteVPNUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *SiteToSiteVPNUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -13085,7 +13182,8 @@ type SiteToSiteVPNDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSiteToSiteVPNDeleteVPCRouterParam return new SiteToSiteVPNDeleteVPCRouterParam
@@ -13094,8 +13192,9 @@ func NewSiteToSiteVPNDeleteVPCRouterParam() *SiteToSiteVPNDeleteVPCRouterParam {
 }
 
 // Initialize init SiteToSiteVPNDeleteVPCRouterParam
-func (p *SiteToSiteVPNDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *SiteToSiteVPNDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -13304,7 +13403,8 @@ type SiteToSiteVPNPeersVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewSiteToSiteVPNPeersVPCRouterParam return new SiteToSiteVPNPeersVPCRouterParam
@@ -13313,8 +13413,9 @@ func NewSiteToSiteVPNPeersVPCRouterParam() *SiteToSiteVPNPeersVPCRouterParam {
 }
 
 // Initialize init SiteToSiteVPNPeersVPCRouterParam
-func (p *SiteToSiteVPNPeersVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *SiteToSiteVPNPeersVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -13399,7 +13500,7 @@ func (p *SiteToSiteVPNPeersVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -13579,7 +13680,8 @@ type StaticRouteInfoVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteInfoVPCRouterParam return new StaticRouteInfoVPCRouterParam
@@ -13588,8 +13690,9 @@ func NewStaticRouteInfoVPCRouterParam() *StaticRouteInfoVPCRouterParam {
 }
 
 // Initialize init StaticRouteInfoVPCRouterParam
-func (p *StaticRouteInfoVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteInfoVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -13674,7 +13777,7 @@ func (p *StaticRouteInfoVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -13850,7 +13953,8 @@ type StaticRouteAddVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteAddVPCRouterParam return new StaticRouteAddVPCRouterParam
@@ -13859,8 +13963,9 @@ func NewStaticRouteAddVPCRouterParam() *StaticRouteAddVPCRouterParam {
 }
 
 // Initialize init StaticRouteAddVPCRouterParam
-func (p *StaticRouteAddVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteAddVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -14098,7 +14203,8 @@ type StaticRouteUpdateVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteUpdateVPCRouterParam return new StaticRouteUpdateVPCRouterParam
@@ -14107,8 +14213,9 @@ func NewStaticRouteUpdateVPCRouterParam() *StaticRouteUpdateVPCRouterParam {
 }
 
 // Initialize init StaticRouteUpdateVPCRouterParam
-func (p *StaticRouteUpdateVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteUpdateVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -14348,7 +14455,8 @@ type StaticRouteDeleteVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewStaticRouteDeleteVPCRouterParam return new StaticRouteDeleteVPCRouterParam
@@ -14357,8 +14465,9 @@ func NewStaticRouteDeleteVPCRouterParam() *StaticRouteDeleteVPCRouterParam {
 }
 
 // Initialize init StaticRouteDeleteVPCRouterParam
-func (p *StaticRouteDeleteVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *StaticRouteDeleteVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -14571,7 +14680,8 @@ type MonitorVPCRouterParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewMonitorVPCRouterParam return new MonitorVPCRouterParam
@@ -14581,8 +14691,9 @@ func NewMonitorVPCRouterParam() *MonitorVPCRouterParam {
 }
 
 // Initialize init MonitorVPCRouterParam
-func (p *MonitorVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *MonitorVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -14718,7 +14829,7 @@ func (p *MonitorVPCRouterParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -14923,7 +15034,8 @@ type LogsVPCRouterParam struct {
 	GenerateSkeleton  bool
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewLogsVPCRouterParam return new LogsVPCRouterParam
@@ -14933,8 +15045,9 @@ func NewLogsVPCRouterParam() *LogsVPCRouterParam {
 }
 
 // Initialize init LogsVPCRouterParam
-func (p *LogsVPCRouterParam) Initialize(in Input, args []string) error {
+func (p *LogsVPCRouterParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}

--- a/pkg/params/zz_web_accel_gen.go
+++ b/pkg/params/zz_web_accel_gen.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -42,7 +43,8 @@ type ListWebAccelParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListWebAccelParam return new ListWebAccelParam
@@ -51,8 +53,9 @@ func NewListWebAccelParam() *ListWebAccelParam {
 }
 
 // Initialize init ListWebAccelParam
-func (p *ListWebAccelParam) Initialize(in Input, args []string) error {
+func (p *ListWebAccelParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -123,7 +126,7 @@ func (p *ListWebAccelParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -289,7 +292,8 @@ type ReadWebAccelParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadWebAccelParam return new ReadWebAccelParam
@@ -298,8 +302,9 @@ func NewReadWebAccelParam() *ReadWebAccelParam {
 }
 
 // Initialize init ReadWebAccelParam
-func (p *ReadWebAccelParam) Initialize(in Input, args []string) error {
+func (p *ReadWebAccelParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -384,7 +389,7 @@ func (p *ReadWebAccelParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -564,7 +569,8 @@ type CertificateInfoWebAccelParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCertificateInfoWebAccelParam return new CertificateInfoWebAccelParam
@@ -573,8 +579,9 @@ func NewCertificateInfoWebAccelParam() *CertificateInfoWebAccelParam {
 }
 
 // Initialize init CertificateInfoWebAccelParam
-func (p *CertificateInfoWebAccelParam) Initialize(in Input, args []string) error {
+func (p *CertificateInfoWebAccelParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -659,7 +666,7 @@ func (p *CertificateInfoWebAccelParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -844,7 +851,8 @@ type CertificateNewWebAccelParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCertificateNewWebAccelParam return new CertificateNewWebAccelParam
@@ -853,8 +861,9 @@ func NewCertificateNewWebAccelParam() *CertificateNewWebAccelParam {
 }
 
 // Initialize init CertificateNewWebAccelParam
-func (p *CertificateNewWebAccelParam) Initialize(in Input, args []string) error {
+func (p *CertificateNewWebAccelParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -990,7 +999,7 @@ func (p *CertificateNewWebAccelParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1210,7 +1219,8 @@ type CertificateUpdateWebAccelParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewCertificateUpdateWebAccelParam return new CertificateUpdateWebAccelParam
@@ -1219,8 +1229,9 @@ func NewCertificateUpdateWebAccelParam() *CertificateUpdateWebAccelParam {
 }
 
 // Initialize init CertificateUpdateWebAccelParam
-func (p *CertificateUpdateWebAccelParam) Initialize(in Input, args []string) error {
+func (p *CertificateUpdateWebAccelParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1356,7 +1367,7 @@ func (p *CertificateUpdateWebAccelParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -1570,7 +1581,8 @@ type DeleteCacheWebAccelParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewDeleteCacheWebAccelParam return new DeleteCacheWebAccelParam
@@ -1579,8 +1591,9 @@ func NewDeleteCacheWebAccelParam() *DeleteCacheWebAccelParam {
 }
 
 // Initialize init DeleteCacheWebAccelParam
-func (p *DeleteCacheWebAccelParam) Initialize(in Input, args []string) error {
+func (p *DeleteCacheWebAccelParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -1654,7 +1667,7 @@ func (p *DeleteCacheWebAccelParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/pkg/params/zz_zone_gen.go
+++ b/pkg/params/zz_zone_gen.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -48,7 +49,8 @@ type ListZoneParam struct {
 	Query             string
 	QueryFile         string
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewListZoneParam return new ListZoneParam
@@ -57,8 +59,9 @@ func NewListZoneParam() *ListZoneParam {
 }
 
 // Initialize init ListZoneParam
-func (p *ListZoneParam) Initialize(in Input, args []string) error {
+func (p *ListZoneParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	if err := p.validate(); err != nil {
 		return err
 	}
@@ -171,7 +174,7 @@ func (p *ListZoneParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}
@@ -372,7 +375,8 @@ type ReadZoneParam struct {
 	QueryFile         string
 	Id                sacloud.ID
 
-	input Input
+	options *flags.Flags
+	input   Input
 }
 
 // NewReadZoneParam return new ReadZoneParam
@@ -381,8 +385,9 @@ func NewReadZoneParam() *ReadZoneParam {
 }
 
 // Initialize init ReadZoneParam
-func (p *ReadZoneParam) Initialize(in Input, args []string) error {
+func (p *ReadZoneParam) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 
 	if len(args) == 0 {
 		return fmt.Errorf("argument <ID> is required")
@@ -482,7 +487,7 @@ func (p *ReadZoneParam) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors, errs...)
 		}

--- a/tools/gen-cli-commands/main.go
+++ b/tools/gen-cli-commands/main.go
@@ -108,12 +108,12 @@ func {{ .CLIVariableFuncName }}() *cobra.Command {
 		Short: "{{ .Usage }}",
 		Long: ` + "`{{ .Usage }}`" + `,
 		SilenceUsage: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return {{ .InputParameterVariable }}.Initialize(newParamsAdapter(cmd.Flags()), args)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, err := cli.NewCLIContext(globalFlags(), args, {{ .InputParameterVariable }})
 			if err != nil {
+				return err
+			}
+			if err := {{ .InputParameterVariable }}.Initialize(newParamsAdapter(cmd.Flags()), args, ctx.Option()); err != nil {
 				return err
 			}
 

--- a/tools/gen-command-params/main.go
+++ b/tools/gen-command-params/main.go
@@ -97,6 +97,7 @@ import (
 
 	"github.com/sacloud/libsacloud/sacloud"
 	"github.com/sacloud/usacloud/pkg/define"
+	"github.com/sacloud/usacloud/pkg/flags"
 	"github.com/sacloud/usacloud/pkg/schema"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/utils"
@@ -110,6 +111,7 @@ type {{.InputParameterTypeName}} struct {
 	{{ range .Params -}}
 	{{.FieldName}} {{.FieldTypeName}} {{.FieldTag}}
 	{{ end }}
+	options *flags.Flags
 	input Input
 }
 
@@ -121,8 +123,9 @@ func New{{.InputParameterTypeName}}() *{{.InputParameterTypeName}}{
 }
 
 // Initialize init {{.InputParameterTypeName}}
-func (p *{{.InputParameterTypeName}}) Initialize(in Input, args []string) error {
+func (p *{{.InputParameterTypeName}}) Initialize(in Input, args []string, options *flags.Flags) error {
 	p.input = in
+	p.options = options
 	{{ if .SingleArgToIdParam }}
 	if len(args) == 0 {
 		return fmt.Errorf("argument <ID> is required")
@@ -172,7 +175,7 @@ func (p *{{.InputParameterTypeName}}) validate() error {
 		}
 	}
 	{
-		errs := validateOutputOption(p)
+		errs := validateOutputOption(p, p.options.DefaultOutputType)
 		if errs != nil {
 			errors = append(errors , errs...)
 		}


### PR DESCRIPTION
a part of #506 

#506 対応のstep2として、GlobalOptionのスコープを小さくする。

v1においてcli.Contextが導入され、各コマンド共通のオプションはcli.Context経由で取得可能となった。
これに伴いv0ではグローバル変数となっていたGlobalOptionのスコープを小さくすることが可能となったためこのPRで対応する。

### 対応内容

- グローバルオプションを`flags`パッケージに切り出し
- `cli.GlobalOption`を除去
- `cli.GlobalOption`を利用していた箇所へ引数として必要な値を渡すように修正
