### PR TITLE
Fixed progress termination process

### DIFF
--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -376,7 +376,9 @@ func (c *Command) exec(ctx cli.Context, ids cli.ResourceContexts) (output.Conten
 		fn := c.Func
 		c.Func = func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			var results []interface{}
-			err := NewProgress(ctx).Exec(func() error {
+			progress := NewProgress(ctx)
+			defer progress.Close()
+			err := progress.Exec(func() error {
 				res, err := fn(ctx, parameter)
 				if err != nil {
 					return err

--- a/pkg/cmd/core/progress.go
+++ b/pkg/cmd/core/progress.go
@@ -94,7 +94,6 @@ func (p *Progress) msgFailed(err error) string {
 
 func (p *Progress) Start() {
 	p.doneCh = make(chan error)
-	defer close(p.doneCh)
 
 	ticker := time.NewTicker(p.duration)
 	defer ticker.Stop()
@@ -129,4 +128,8 @@ func (p *Progress) print(clr *color.Color, msg string) {
 	defer mutex.Unlock()
 	p.printer.Fprint(p.out, clr, msg)
 	p.printer.Fprint(p.out, color.New(color.Reset), "")
+}
+
+func (p *Progress) Close() {
+	close(p.doneCh)
 }


### PR DESCRIPTION
fixes #567 

プログレスの終了処理時にchannelを閉じるタイミングが早すぎたために #567 の問題が起きていたのを修正。