### PR TITLE
Added ID field to output.Content

### DIFF
--- a/pkg/cmd/commands/archive/ftp_open.go
+++ b/pkg/cmd/commands/archive/ftp_open.go
@@ -29,6 +29,8 @@ var ftpOpenCommand = &core.Command{
 	SelectorType:       core.SelectorTypeRequireMulti,
 
 	ColumnDefs: []output.ColumnDef{
+		{Name: "Zone"},
+		{Name: "ID"},
 		{Name: "HostName"},
 		{Name: "IPAddress"},
 		{Name: "User"},

--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -440,7 +440,7 @@ func (c *Command) execParallel(ctx cli.Context, ids cli.ResourceContexts) (outpu
 
 			var contents = output.Contents{}
 			for _, r := range res {
-				contents = append(contents, &output.Content{Zone: ctx.Zone(), Value: r})
+				contents = append(contents, &output.Content{Zone: ctx.Zone(), ID: ctx.ID(), Value: r})
 			}
 
 			resultCh <- &funcResult{results: contents}

--- a/pkg/output/contents.go
+++ b/pkg/output/contents.go
@@ -18,10 +18,12 @@ import (
 	"sort"
 
 	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 type Content struct {
 	Zone  string
+	ID    types.ID
 	Value interface{}
 }
 
@@ -43,11 +45,18 @@ func (c *Contents) Sort(zones []string) {
 	}
 
 	values := *c
+	// 優先度: ゾーン => ID(Content内の) => ID(Content.Valueの)
 	sort.Slice(values, func(i, j int) bool {
 		o1 := zoneOrder[values[i].Zone]
 		o2 := zoneOrder[values[j].Zone]
 		if o1 != o2 {
 			return o1 < o2
+		}
+
+		cid1 := values[i].ID
+		cid2 := values[j].ID
+		if cid1 != cid2 {
+			return cid1 < cid2
 		}
 
 		id1 := c.forceID(values[i].Value)

--- a/pkg/output/free_output.go
+++ b/pkg/output/free_output.go
@@ -94,6 +94,11 @@ func (o *freeOutput) Print(contents Contents) error {
 				mapValue["Zone"] = contents[i].Zone
 			}
 		}
+		if !contents[i].ID.IsEmpty() {
+			if _, ok := mapValue["ID"]; !ok {
+				mapValue["ID"] = contents[i].ID
+			}
+		}
 
 		buf := bytes.NewBufferString("")
 		if err := t.Execute(buf, mapValue); err != nil {

--- a/pkg/output/json_output.go
+++ b/pkg/output/json_output.go
@@ -79,6 +79,12 @@ func (o *jsonOutput) Print(contents Contents) error {
 				row.Set("Zone", contents[i].Zone)
 			}
 		}
+		if !contents[i].ID.IsEmpty() {
+			row := j.GetIndex(i)
+			if _, ok := row.CheckGet("ID"); !ok {
+				row.Set("ID", contents[i].ID)
+			}
+		}
 	}
 
 	b, err := j.EncodePretty()

--- a/pkg/output/table_output.go
+++ b/pkg/output/table_output.go
@@ -78,6 +78,11 @@ func (o *tableOutput) Print(contents Contents) error {
 				mapValue["Zone"] = contents[i].Zone
 			}
 		}
+		if !contents[i].ID.IsEmpty() {
+			if _, ok := mapValue["ID"]; !ok {
+				mapValue["ID"] = contents[i].ID
+			}
+		}
 		if err := table.append(mapValue); err != nil {
 			return fmt.Errorf("TableOutput:Print: processing template failed: %v", err)
 		}

--- a/pkg/output/yaml_output.go
+++ b/pkg/output/yaml_output.go
@@ -71,6 +71,12 @@ func (o *yamlOutput) Print(contents Contents) error {
 				row.Set("Zone", contents[i].Zone)
 			}
 		}
+		if !contents[i].ID.IsEmpty() {
+			row := j.GetIndex(i)
+			if _, ok := row.CheckGet("ID"); !ok {
+				row.Set("ID", contents[i].ID)
+			}
+		}
 	}
 
 	b, err := yaml.Marshal(j)


### PR DESCRIPTION
closes #590 

IDを引数にとるコマンドでアウトプット時にIDを参照可能にする。

例: アーカイブのFTPオープンの出力

```bash
+------+--------------+---------------------------------+-----------------+---------------------+------------------+
| Zone |      ID      |            HostName             |    IPAddress    |        User         |     Password     |
+------+--------------+---------------------------------+-----------------+---------------------+------------------+
| is1b | 123456789012 | sac-is1b-ftp.cloud.sakura.ad.jp | 192.0.2.1       | archive123456789012 | xxxxxxxxxxxxxxxx |
+------+--------------+---------------------------------+-----------------+---------------------+------------------+
```