### PR TITLE
Allow non-JSON content when reading flag values

### DIFF
--- a/pkg/cmd/commands/disk/zz_monitor_disk_gen.go
+++ b/pkg/cmd/commands/disk/zz_monitor_disk_gen.go
@@ -55,8 +55,7 @@ func (p *monitorParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("start"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("end"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Disk options",
 			Flags: fs,
@@ -65,7 +64,8 @@ func (p *monitorParameter) buildFlagsUsage(cmd *cobra.Command) {
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("disk", pflag.ContinueOnError)
-		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("start"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("end"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Disk options",
 			Flags: fs,

--- a/pkg/cmd/commands/note/create.go
+++ b/pkg/cmd/commands/note/create.go
@@ -38,7 +38,7 @@ type createParameter struct {
 	Tags    []string `validate:"tags"`
 	IconID  types.ID
 	Class   string `cli:",options=note_class" validate:"required,note_class"`
-	Content string `cli:",aliases=contents" validate:"required"`
+	Content string `cli:",aliases=contents script scripts" validate:"required" mapconv:",filters=path_or_content"`
 
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`

--- a/pkg/cmd/commands/note/zz_create_gen.go
+++ b/pkg/cmd/commands/note/zz_create_gen.go
@@ -32,7 +32,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
 	fs.StringVarP(&p.Class, "class", "", p.Class, "options: [shell/yaml_cloud_config]")
-	fs.StringVarP(&p.Content, "content", "", p.Content, "(aliases: --contents)")
+	fs.StringVarP(&p.Content, "content", "", p.Content, "(aliases: --contents, --script, --scripts)")
 	fs.BoolVarP(&p.AssumeYes, "assumeyes", "y", p.AssumeYes, "Assume that the answer to any question which would be asked is yes")
 	fs.StringVarP(&p.OutputType, "output-type", "o", p.OutputType, "Output format: one of the following [table/json/yaml] (aliases: --out)")
 	fs.BoolVarP(&p.Quiet, "quiet", "q", p.Quiet, "Output IDs only")
@@ -46,6 +46,10 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
 	case "contents":
+		name = "content"
+	case "script":
+		name = "content"
+	case "scripts":
 		name = "content"
 	case "out":
 		name = "output-type"

--- a/pkg/util/struct.go
+++ b/pkg/util/struct.go
@@ -42,18 +42,9 @@ func BytesFromPathOrContent(pathOrContent string) ([]byte, error) {
 		return nil, errors.New("pathOrContent required")
 	}
 
-	if isJSON(pathOrContent) {
-		return []byte(pathOrContent), nil
-	}
-
 	data, err := ioutil.ReadFile(pathOrContent)
 	if err != nil {
-		return nil, err
+		return []byte(pathOrContent), nil // ファイルを読んでみてエラーだった場合はJSONなどのコンテンツと判定する
 	}
 	return data, nil
-}
-
-func isJSON(s string) bool {
-	m := make(map[string]interface{})
-	return json.Unmarshal([]byte(s), &m) == nil
 }


### PR DESCRIPTION
closes #602 

フラグの読み取り時にファイルパス or JSONを受けとる場合にJSON以外のコンテンツも受け入れ可能にする。

Note: 現在は簡易的な実装となっているが、もう少しエラー判定処理を細かくしないと意図せずファイルの内容が読めていないという状況が発生しそう。別途対応する。

```go
func BytesFromPathOrContent(pathOrContent string) ([]byte, error) {
	if pathOrContent == "" {
		return nil, errors.New("pathOrContent required")
	}

	data, err := ioutil.ReadFile(pathOrContent)
	if err != nil {
		return []byte(pathOrContent), nil // ファイルを読んでみてエラーだった場合はJSONなどのコンテンツと判定する
	}
	return data, nil
}
```