### PR TITLE
show progress

### DIFF
--- a/pkg/cli/progress.go
+++ b/pkg/cli/progress.go
@@ -56,7 +56,11 @@ func (p *Progress) Exec(f func() error) error {
 	go p.Start()
 	defer p.Stop()
 
-	return f()
+	err := f()
+	if err != nil {
+		p.doneCh <- err
+	}
+	return err
 }
 
 func (p *Progress) msgPrefix() string {

--- a/pkg/cmd/disk/list.go
+++ b/pkg/cmd/disk/list.go
@@ -25,6 +25,7 @@ var listCommand = &base.Command{
 	Order:              10,
 	ServiceFuncAltName: "Find",
 	NoConfirm:          true,
+	NoProgress:         true,
 
 	ParameterInitializer: func() interface{} {
 		return newListParameter()


### PR DESCRIPTION
v0のプログレス表示をv1に移行する。

- v0では各コマンドの実装内でプログレス表示を実装していたが、v1ではbase.Commandで実装することで各コマンドはプログレスを意識しないようにする
- プログレスは以下のようにコマンド定義時に利用有無を指定する(デフォルトで`ON`)

プログレス表示設定の例:

```go
var listCommand = &base.Command{
	Name:               "list",
	Aliases:            []string{"ls", "find", "select"},
	Category:           "basics",
	Order:              10,
	ServiceFuncAltName: "Find",
	NoConfirm:          true,
	NoProgress:         true, // **ここをtrueにするとプログレス表示なしになる

	ParameterInitializer: func() interface{} {
		return newListParameter()
	},
}
```

プログレス表示の例:
```console
$ usacloud --zone is1a disk create --disk-plan ssd --name "from-usacloud-v1" --size 20 --connection=virtio

Are you sure you want to create?(y/n) [n]: y
disk/create: started...
disk/create: done
+---+--------------+------------------+
| # |      ID      |       Name       |
+---+--------------+------------------+
| 1 | 123456789012 | from-usacloud-v1 |
+---+--------------+------------------+

```