### PR TITLE
Shell Completion

### DIFF
--- a/pkg/cmd/commands/archive/zz_list_gen.go
+++ b/pkg/cmd/commands/archive/zz_list_gen.go
@@ -18,6 +18,7 @@ package archive
 
 import (
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -99,6 +100,9 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 			Flags: fs,
 		})
 	}
+
+	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "centos7", "centos6", "ubuntu", "ubuntu2004", "ubuntu1804", "ubuntu1604", "debian", "debian10", "debian9", "coreos", "rancheros", "k3os", "kusanagi", "freebsd", "windows2016", "windows2016-rds", "windows2016-rds-office", "windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all", "windows2016-sql2017-standard", "windows2016-sql2017-enterprise", "windows2016-sql2017-standard-all", "windows2019", "windows2019-rds", "windows2019-rds-office2019", "windows2019-sql2017-web", "windows2019-sql2019-web", "windows2019-sql2017-standard", "windows2019-sql2019-standard", "windows2019-sql2017-enterprise", "windows2019-sql2019-enterprise", "windows2019-sql2017-standard-all", "windows2019-sql2019-standard-all"))
+	cmd.RegisterFlagCompletionFunc("scope", util.FlagCompletionFunc("user", "shared"))
 
 	core.BuildFlagsUsage(cmd, sets)
 }

--- a/pkg/cmd/commands/disk/zz_create_gen.go
+++ b/pkg/cmd/commands/disk/zz_create_gen.go
@@ -18,6 +18,7 @@ package disk
 
 import (
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -107,6 +108,10 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 			Flags: fs,
 		})
 	}
+
+	cmd.RegisterFlagCompletionFunc("disk-plan", util.FlagCompletionFunc("ssd", "hdd"))
+	cmd.RegisterFlagCompletionFunc("connection", util.FlagCompletionFunc("virtio", "ide"))
+	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "centos7", "centos6", "ubuntu", "ubuntu2004", "ubuntu1804", "ubuntu1604", "debian", "debian10", "debian9", "coreos", "rancheros", "k3os", "kusanagi", "freebsd", "windows2016", "windows2016-rds", "windows2016-rds-office", "windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all", "windows2016-sql2017-standard", "windows2016-sql2017-enterprise", "windows2016-sql2017-standard-all", "windows2019", "windows2019-rds", "windows2019-rds-office2019", "windows2019-sql2017-web", "windows2019-sql2019-web", "windows2019-sql2017-standard", "windows2019-sql2019-standard", "windows2019-sql2017-enterprise", "windows2019-sql2019-enterprise", "windows2019-sql2017-standard-all", "windows2019-sql2019-standard-all"))
 
 	core.BuildFlagsUsage(cmd, sets)
 }

--- a/pkg/cmd/commands/disk/zz_update_gen.go
+++ b/pkg/cmd/commands/disk/zz_update_gen.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/pointer"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -123,6 +124,8 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 			Flags: fs,
 		})
 	}
+
+	cmd.RegisterFlagCompletionFunc("connection", util.FlagCompletionFunc("virtio", "ide"))
 
 	core.BuildFlagsUsage(cmd, sets)
 }

--- a/pkg/cmd/commands/note/zz_create_gen.go
+++ b/pkg/cmd/commands/note/zz_create_gen.go
@@ -18,6 +18,7 @@ package note
 
 import (
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -97,6 +98,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 			Flags: fs,
 		})
 	}
+
+	cmd.RegisterFlagCompletionFunc("class", util.FlagCompletionFunc("shell", "yaml_cloud_config"))
 
 	core.BuildFlagsUsage(cmd, sets)
 }

--- a/pkg/cmd/commands/note/zz_list_gen.go
+++ b/pkg/cmd/commands/note/zz_list_gen.go
@@ -18,6 +18,7 @@ package note
 
 import (
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -87,6 +88,8 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 			Flags: fs,
 		})
 	}
+
+	cmd.RegisterFlagCompletionFunc("scope", util.FlagCompletionFunc("user", "shared"))
 
 	core.BuildFlagsUsage(cmd, sets)
 }

--- a/pkg/cmd/core/completion.go
+++ b/pkg/cmd/core/completion.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sacloud/usacloud/pkg/cmd/root"
@@ -24,20 +25,57 @@ import (
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates bash completion scripts",
-	Long: `To load completion run
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
 
-. <(usacloud completion)
+Bash:
 
-To configure your bash shell to load completions for each session add to your bashrc
+$ source <(usacloud completion bash)
 
-# ~/.bashrc or ~/.profile
-. <(usacloud completion)
+# To load completions for each session, execute once:
+Linux:
+  $ usacloud completion bash > /etc/bash_completion.d/usacloud
+MacOS:
+  $ usacloud completion bash > /usr/local/etc/bash_completion.d/usacloud
+
+Zsh:
+
+# If shell completion is not already enabled in your environment you will need
+# to enable it.  You can execute the following once:
+
+$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# To load completions for each session, execute once:
+$ usacloud completion zsh > "${fpath[1]}/_usacloud"
+
+# You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ usacloud completion fish | source
+
+# To load completions for each session, execute once:
+$ usacloud completion fish > ~/.config/fish/completions/usacloud.fish
 `,
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return root.Command.GenBashCompletion(os.Stdout)
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+		switch args[0] {
+		case "bash":
+			err = cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			err = cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			err = cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			err = cmd.Root().GenPowerShellCompletion(os.Stdout)
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err) // nolint
+		}
 	},
 }
 

--- a/pkg/util/flag_completion.go
+++ b/pkg/util/flag_completion.go
@@ -12,9 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vdef
+package util
 
-// FlagOptionsMap CLIで指定するフラグでの静的な候補値一覧(cliタグで指定する)
-//
-// Note: コード生成で利用されるため実行時に動的に変化する項目には利用できない
-var FlagOptionsMap = map[string][]string{}
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func FlagCompletionFunc(options ...string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var results []string
+		for _, v := range options {
+			if toComplete == "" || strings.HasPrefix(v, toComplete) {
+				results = append(results, v)
+			}
+		}
+		return results, cobra.ShellCompDirectiveDefault
+	}
+}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -25,3 +25,32 @@ func FirstNonEmptyString(values ...string) string {
 	}
 	return values[len(values)-1]
 }
+
+func UniqStrings(elements []string) []string {
+	encountered := map[string]bool{}
+	var result []string
+	for v := range elements {
+		if !encountered[elements[v]] {
+			encountered[elements[v]] = true
+			result = append(result, elements[v])
+		}
+	}
+	return result
+}
+
+func RemoveStringsFromSlice(elements []string, remove []string) []string {
+	var results []string
+	for _, e := range elements {
+		exists := false
+		for _, r := range remove {
+			if e == r {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			results = append(results, e)
+		}
+	}
+	return results
+}

--- a/tools/gen-commands/flags_template.go
+++ b/tools/gen-commands/flags_template.go
@@ -20,6 +20,7 @@ package {{ .PackageDirName }}
 
 import (
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -60,6 +61,11 @@ func (p *{{.CLICommandParameterTypeName}}) buildFlagsUsage(cmd *cobra.Command) {
 			Flags: fs,
 		})
 	}
+	{{ end }}
+	{{ range .Fields -}}
+	{{ if .Options -}}
+	cmd.RegisterFlagCompletionFunc("{{ .FlagName }}", util.FlagCompletionFunc({{ range .Options }}"{{ . }}",{{ end }}))
+	{{ end -}}
 	{{ end }}
 	core.BuildFlagsUsage(cmd, sets)
 }


### PR DESCRIPTION
shell completionを実装する。

### 仕様

- `bash` / `zsh` / `fish` / `PowerShell`に対応 (ただし動作確認は現状`bash`のみ)
- サブコマンド補完
- フラグ名の補完(`-`まで入力してタブ)
- フラグ値の補完
- 引数(ID or Name or Tags)の補完

### 引数の補完

`update`などの引数を取るコマンドについてはID or Name or Tagsを補完する。
既に指定されている引数は除外するが、除外された結果に同一リソースを指すものが含まれる場合がある。

例: 以下のようなリソースがある場合

```console
Disk {
	ID: 111111111111,
	Name: "foobar",
	Tags: ["stage=production"]
}
```

`usacloud disk update <TAB>`で補完すると以下の候補が出る。

```console
$ usacloud disk update <TAB>
111111111111	foobar	stage=production
```

既にリソース`111111111111`を引数に指定している場合でもNameやTagsが候補として出る。

```console
$ usacloud disk update 111111111111 <TAB>
foobar	stage=production
```

### 引数補完の実装

既存の`core.Command`.`ListAllFunc`(基本的にコード生成、自前実装も可)を用いて対象リソースの一覧を取得、
ID or Name or Tagsに前方一致したものを補完候補として抽出する。

spf13/cobraのshell completion実装ではフラグのパースまで行われた後に補完処理となるが、
usacloudではさらにパラメータファイル`--parameter`などのコマンド実行時の前処理も行った上で補完処理を行う。

### フラグ補完の実装

コード生成時にパラメータstructのフィールドに付与された`cli:"options="`タグから値を取得(ヘルプ表示生成処理と同様)
フラグの初期化時に`*cobra.command`.`RegisterFlagCompletionFunc`をコールしている。

### このPRでは実装していないもの

- APIリクエストが必要なフラグ補完処理
- グローバルフラグの補完処理(`--zone`には補完があったほうがよさそう)
- bash以外のシェルでの動作確認/CI