### PR TITLE
Improve error message

### DIFF
--- a/pkg/validate/validator.go
+++ b/pkg/validate/validator.go
@@ -64,5 +64,12 @@ func errorFromValidationErr(err validator.FieldError) error {
 	if param != "" {
 		detail += "=" + param
 	}
+
+	// detailがvalidatorのタグ名だけの場合の対応をここで行う。
+	switch detail {
+	case "file":
+		detail = fmt.Sprintf("invalid file path: %v", err.Value())
+	}
+
 	return NewFlagError(flagName, detail)
 }


### PR DESCRIPTION
closes #605 

`file`タグのエラーメッセージを改善する。

```console
$ usacloud archive create --name example --size 20 --source-file example-not-exist-file

validation error:
	--source-file: invalid file path: example-not-exist-file
```

Note: 根本的な対応ではなく、問題となったタグに対する個別対応となっている。
このため今後もエラーメッセージの改善が必要な箇所が出てくる可能性があるが都度改善する。