### PR TITLE
Improve help texts

### DIFF
--- a/pkg/cmd/core/resource.go
+++ b/pkg/cmd/core/resource.go
@@ -65,6 +65,8 @@ func (r *Resource) CLICommand() *cobra.Command {
 			parameter.SetupCobraCommandFlags(cmd)
 		}
 	}
+
+	buildCommandsUsage(cmd, r.CategorizedCommands())
 	return cmd
 }
 
@@ -75,6 +77,13 @@ func (r *Resource) runDefaultCmd(cmd *cobra.Command, args []string, commandName 
 		return nil
 	}
 	return defaultCmd.RunE(defaultCmd, args)
+}
+
+func (r *Resource) CategorizedCommands() []*CategorizedCommands {
+	sort.Slice(r.categorizedCommands, func(i, j int) bool {
+		return r.categorizedCommands[i].Category.Order < r.categorizedCommands[j].Category.Order
+	})
+	return r.categorizedCommands
 }
 
 func (r *Resource) Commands() []*Command {

--- a/pkg/cmd/core/resources.go
+++ b/pkg/cmd/core/resources.go
@@ -1,0 +1,49 @@
+// Copyright 2017-2020 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import "sort"
+
+type Resources []*Resource
+
+type CategorizedResources struct {
+	Category  Category
+	Resources []*Resource
+}
+
+func (r Resources) CategorizedResources() []*CategorizedResources {
+	categories := ResourceCategories
+	sort.Slice(categories, func(i, j int) bool {
+		return categories[i].Order < categories[j].Order
+	})
+
+	var results []*CategorizedResources
+	for _, c := range categories {
+		result := &CategorizedResources{
+			Category:  c,
+			Resources: []*Resource{},
+		}
+		for _, resource := range r {
+			if c.Equals(&resource.Category) {
+				result.Resources = append(result.Resources, resource)
+			}
+		}
+
+		if len(result.Resources) > 0 {
+			results = append(results, result)
+		}
+	}
+	return results
+}

--- a/pkg/cmd/funcs/disk/apply.go
+++ b/pkg/cmd/funcs/disk/apply.go
@@ -22,7 +22,7 @@ import (
 // TODO 未実装
 var applyCommand = &core.Command{ // nolint TODO あとでnolintを消す
 	Name:         "apply",
-	Category:     "basics",
+	Category:     "basic",
 	Order:        40,
 	SelectorType: core.SelectorTypeNone, // TODO 将来的には作成(ID不要) + 更新(ID必要)をサポートしたい、この際にSelectorTypeを増やすべきかも
 

--- a/pkg/cmd/funcs/disk/connect_to_server.go
+++ b/pkg/cmd/funcs/disk/connect_to_server.go
@@ -22,7 +22,7 @@ import (
 var connectToServerCommand = &core.Command{
 	Name:         "connect-to-server",
 	Aliases:      []string{"server-connect"}, // v0との互換用
-	Category:     "server",
+	Category:     "operation",
 	Order:        10,
 	SelectorType: core.SelectorTypeRequireSingle,
 

--- a/pkg/cmd/funcs/disk/create.go
+++ b/pkg/cmd/funcs/disk/create.go
@@ -23,9 +23,8 @@ import (
 
 var createCommand = &core.Command{
 	Name:     "create",
-	Category: "basics",
+	Category: "basic",
 	Order:    20,
-
 	ParameterInitializer: func() interface{} {
 		return newCreateParameter()
 	},

--- a/pkg/cmd/funcs/disk/delete.go
+++ b/pkg/cmd/funcs/disk/delete.go
@@ -21,7 +21,7 @@ import (
 var deleteCommand = &core.Command{
 	Name:         "delete",
 	Aliases:      []string{"rm"},
-	Category:     "basics",
+	Category:     "basic",
 	Order:        50,
 	SelectorType: core.SelectorTypeRequireMulti,
 

--- a/pkg/cmd/funcs/disk/disconnect_from_server.go
+++ b/pkg/cmd/funcs/disk/disconnect_from_server.go
@@ -21,7 +21,7 @@ import (
 var disconnectFromServerCommand = &core.Command{
 	Name:         "disconnect-from-server",
 	Aliases:      []string{"server-disconnect"}, // v0との互換用
-	Category:     "server",
+	Category:     "operation",
 	Order:        20,
 	SelectorType: core.SelectorTypeRequireSingle,
 

--- a/pkg/cmd/funcs/disk/edit.go
+++ b/pkg/cmd/funcs/disk/edit.go
@@ -23,7 +23,7 @@ import (
 // TODO 未実装
 var editCommand = &core.Command{ // nolint TODO あとでnolintを消す
 	Name:         "edit",
-	Category:     "edit",
+	Category:     "operation",
 	Order:        10,
 	SelectorType: core.SelectorTypeRequireSingle,
 

--- a/pkg/cmd/funcs/disk/list.go
+++ b/pkg/cmd/funcs/disk/list.go
@@ -21,7 +21,7 @@ import (
 var listCommand = &core.Command{
 	Name:               "list",
 	Aliases:            []string{"ls", "find", "select"},
-	Category:           "basics",
+	Category:           "basic",
 	Order:              10,
 	ServiceFuncAltName: "Find",
 	NoConfirm:          true,

--- a/pkg/cmd/funcs/disk/read.go
+++ b/pkg/cmd/funcs/disk/read.go
@@ -21,7 +21,7 @@ import (
 var readCommand = &core.Command{
 	Name:       "read",
 	Aliases:    []string{"show"},
-	Category:   "basics",
+	Category:   "basic",
 	Order:      30,
 	NoConfirm:  true,
 	NoProgress: true,

--- a/pkg/cmd/funcs/disk/resize_partition.go
+++ b/pkg/cmd/funcs/disk/resize_partition.go
@@ -20,7 +20,7 @@ import (
 
 var resizePartitionCommand = &core.Command{
 	Name:         "resize-partition",
-	Category:     "edit",
+	Category:     "operation",
 	Order:        20,
 	SelectorType: core.SelectorTypeRequireSingle,
 

--- a/pkg/cmd/funcs/disk/resource.go
+++ b/pkg/cmd/funcs/disk/resource.go
@@ -29,33 +29,23 @@ var Resource = &core.Resource{
 	Category:    core.ResourceCategoryStorage,
 	CommandCategories: []core.Category{
 		{
-			Key:         "basics",
-			DisplayName: "Basics",
+			Key:         "basic",
+			DisplayName: "Basic Commands",
 			Order:       10,
 		},
 		{
-			Key:         "edit",
-			DisplayName: "Disk Edit",
+			Key:         "operation",
+			DisplayName: "Disk Operation Commands",
 			Order:       20,
 		},
 		{
-			Key:         "re-install",
-			DisplayName: "Re-Install",
-			Order:       25,
-		},
-		{
-			Key:         "server",
-			DisplayName: "Server Connection Management",
+			Key:         "monitor",
+			DisplayName: "Monitoring Commands",
 			Order:       30,
 		},
 		{
-			Key:         "monitor",
-			DisplayName: "Monitoring",
-			Order:       40,
-		},
-		{
 			Key:         "other",
-			DisplayName: "Other",
+			DisplayName: "Other Commands",
 			Order:       1000,
 		},
 	},

--- a/pkg/cmd/funcs/disk/update.go
+++ b/pkg/cmd/funcs/disk/update.go
@@ -21,7 +21,7 @@ import (
 
 var updateCommand = &core.Command{
 	Name:         "update",
-	Category:     "basics",
+	Category:     "basic",
 	Order:        40,
 	SelectorType: core.SelectorTypeRequireMulti,
 

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sacloud/usacloud/pkg/cmd/root"
 )
 
-var Resources = []*core.Resource{
+var Resources = core.Resources{
 	authstatus.Resource,
 	disk.Resource,
 }
@@ -31,4 +31,5 @@ func initCommands() {
 	for _, r := range Resources {
 		root.Command.AddCommand(r.CLICommand())
 	}
+	core.BuildRootCommandsUsage(root.Command, Resources.CategorizedResources())
 }


### PR DESCRIPTION
follow up #553 

コマンドヘルプでのカテゴリー表示/~エイリアス表示~を行う。

表示例(トップレベル):
```console
$ usacloud -h

CLI to manage to resources on the SAKURA Cloud

Usage:
  usacloud [command]

Available Commands:
 === Authentication ===
    auth-status 

 === Storage ===
    disk        

Flags:
      --profile string      the name of saved credentials (default "default")
      --token string        the API token used when calling SAKURA Cloud API
      --secret string       the API secret used when calling SAKURA Cloud API
      --zone string         target zone name
      --zones strings       permitted zone names
      --no-color            disable ANSI color output
      --trace               enable trace logs for API calling
      --fake                enable fake API driver
      --fake-store string   path to file store used by the fake API driver
  -h, --help                help for usacloud

Use "usacloud [command] --help" for more information about a command.

Copyright 2017-2020 The Usacloud Authors
```

表示例(リソースレベル):
```console
$ usacloud disk -h

Usage:
  usacloud disk [flags]
  usacloud disk [command]

Available Commands:
 === Basic Commands ===
    list                   
    create                 
    read                   
    update                 
    delete                 

 === Disk Operation Commands ===
    connect-to-server      
    disconnect-from-server 
    resize-partition       

 === Monitoring Commands ===
    monitor-disk           

 === Other Commands ===
    wait-until-ready       

Flags:
  -h, --help   help for disk

Global Flags:
      --fake                enable fake API driver
      --fake-store string   path to file store used by the fake API driver
      --no-color            disable ANSI color output
      --profile string      the name of saved credentials (default "default")
      --secret string       the API secret used when calling SAKURA Cloud API
      --token string        the API token used when calling SAKURA Cloud API
      --trace               enable trace logs for API calling
      --zone string         target zone name
      --zones strings       permitted zone names

Use "usacloud disk [command] --help" for more information about a command.
```

表示例(コマンドレベル)
```console
$ usacloud disk list -h

Usage:
  usacloud disk list [flags]

Aliases:
  list, ls, find, select

Flags:
 === Filter options ===
      --count int       (aliases: --max, --limit)
      --from int        (aliases: --offset)
      --names strings   
      --tags strings    

 === Output options ===
      --format string        Output format in Go templates (aliases: --fmt)
      --format-file string   Output format in Go templates(from file)
  -o, --output-type string   Output format: one of the following [table/json/yaml] (aliases: --out)
      --query string         JMESPath query
      --query-file string    JMESPath query(from file)
  -q, --quiet                Output IDs only

 === Other options ===
      --zone string   

Global Flags:
      --fake                enable fake API driver
      --fake-store string   path to file store used by the fake API driver
      --no-color            disable ANSI color output
      --profile string      the name of saved credentials (default "default")
      --secret string       the API secret used when calling SAKURA Cloud API
      --token string        the API token used when calling SAKURA Cloud API
      --trace               enable trace logs for API calling
      --zones strings       permitted zone name
```