### PR TITLE
Default category for parameters

### DIFF
--- a/pkg/cmd/commands/archive/create.go
+++ b/pkg/cmd/commands/archive/create.go
@@ -38,15 +38,15 @@ var createCommand = &core.Command{
 type createParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 
-	Name        string   `cli:",category=archive" validate:"required"`
-	Description string   `cli:",category=archive" validate:"description"`
-	Tags        []string `cli:",category=archive" validate:"tags"`
-	IconID      types.ID `cli:",category=archive"`
-	SizeGB      int      `cli:"size,category=archive" validate:"required_with=SourceFile"`
+	Name        string   `validate:"required"`
+	Description string   `validate:"description"`
+	Tags        []string `validate:"tags"`
+	IconID      types.ID
+	SizeGB      int `cli:"size" validate:"required_with=SourceFile"`
 
-	SourceFile      string   `cli:",category=archive" mapconv:"SourceReader,filters=path_to_reader" validate:"omitempty,file"` // TODO 標準入力(パイプも)への対応
-	SourceDiskID    types.ID `cli:",category=archive"`
-	SourceArchiveID types.ID `cli:",category=archive"`
+	SourceFile      string `mapconv:"SourceReader,filters=path_to_reader" validate:"omitempty,file"` // TODO 標準入力(パイプも)への対応
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/archive/delete.go
+++ b/pkg/cmd/commands/archive/delete.go
@@ -35,7 +35,7 @@ type deleteParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	FailIfNotFound bool `cli:",category=archive"`
+	FailIfNotFound bool
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/archive/download.go
+++ b/pkg/cmd/commands/archive/download.go
@@ -40,7 +40,7 @@ type downloadParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	Destination string `cli:",aliases=dest,category=archive" mapconv:"Writer,omitempty,filters=path_to_writer"` // 省略時は標準出力
+	Destination string `cli:",aliases=dest" mapconv:"Writer,omitempty,filters=path_to_writer"` // 省略時は標準出力
 	Force       bool   `cli:",short=f,desc=overwrite file when --destination file is already exist"`
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/archive/update.go
+++ b/pkg/cmd/commands/archive/update.go
@@ -37,10 +37,10 @@ type updateParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	Name        *string   `cli:",category=archive" validate:"omitempty,min=1"`
-	Description *string   `cli:",category=archive" validate:"omitempty,description"`
-	Tags        *[]string `cli:",category=archive" validate:"omitempty,tags"`
-	IconID      *types.ID `cli:",category=archive"`
+	Name        *string   `validate:"omitempty,min=1"`
+	Description *string   `validate:"omitempty,description"`
+	Tags        *[]string `validate:"omitempty,tags"`
+	IconID      *types.ID
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/archive/upload.go
+++ b/pkg/cmd/commands/archive/upload.go
@@ -34,7 +34,7 @@ type uploadParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	SourceFile string `cli:",category=archive" mapconv:"Reader,filters=path_to_reader" validate:"omitempty,file"`
+	SourceFile string `mapconv:"Reader,filters=path_to_reader" validate:"omitempty,file"`
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 }

--- a/pkg/cmd/commands/archive/zz_create_gen.go
+++ b/pkg/cmd/commands/archive/zz_create_gen.go
@@ -62,6 +62,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("description"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("tags"))
@@ -95,15 +96,6 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_delete_gen.go
+++ b/pkg/cmd/commands/archive/zz_delete_gen.go
@@ -55,6 +55,7 @@ func (p *deleteParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("fail-if-not-found"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Archive options",
@@ -81,15 +82,6 @@ func (p *deleteParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_download_gen.go
+++ b/pkg/cmd/commands/archive/zz_download_gen.go
@@ -48,7 +48,9 @@ func (p *downloadParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("destination"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("force"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Archive options",
 			Flags: fs,
@@ -60,16 +62,6 @@ func (p *downloadParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Input options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("force"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_ftp_close_gen.go
+++ b/pkg/cmd/commands/archive/zz_ftp_close_gen.go
@@ -41,19 +41,19 @@ func (p *ftpCloseParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("Input", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
+		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Input options",
+			Title: "Archive options",
 			Flags: fs,
 		})
 	}
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		fs = pflag.NewFlagSet("Input", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
+			Title: "Input options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_ftp_open_gen.go
+++ b/pkg/cmd/commands/archive/zz_ftp_open_gen.go
@@ -54,6 +54,16 @@ func (p *ftpOpenParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
+		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("change-password"))
+		sets = append(sets, &core.FlagSet{
+			Title: "Archive options",
+			Flags: fs,
+		})
+	}
+	{
+		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("Input", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
 		sets = append(sets, &core.FlagSet{
@@ -72,16 +82,6 @@ func (p *ftpOpenParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("change-password"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_list_gen.go
+++ b/pkg/cmd/commands/archive/zz_list_gen.go
@@ -64,6 +64,15 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
+		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		sets = append(sets, &core.FlagSet{
+			Title: "Archive options",
+			Flags: fs,
+		})
+	}
+	{
+		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("filter", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("names"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("tags"))
@@ -87,15 +96,6 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_read_gen.go
+++ b/pkg/cmd/commands/archive/zz_read_gen.go
@@ -52,6 +52,15 @@ func (p *readParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
+		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		sets = append(sets, &core.FlagSet{
+			Title: "Archive options",
+			Flags: fs,
+		})
+	}
+	{
+		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("output", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("output-type"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("quiet"))
@@ -61,15 +70,6 @@ func (p *readParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_update_gen.go
+++ b/pkg/cmd/commands/archive/zz_update_gen.go
@@ -82,6 +82,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("description"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("tags"))
@@ -111,15 +112,6 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_upload_gen.go
+++ b/pkg/cmd/commands/archive/zz_upload_gen.go
@@ -43,6 +43,7 @@ func (p *uploadParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("source-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Archive options",
@@ -55,15 +56,6 @@ func (p *uploadParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Input options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/archive/zz_wait_until_ready_gen.go
+++ b/pkg/cmd/commands/archive/zz_wait_until_ready_gen.go
@@ -40,10 +40,10 @@ func (p *waitUntilReadyParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
+		fs = pflag.NewFlagSet("archive", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
+			Title: "Archive options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/apply.go
+++ b/pkg/cmd/commands/disk/apply.go
@@ -36,18 +36,18 @@ type applyParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	// cflag.IDParameter   `cli:",squash" mapconv:",squash"` //TODO SelectorTypeのコメント参照(将来ID使うかも)
 
-	Name            string     `cli:",category=disk" validate:"required"`
-	Description     string     `cli:",category=disk" validate:"description"`
-	Tags            []string   `cli:",category=disk" validate:"tags"`
-	IconID          types.ID   `cli:",category=disk"`
-	DiskPlan        string     `cli:",category=disk,options=disk_plan" mapconv:"DiskPlanID,filters=disk_plan_to_value" validate:"required,disk_plan"`
-	Connection      string     `cli:",category=disk,options=disk_connection" validate:"required,disk_connection"`
-	SourceDiskID    types.ID   `cli:",category=disk"`
-	SourceArchiveID types.ID   `cli:",category=disk"`
-	ServerID        types.ID   `cli:",category=disk"`
-	SizeGB          int        `cli:"size,category=disk"`
-	DistantFrom     []types.ID `cli:",category=disk"`
-	OSType          string     `cli:",category=disk,options=os_type" mapconv:",filters=os_type_to_value" validate:"omitempty,os_type"`
+	Name            string   `validate:"required"`
+	Description     string   `validate:"description"`
+	Tags            []string `validate:"tags"`
+	IconID          types.ID
+	DiskPlan        string `cli:",options=disk_plan" mapconv:"DiskPlanID,filters=disk_plan_to_value" validate:"required,disk_plan"`
+	Connection      string `cli:",options=disk_connection" validate:"required,disk_connection"`
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+	ServerID        types.ID
+	SizeGB          int `cli:"size"`
+	DistantFrom     []types.ID
+	OSType          string `cli:",options=os_type" mapconv:",filters=os_type_to_value" validate:"omitempty,os_type"`
 
 	//EditParameter editParameter `cli:",category=edit" mapconv:",omitempty"`
 

--- a/pkg/cmd/commands/disk/connect_to_server.go
+++ b/pkg/cmd/commands/disk/connect_to_server.go
@@ -36,7 +36,7 @@ type connectToServerParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	ServerID types.ID `cli:",category=disk" validate:"required"`
+	ServerID types.ID `validate:"required"`
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 }

--- a/pkg/cmd/commands/disk/create.go
+++ b/pkg/cmd/commands/disk/create.go
@@ -38,18 +38,18 @@ var createCommand = &core.Command{
 type createParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 
-	Name            string     `cli:",category=disk" validate:"required"`
-	Description     string     `cli:",category=disk" validate:"description"`
-	Tags            []string   `cli:",category=disk" validate:"tags"`
-	IconID          types.ID   `cli:",category=disk"`
-	DiskPlan        string     `cli:",category=disk,options=disk_plan" mapconv:"DiskPlanID,filters=disk_plan_to_value" validate:"required,disk_plan"`
-	Connection      string     `cli:",category=disk,options=disk_connection" validate:"required,disk_connection"`
-	SourceDiskID    types.ID   `cli:",category=disk"`
-	SourceArchiveID types.ID   `cli:",category=disk"`
-	ServerID        types.ID   `cli:",category=disk"`
-	SizeGB          int        `cli:"size,category=disk"`
-	DistantFrom     []types.ID `cli:",category=disk"`
-	OSType          string     `cli:",category=disk,options=os_type" mapconv:",filters=os_type_to_value" validate:"omitempty,os_type"`
+	Name            string   `validate:"required"`
+	Description     string   `validate:"description"`
+	Tags            []string `validate:"tags"`
+	IconID          types.ID
+	DiskPlan        string `cli:",options=disk_plan" mapconv:"DiskPlanID,filters=disk_plan_to_value" validate:"required,disk_plan"`
+	Connection      string `cli:",options=disk_connection" validate:"required,disk_connection"`
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+	ServerID        types.ID
+	SizeGB          int `cli:"size"`
+	DistantFrom     []types.ID
+	OSType          string `cli:",options=os_type" mapconv:",filters=os_type_to_value" validate:"omitempty,os_type"`
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/disk/delete.go
+++ b/pkg/cmd/commands/disk/delete.go
@@ -35,7 +35,7 @@ type deleteParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	FailIfNotFound bool `cli:",category=disk"`
+	FailIfNotFound bool
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/disk/edit.go
+++ b/pkg/cmd/commands/disk/edit.go
@@ -37,26 +37,26 @@ type editParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	EditParameter editServiceParameter `cli:",squash,category=edit" mapconv:",omitempty"`
+	EditParameter editServiceParameter `cli:",squash" mapconv:",omitempty"`
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`
 }
 
 type editServiceParameter struct {
-	HostName string `cli:",category=edit"`
-	Password string `cli:",category=edit"`
+	HostName string
+	Password string
 
-	DisablePWAuth       bool `cli:",category=edit"`
-	EnableDHCP          bool `cli:",category=edit"`
-	ChangePartitionUUID bool `cli:",category=edit"`
+	DisablePWAuth       bool
+	EnableDHCP          bool
+	ChangePartitionUUID bool
 
-	IPAddress      string `cli:",category=edit"`
-	NetworkMaskLen int    `cli:",category=edit"`
-	DefaultRoute   string `cli:",category=edit"`
+	IPAddress      string
+	NetworkMaskLen int
+	DefaultRoute   string
 
-	SSHKeys   []string   `cli:",category=edit"`
-	SSHKeyIDs []types.ID `cli:",category=edit"`
+	SSHKeys   []string
+	SSHKeyIDs []types.ID
 
 	Notes []*sacloud.DiskEditNote // TODO 2段階以上にネストしたパラメータをどう扱うか? => https://github.com/sacloud/usacloud/issues/568
 }

--- a/pkg/cmd/commands/disk/update.go
+++ b/pkg/cmd/commands/disk/update.go
@@ -37,11 +37,11 @@ type updateParameter struct {
 	cflag.ZoneParameter `cli:",squash" mapconv:",squash"`
 	cflag.IDParameter   `cli:",squash" mapconv:",squash"`
 
-	Name        *string   `cli:",category=disk" validate:"omitempty,min=1"`
-	Description *string   `cli:",category=disk" validate:"omitempty,description"`
-	Tags        *[]string `cli:",category=disk" validate:"omitempty,tags"`
-	IconID      *types.ID `cli:",category=disk"`
-	Connection  *string   `cli:",category=disk,options=disk_connection" validate:"omitempty,disk_connection"`
+	Name        *string   `validate:"omitempty,min=1"`
+	Description *string   `validate:"omitempty,description"`
+	Tags        *[]string `validate:"omitempty,tags"`
+	IconID      *types.ID
+	Connection  *string `cli:",options=disk_connection" validate:"omitempty,disk_connection"`
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/disk/zz_connect_to_server_gen.go
+++ b/pkg/cmd/commands/disk/zz_connect_to_server_gen.go
@@ -43,6 +43,7 @@ func (p *connectToServerParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("server-id"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Disk options",
@@ -55,15 +56,6 @@ func (p *connectToServerParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Input options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_create_gen.go
+++ b/pkg/cmd/commands/disk/zz_create_gen.go
@@ -66,6 +66,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("description"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("tags"))
@@ -103,15 +104,6 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_delete_gen.go
+++ b/pkg/cmd/commands/disk/zz_delete_gen.go
@@ -55,6 +55,7 @@ func (p *deleteParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("fail-if-not-found"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Disk options",
@@ -81,15 +82,6 @@ func (p *deleteParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_disconnect_from_server_gen.go
+++ b/pkg/cmd/commands/disk/zz_disconnect_from_server_gen.go
@@ -41,19 +41,19 @@ func (p *disconnectFromServerParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("Input", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
+		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Input options",
+			Title: "Disk options",
 			Flags: fs,
 		})
 	}
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		fs = pflag.NewFlagSet("Input", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
+			Title: "Input options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_list_gen.go
+++ b/pkg/cmd/commands/disk/zz_list_gen.go
@@ -62,6 +62,15 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
+		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		sets = append(sets, &core.FlagSet{
+			Title: "Disk options",
+			Flags: fs,
+		})
+	}
+	{
+		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("filter", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("names"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("tags"))
@@ -83,15 +92,6 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_monitor_disk_gen.go
+++ b/pkg/cmd/commands/disk/zz_monitor_disk_gen.go
@@ -54,11 +54,20 @@ func (p *monitorParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("monitor", pflag.ContinueOnError)
+		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		sets = append(sets, &core.FlagSet{
+			Title: "Disk options",
+			Flags: fs,
+		})
+	}
+	{
+		var fs *pflag.FlagSet
+		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("start"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("end"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Monitor options",
+			Title: "Disk options",
 			Flags: fs,
 		})
 	}
@@ -73,15 +82,6 @@ func (p *monitorParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_read_gen.go
+++ b/pkg/cmd/commands/disk/zz_read_gen.go
@@ -52,6 +52,15 @@ func (p *readParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
+		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		sets = append(sets, &core.FlagSet{
+			Title: "Disk options",
+			Flags: fs,
+		})
+	}
+	{
+		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("output", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("output-type"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("quiet"))
@@ -61,15 +70,6 @@ func (p *readParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_resize_partition_gen.go
+++ b/pkg/cmd/commands/disk/zz_resize_partition_gen.go
@@ -41,19 +41,19 @@ func (p *resizePartitionParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("Input", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
+		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Input options",
+			Title: "Disk options",
 			Flags: fs,
 		})
 	}
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		fs = pflag.NewFlagSet("Input", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("assumeyes"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
+			Title: "Input options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_update_gen.go
+++ b/pkg/cmd/commands/disk/zz_update_gen.go
@@ -89,6 +89,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("description"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("tags"))
@@ -119,15 +120,6 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("query-file"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
-			Flags: fs,
-		})
-	}
-	{
-		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
-		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/commands/disk/zz_wait_until_ready_gen.go
+++ b/pkg/cmd/commands/disk/zz_wait_until_ready_gen.go
@@ -40,10 +40,10 @@ func (p *waitUntilReadyParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
 	{
 		var fs *pflag.FlagSet
-		fs = pflag.NewFlagSet("default", pflag.ContinueOnError)
+		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		sets = append(sets, &core.FlagSet{
-			Title: "Other options",
+			Title: "Disk options",
 			Flags: fs,
 		})
 	}

--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -501,8 +501,6 @@ func (c *Command) parameterWithZone(zone string) (interface{}, error) {
 
 func (c *Command) ParameterCategoryBy(key string) *Category {
 	switch key {
-	case "":
-		return ParameterCategoryDefault
 	case "output":
 		return ParameterCategoryOutput
 	case "input":
@@ -516,7 +514,8 @@ func (c *Command) ParameterCategoryBy(key string) *Category {
 	case "filter":
 		return ParameterCategoryFilter
 	default:
-		if len(c.ParameterCategories) == 0 {
+		if key == "" || len(c.ParameterCategories) == 0 {
+			key = c.resource.Name
 			return &Category{
 				Key:         key,
 				DisplayName: fmt.Sprintf("%s options", strings.Title(key)),

--- a/pkg/cmd/core/usage.go
+++ b/pkg/cmd/core/usage.go
@@ -87,10 +87,12 @@ func buildCommandsUsage(cmd *cobra.Command, commands []*CategorizedCommands) {
 const originalFlagsUsage = `Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}`
 
-const flagsUsageTemplate = ` === %s ===
+const flagsUsageTemplate = `  === %s ===
+
 %s`
 
 const flagsUsageWrapperTemplate = `Flags:
+
 %s`
 
 func BuildFlagsUsage(cmd *cobra.Command, sets []*FlagSet) {


### PR DESCRIPTION
closes #539 

各パラメータにカテゴリー指定がない場合のデフォルトカテゴリーを設定する。
デフォルトカテゴリーは`strings.Title(リソース名)` + ` options`とする。

例:

```bash
$ usacloud disk create -h

Usage:
  usacloud disk create [flags]

Flags:

  === Disk options ===

      --connection string            options: [virtio/ide] (default "virtio")
      --description string           
      --disk-plan string             options: [ssd/hdd] (default "ssd")
      --distant-from types.IDSlice   
      --icon-id types.ID             
      --name string 
...
```