### PR TITLE
Default value

### DIFF
--- a/pkg/cmd/disk/create.go
+++ b/pkg/cmd/disk/create.go
@@ -51,7 +51,9 @@ type createParameter struct {
 
 func newCreateParameter() *createParameter {
 	return &createParameter{
-		// TODO デフォルト値はここで設定する
+		DiskPlan:   "ssd",
+		Connection: "virtio",
+		SizeGB:     20,
 	}
 }
 


### PR DESCRIPTION
follow up #553 

各コマンドのパラメータにデフォルト値を設定する。
デフォルト値はbase.Commandの`ParameterInitializer`の中で設定する。

```go
// コマンドの定義
var createCommand = &base.Command{
	Name:     "create",
	Category: "basics",
	Order:    20,

	ParameterInitializer: func() interface{} {
		return newCreateParameter() // この中でデフォルト値をセットしておく
	},
}

// パラメータの定義
type createParameter struct {
	/* ... */
	DiskPlan        string     `cli:",category=disk,options=disk_plan" mapconv:"DiskPlanID,filters=disk_plan_to_id" validate:"oneof=ssd hdd"`
	Connection      string     `cli:",category=disk,options=disk_connection" validate:"oneof=virtio ide"`
	SizeGB          int        `cli:"size,category=disk"`

	/* ... */
}

func newCreateParameter() *createParameter {
	return &createParameter{
		DiskPlan:   "ssd",
		Connection: "virtio",
		SizeGB:     20,
	}
}
```