### PR TITLE
Use cobra.Command.Run instead of cobra.Command.RunE

### DIFF
--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -127,13 +127,13 @@ func (c *Command) CLICommand() *cobra.Command {
 		Short:        c.Usage,
 		Long:         c.Usage,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			// コンテキスト構築
 			ctx, err := cli.NewCLIContext(c.resource.Name, c.Name, root.Command.PersistentFlags(), args, c.ColumnDefs, c.currentParameter)
 			if err != nil {
 				// この段階ではctx.IO()が参照できないため標準エラーに出力する
 				fmt.Fprintln(os.Stderr, err) // nolint
-				return err
+				return
 			}
 
 			// エラー出力(可能ならカラーで出力)
@@ -141,9 +141,8 @@ func (c *Command) CLICommand() *cobra.Command {
 				out := ctx.IO().Err()
 				(&printer.Printer{NoColor: ctx.Option().NoColor}).Fprint(out, color.New(color.FgHiRed), err)
 				fmt.Fprintln(out, "") // nolint // エラーのあとは常に改行させる
-				return err
+				return
 			}
-			return nil
 		},
 	}
 

--- a/pkg/cmd/root/command.go
+++ b/pkg/cmd/root/command.go
@@ -24,8 +24,6 @@ var Command = &cobra.Command{
 	Use:   "usacloud [global options] <command> <sub-command> [options] [arguments]",
 	Short: "Usacloud is CLI for manage to resources on the SAKURA Cloud",
 	Long:  `CLI to manage to resources on the SAKURA Cloud`,
-	// TODO 一旦off
-	//SilenceErrors: true, // core.Commandでエラー出力を制御するためtrueにしておく
 }
 
 func init() {


### PR DESCRIPTION
#600 対応。

- ルートコマンドの`SilenceErrors`をtrueにする
- *cobra.Commandの`RunE`の代わりに`Run`を利用する(エラーハンドリングは実装済み)
