### PR TITLE
support for category/order fields in clitag

### DIFF
--- a/tools/clitag/parse_tag.go
+++ b/tools/clitag/parse_tag.go
@@ -16,6 +16,7 @@ package clitag
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -24,6 +25,8 @@ const (
 	shortHandKey = "short"
 	descKey      = "desc"
 	squashKey    = "squash"
+	categoryKey  = "category"
+	orderKey     = "order"
 )
 
 func (p *Parser) parseTag(t string) (Tag, error) {
@@ -72,9 +75,17 @@ func (p *Parser) parseTag(t string) (Tag, error) {
 				if len(val) != 1 {
 					return tag, fmt.Errorf("got invalid tag value: key 'short' must have only 1 character: %q", token)
 				}
-				tag.Shorthand = kv[1]
+				tag.Shorthand = val
 			case descKey:
-				tag.Description = kv[1]
+				tag.Description = val
+			case categoryKey:
+				tag.Category = val
+			case orderKey:
+				order, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					return tag, fmt.Errorf("got invalid tag value: key 'order' must have valid number: %q", token)
+				}
+				tag.Order = int(order)
 			default:
 				return tag, fmt.Errorf("got invalid tag key: %q", token)
 			}

--- a/tools/clitag/parser_tag_test.go
+++ b/tools/clitag/parser_tag_test.go
@@ -53,11 +53,13 @@ func TestParser_parseTag(t *testing.T) {
 			},
 		},
 		{
-			in: `,short=e,desc=desc,squash`,
+			in: `,short=e,desc=desc,squash,category=foo,order=10`,
 			expect: Tag{
 				Shorthand:   "e",
 				Description: "desc",
 				Squash:      true,
+				Category:    "foo",
+				Order:       10,
 			},
 		},
 		{

--- a/tools/clitag/types.go
+++ b/tools/clitag/types.go
@@ -31,6 +31,8 @@ type StructField struct {
 // - Description: foobar
 // - Squash: false
 // - Ignore: false
+// - Category: (empty)
+// - Order: 0
 type Tag struct {
 	Name        string
 	Aliases     []string
@@ -38,4 +40,6 @@ type Tag struct {
 	Description string
 	Squash      bool
 	Ignore      bool
+	Category    string
+	Order       int
 }


### PR DESCRIPTION
related: #534 - #535 の補完

clitagで`category`と`order`を指定可能にする。