### PR TITLE
Improve CLI error handling

### DIFF
--- a/pkg/cmd/core/progress.go
+++ b/pkg/cmd/core/progress.go
@@ -20,9 +20,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sacloud/usacloud/pkg/cli"
-
 	"github.com/fatih/color"
+	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/printer"
 )
 
@@ -56,12 +55,9 @@ func NewProgress(ctx cli.Context) *Progress {
 
 func (p *Progress) Exec(f func() error) error {
 	go p.Start()
-	defer p.Stop()
 
 	err := f()
-	if err != nil {
-		p.doneCh <- err
-	}
+	p.doneCh <- err
 	return err
 }
 
@@ -88,9 +84,9 @@ func (p *Progress) msgComplete() string {
 	return fmt.Sprintf("%s: done\n", p.msgPrefix())
 }
 
-func (p *Progress) msgFailed(err error) string {
-	return fmt.Sprintf("%s: failed: %s\n", p.msgPrefix(), err)
-}
+//func (p *Progress) msgFailed(err error) string {
+//	return fmt.Sprintf("%s: failed: %s\n", p.msgPrefix(), err)
+//}
 
 func (p *Progress) Start() {
 	p.doneCh = make(chan error)
@@ -106,7 +102,6 @@ func (p *Progress) Start() {
 			p.print(color.New(color.FgWhite), p.msgProgress())
 		case err := <-p.doneCh:
 			if err != nil {
-				p.print(color.New(color.FgHiRed), p.msgFailed(err))
 				return
 			}
 			p.print(color.New(color.FgHiGreen), p.msgComplete())
@@ -119,10 +114,6 @@ func (p *Progress) Start() {
 	}
 }
 
-func (p *Progress) Stop() {
-	p.doneCh <- nil
-}
-
 func (p *Progress) print(clr *color.Color, msg string) {
 	mutex.Lock()
 	defer mutex.Unlock()
@@ -132,4 +123,5 @@ func (p *Progress) print(clr *color.Color, msg string) {
 
 func (p *Progress) Close() {
 	close(p.doneCh)
+	p.printer.Fprint(p.out, color.New(color.Reset), "") // 念のため色をリセットしておく
 }

--- a/pkg/cmd/root/command.go
+++ b/pkg/cmd/root/command.go
@@ -21,9 +21,10 @@ import (
 
 // Command represents the base command when called without any sub-commands
 var Command = &cobra.Command{
-	Use:   "usacloud [global options] <command> <sub-command> [options] [arguments]",
-	Short: "Usacloud is CLI for manage to resources on the SAKURA Cloud",
-	Long:  `CLI to manage to resources on the SAKURA Cloud`,
+	Use:           "usacloud [global options] <command> <sub-command> [options] [arguments]",
+	Short:         "Usacloud is CLI for manage to resources on the SAKURA Cloud",
+	Long:          `CLI to manage to resources on the SAKURA Cloud`,
+	SilenceErrors: true, // core.Commandでエラー出力を制御するためtrueにしておく
 }
 
 func init() {


### PR DESCRIPTION
closes #589 

プログレス表示やcore.Commandでのエラー処理を改善

- プログレス表示ではエラーの出力は行わない
- core.Commandでエラー出力を制御し、cobra.Commandのエラー出力を利用しない(`SilenceErrors: true`)