### PR TITLE
Remove link to sandbox.usacloud.jp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@
 
 # 使い方
 
-## オンラインで試す
-
-ブラウザ上でUsacloudをお試しいただけます。
-
-<a href="https://sandbox.usacloud.jp" target="_blank">https://sandbox.usacloud.jp</a>
-
 ## ローカルマシンにインストール
 
 ### macOS(`brew`) / Linux(`apt` or `yum` or `brew`) / bash on Windows(Ubuntu)

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -19,12 +19,6 @@
 
 # Usage
 
-## Try `usacloud` in sandbox
-
-You can try `usacloud` by using your web browser.
-
-<a href="https://sandbox.usacloud.jp" target="_blank">https://sandbox.usacloud.jp</a>
-
 ## Install on local machine
 
 ### macOS(`brew`) / Linux(`apt` or `yum` or `brew`) / bash on Windows(Ubuntu)


### PR DESCRIPTION
v0のsandbox.usacloud.jpを廃止し当該サイトへのリンクを除去する。

v1リリース後に代替サービスへのリンクを改めて設置する。