### PR TITLE
Commands: version

### DIFF
--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -42,7 +42,7 @@ import (
 	"github.com/sacloud/usacloud/pkg/cmd/commands/licenseinfo"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/loadbalancer"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/localrouter"
-	mobilegateway "github.com/sacloud/usacloud/pkg/cmd/commands/mobilegateway"
+	"github.com/sacloud/usacloud/pkg/cmd/commands/mobilegateway"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/nfs"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/note"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/packetfilter"
@@ -62,6 +62,7 @@ import (
 	"github.com/sacloud/usacloud/pkg/cmd/commands/zone"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
 	"github.com/sacloud/usacloud/pkg/cmd/root"
+	_ "github.com/sacloud/usacloud/pkg/cmd/version"
 )
 
 var Resources = core.Resources{

--- a/pkg/cmd/root/command.go
+++ b/pkg/cmd/root/command.go
@@ -24,6 +24,18 @@ var Command = &cobra.Command{
 	Use:   "usacloud [global options] <command> <sub-command> [options] [arguments]",
 	Short: "Usacloud is CLI for manage to resources on the SAKURA Cloud",
 	Long:  `CLI to manage to resources on the SAKURA Cloud`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		v, err := cmd.Flags().GetBool("version")
+		if err != nil {
+			return err
+		}
+		if v {
+			cmd.Root().SetArgs([]string{"version"})
+			return cmd.Root().Execute()
+		}
+		return cmd.Help()
+	},
 }
 
 func init() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,8 @@ func InitConfig(flags *pflag.FlagSet) {
 	initCredentialConfig(flags)
 	initOutputConfig(flags)
 	initDebugConfig(flags)
+	// misc flags
+	flags.BoolP("version", "v", false, "show version info")
 }
 
 // LoadConfigValue 指定のフラグセットからフラグを読み取り*Flagsを組み立てて返す

--- a/scripts/build.dockerfile
+++ b/scripts/build.dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13
+FROM golang:1.14
 MAINTAINER Kazumichi Yamamoto <yamamoto.febc@gmail.com>
 
 RUN  apt-get update && apt-get -y install \


### PR DESCRIPTION
`version`サブコマンドを追加する。

```bash
# 通常
$ usacloud version

# -vもOK
$ usacloud -v

# --versionでもOK
$ usacloud --version
```

Note: `version`サブコマンドはヘルプ表示には出てこない隠しコマンド扱いとなっている(フラグの方は表示される)。