### PR TITLE
Some minor updates

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"time"
 
@@ -132,6 +133,11 @@ func (c *cliContext) WithResource(id types.ID, zone string) Context {
 
 func (c *cliContext) Client() sacloud.APICaller {
 	o := c.Option()
+	if o.FakeMode {
+		// libsacloud fakeドライバはlogパッケージにシステムログを出すがusacloudからは利用しないため出力を抑制する
+		log.SetOutput(ioutil.Discard)
+	}
+
 	return api.NewCaller(&api.CallerOptions{
 		AccessToken:          o.AccessToken,
 		AccessTokenSecret:    o.AccessTokenSecret,

--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -444,12 +444,10 @@ func (c *Command) execParallel(ctx cli.Context, ids cli.ResourceContexts) (outpu
 
 	// 結果の受け取り
 	go func() {
-		for {
-			res := <-resultCh
+		for res := range resultCh {
 			if res == nil {
 				return
 			}
-
 			if res.err != nil {
 				errs = append(errs, res.err)
 			}
@@ -586,12 +584,10 @@ func (c *Command) collectResources(ctx cli.Context) ([]*collectedResources, erro
 
 	// 非同期で実行されたAPIコールの結果受け取り
 	go func() {
-		for {
-			res := <-resultCh
+		for res := range resultCh {
 			if res == nil {
 				return
 			}
-
 			if res.err != nil {
 				errs = append(errs, res.err)
 			}


### PR DESCRIPTION
- core.Commandの細かな修正
- fakeモードが有効な場合に`log.SetOutput(ioutil.Discard)`を呼ぶことでfakeモードのログを抑制