### PR TITLE
Install gnupg2 when running install script on Ubuntu/Debian

### DIFF
--- a/repos/install.sh
+++ b/repos/install.sh
@@ -49,7 +49,7 @@ install_by_apt() {
   sudo sh <<'SCRIPT'
     set -x
     apt-get update -qq
-    apt-get install -y curl apt-transport-https
+    apt-get install -y curl apt-transport-https gnupg2
     echo "deb https://releases.usacloud.jp/usacloud/repos/debian /" > /etc/apt/sources.list.d/usacloud.list
     curl -fsS https://releases.usacloud.jp/usacloud/repos/GPG-KEY-usacloud | apt-key add -
     apt-get update -qq

--- a/repos/setup-apt.sh
+++ b/repos/setup-apt.sh
@@ -21,7 +21,7 @@ echo "===== install usacloud by apt ====="
 sudo sh <<'SCRIPT'
   set -x
   apt-get update -qq
-  apt-get install -y curl apt-transport-https
+  apt-get install -y curl apt-transport-https gnupg2
   echo "deb https://releases.usacloud.jp/usacloud/repos/debian /" > /etc/apt/sources.list.d/usacloud.list
   curl -fsS https://releases.usacloud.jp/usacloud/repos/GPG-KEY-usacloud | apt-key add -
   apt-get update -qq


### PR DESCRIPTION
fixes #497 

aptでのインストール時にgnupg2をインストールする。