### PR TITLE
Show zone name on progress/confirm

### DIFF
--- a/pkg/cli/progress.go
+++ b/pkg/cli/progress.go
@@ -64,10 +64,14 @@ func (p *Progress) Exec(f func() error) error {
 }
 
 func (p *Progress) msgPrefix() string {
-	if p.ctx.ID().IsEmpty() {
-		return p.jobName
+	prefix := p.jobName
+	if p.ctx.Zone() != "" {
+		prefix = fmt.Sprintf("[%s] %s", p.ctx.Zone(), prefix)
 	}
-	return fmt.Sprintf("%s(ID:%s)", p.jobName, p.ctx.ID().String())
+	if !p.ctx.ID().IsEmpty() {
+		prefix = fmt.Sprintf("%s (ID:%s)", prefix, p.ctx.ID().String())
+	}
+	return prefix
 }
 
 func (p *Progress) msgStart() string {

--- a/pkg/cli/resource_context.go
+++ b/pkg/cli/resource_context.go
@@ -14,12 +14,26 @@
 
 package cli
 
-import "github.com/sacloud/libsacloud/v2/sacloud/types"
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
 
 // ResourceContext 現在処理中のリソースの情報
 type ResourceContext struct {
 	ID   types.ID
 	Zone string
+}
+
+func (r *ResourceContext) String() string {
+	if r.ID.IsEmpty() {
+		return ""
+	}
+	if r.Zone == "" {
+		return r.ID.String()
+	}
+	return fmt.Sprintf("[%s] %s", r.Zone, r.ID.String())
 }
 
 type ResourceContexts []ResourceContext
@@ -47,4 +61,15 @@ func (r *ResourceContexts) IDs() []types.ID {
 		}
 	}
 	return ids
+}
+
+func (r *ResourceContexts) Strings() []string {
+	var res []string
+	for _, v := range *r {
+		s := v.String()
+		if s != "" {
+			res = append(res, s)
+		}
+	}
+	return res
 }

--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/sacloud/libsacloud/v2/pkg/mapconv"
-	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/cmd/cflag"
@@ -237,7 +236,7 @@ func (c *Command) confirmContinue(ctx cli.Context, resources cli.ResourceContext
 
 func (c *Command) allZoneResourceContext(ctx cli.Context) cli.ResourceContexts {
 	if c.resource.IsGlobalResource {
-		return cli.ResourceContexts{{Zone: sacloud.APIDefaultZone}}
+		return cli.ResourceContexts{}
 	}
 
 	zone := cflag.ZoneFlagValue(c.currentParameter)
@@ -442,13 +441,9 @@ func (c *Command) execParallel(ctx cli.Context, ids cli.ResourceContexts) (outpu
 				return
 			}
 
-			zone := ctx.Zone()
-			if c.resource.IsGlobalResource {
-				zone = ""
-			}
 			var contents = output.Contents{}
 			for _, r := range res {
-				contents = append(contents, &output.Content{Zone: zone, Value: r})
+				contents = append(contents, &output.Content{Zone: ctx.Zone(), Value: r})
 			}
 
 			resultCh <- &funcResult{results: contents}

--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -224,7 +224,7 @@ func (c *Command) confirmContinue(ctx cli.Context, resources cli.ResourceContext
 				if !term.IsTerminal() {
 					return false, errors.New("the confirm dialog cannot be used without the terminal. Please use --assumeyes(-y) option")
 				}
-				result, err := util.ConfirmContinue(c.confirmMessage(), ctx.IO().In(), ctx.IO().Out(), resources.IDs()...) // TODO cli.Contextを渡す??
+				result, err := util.ConfirmContinue(c.confirmMessage(), ctx.IO().In(), ctx.IO().Out(), resources.Strings()...)
 				if err != nil || !result {
 					return result, err
 				}

--- a/pkg/util/confirm.go
+++ b/pkg/util/confirm.go
@@ -19,8 +19,6 @@ import (
 	"io"
 	"os"
 	"strings"
-
-	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 type In interface {
@@ -49,11 +47,11 @@ func Confirm(msg string, in In, out io.Writer) (bool, error) {
 	return input == "y" || input == "yes", nil
 }
 
-func ConfirmContinue(target string, in In, out io.Writer, ids ...types.ID) (bool, error) {
+func ConfirmContinue(target string, in In, out io.Writer, ids ...string) (bool, error) {
 	msg := fmt.Sprintf("Are you sure you want to %s?", target)
 	if len(ids) > 0 {
 		msg = fmt.Sprintf("Target resource IDs => [\n\t%s\n]\nAre you sure you want to %s?",
-			strings.Join(StringIDs(ids), ",\n\t"),
+			strings.Join(ids, ",\n\t"),
 			target,
 		)
 	}


### PR DESCRIPTION
closes #577 

プログレス表示/確認ダイアログでゾーン名を表示する。全ゾーン対象動作(`--zone=all`指定時)だけでなく通常の操作時も表示される。

### プログレス表示の例

```bash
usacloud disk create --zone=all --name "example"

Are you sure you want to create?(y/n) [n]: y
[tk1b] disk/create: started...
[is1a] disk/create: started...
[is1b] disk/create: started...
[tk1v] disk/create: started...
[tk1a] disk/create: started...
[tk1v] disk/create: done
[is1b] disk/create: done
[tk1b] disk/create: done
	[is1a] disk/create: 10s elapsed
	[tk1a] disk/create: 10s elapsed
[is1a] disk/create: done
[tk1a] disk/create: done

```

### 確認ダイアログの例

```bash
$ usacloud disk rm --zone=all "example"

Target resource IDs => [
	[is1b] 000000000001,
	[tk1v] 000000000002,
	[is1a] 000000000003,
	[tk1b] 000000000004,
	[tk1a] 000000000005
]

Are you sure you want to delete?(y/n) [n]: 
```

Note: グローバルリソースの場合は従来のままゾーン名は表示されない