### PR TITLE
GitHub Actions: Add macos-11.0 and ubuntu-20.04

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
+        os: [macos-10.15, macos-11.0, windows-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Actionsでのos matrixに`macos-11.0`と`ubuntu-20.04`を追加