### PR TITLE
Improve Server commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mattn/go-isatty v0.0.7
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
-	github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204035447-11e66e151098
+	github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204095741-a902ffb85f95
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
-github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204035447-11e66e151098 h1:1xFSGlyrjmMzQy5vuoXSKvX5gcRyA4Dd05kLcMYETXY=
-github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204035447-11e66e151098/go.mod h1:gRNUdloSQqgQfTEMpot80TK7REly0TSME6dn5aZl3GY=
+github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204095741-a902ffb85f95 h1:C48z+soBm+CKSZwdX3AzsIFMsrSAjCpwaeKQ7L71HCg=
+github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204095741-a902ffb85f95/go.mod h1:gRNUdloSQqgQfTEMpot80TK7REly0TSME6dn5aZl3GY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cmd/commands/common/types.go
+++ b/pkg/cmd/commands/common/types.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package disk
+package common
 
 import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -21,7 +21,7 @@ import (
 	"github.com/sacloud/usacloud/pkg/util"
 )
 
-type editRequest struct {
+type EditRequest struct {
 	HostName string
 	Password string
 
@@ -44,7 +44,7 @@ type editRequest struct {
 }
 
 // Customize パラメータ変換処理
-func (p *editRequest) Customize(_ cli.Context) error {
+func (p *EditRequest) Customize(_ cli.Context) error {
 	var notes []*sacloud.DiskEditNote
 	if p.NotesData != "" {
 		if err := util.MarshalJSONFromPathOrContent(p.NotesData, &notes); err != nil {

--- a/pkg/cmd/commands/disk/create.go
+++ b/pkg/cmd/commands/disk/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/cmd/cflag"
+	"github.com/sacloud/usacloud/pkg/cmd/commands/common"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
 	"github.com/sacloud/usacloud/pkg/validate"
 )
@@ -54,7 +55,7 @@ type createParameter struct {
 	DistantFrom     []types.ID
 	OSType          string `cli:",options=os_type" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
 
-	EditDisk editRequest `cli:",category=edit" mapconv:"EditParameter,omitempty"`
+	EditDisk common.EditRequest `cli:",category=edit" mapconv:"EditParameter,omitempty"`
 	NoWait   bool
 }
 

--- a/pkg/cmd/commands/disk/edit.go
+++ b/pkg/cmd/commands/disk/edit.go
@@ -17,6 +17,7 @@ package disk
 import (
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/cmd/cflag"
+	"github.com/sacloud/usacloud/pkg/cmd/commands/common"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
 )
 
@@ -38,8 +39,8 @@ type editParameter struct {
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`
 
-	EditDisk editRequest `cli:",squash" mapconv:",squash"`
-	NoWait   bool        `request:"-"` // trueの場合ディスクの修正完了まで待たずに即時復帰する
+	EditDisk common.EditRequest `cli:",squash" mapconv:",squash"`
+	NoWait   bool               `request:"-"` // trueの場合ディスクの修正完了まで待たずに即時復帰する
 }
 
 func newEditParameter() *editParameter {

--- a/pkg/cmd/commands/disk/update.go
+++ b/pkg/cmd/commands/disk/update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/cmd/cflag"
+	"github.com/sacloud/usacloud/pkg/cmd/commands/common"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
 )
 
@@ -45,8 +46,8 @@ type updateParameter struct {
 	Description *string   `validate:"omitempty,description"`
 	Tags        *[]string `validate:"omitempty,tags"`
 	IconID      *types.ID
-	Connection  *string     `cli:",options=disk_connection" validate:"omitempty,disk_connection"`
-	EditDisk    editRequest `mapconv:"EditParameter,omitempty"`
+	Connection  *string            `cli:",options=disk_connection" validate:"omitempty,disk_connection"`
+	EditDisk    common.EditRequest `mapconv:"EditParameter,omitempty"`
 	NoWait      bool
 }
 

--- a/pkg/cmd/commands/server/columns.go
+++ b/pkg/cmd/commands/server/columns.go
@@ -34,7 +34,7 @@ var defaultColumnDefs = []output.ColumnDef{
 
 	{
 		Name:     "IPAddress",
-		Template: "{{ if gt (len .Interfaces) 0 }}{{ with index .Interfaces 0 }}{{ if .IPAddress }}{{ .IPAddress }}{{ .SubnetNetworkMaskLen }}{{ else }}{{ .UserIPAddress }}{{ end }}/{{ .UserSubnetNetworkMaskLen }}{{ end }}{{ end }}",
+		Template: "{{ if gt (len .Interfaces) 0 }}{{ with index .Interfaces 0 }}{{ if .IPAddress }}{{ .IPAddress }}/{{ .SubnetNetworkMaskLen }}{{ else }}{{ .UserIPAddress }}/{{ .UserSubnetNetworkMaskLen }}{{ end }}{{ end }}{{ end }}",
 	},
 	{
 		Name:     "Upstream(Mbps)",

--- a/pkg/cmd/commands/server/create.go
+++ b/pkg/cmd/commands/server/create.go
@@ -15,9 +15,18 @@
 package server
 
 import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/helper/service/disk"
+
+	"github.com/sacloud/libsacloud/v2/helper/service/server"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/cmd/cflag"
+	"github.com/sacloud/usacloud/pkg/cmd/commands/common"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
+	"github.com/sacloud/usacloud/pkg/validate"
 )
 
 var createCommand = &core.Command{
@@ -30,6 +39,8 @@ var createCommand = &core.Command{
 	ParameterInitializer: func() interface{} {
 		return newCreateParameter()
 	},
+
+	ValidateFunc: validateCreateParameter,
 }
 
 type createParameter struct {
@@ -43,21 +54,167 @@ type createParameter struct {
 	Tags        []string `validate:"tags"`
 	IconID      types.ID
 
-	CPU        int    `cli:"cpu,aliases=core" validate:"required"`
-	Memory     int    `cli:"memory" mapconv:"MemoryMB,filters=gib_to_mib" validate:"required"`
-	Commitment string `cli:",options=server_plan_commitment" mapconv:"ServerPlanCommitment,filters=server_plan_commitment_to_value" validate:"required,server_plan_commitment"`
-	Generation string `cli:",options=server_plan_generation" mapconv:"ServerPlanGeneration,filters=server_plan_generation_to_value" validate:"required,server_plan_generation"`
+	CPU             int    `cli:"cpu,aliases=core" validate:"required"`
+	Memory          int    `cli:"memory" mapconv:"MemoryGB" validate:"required"`
+	Commitment      string `cli:",options=server_plan_commitment" mapconv:",filters=server_plan_commitment_to_value" validate:"required,server_plan_commitment"`
+	Generation      string `cli:",options=server_plan_generation" mapconv:",filters=server_plan_generation_to_value" validate:"required,server_plan_generation"`
+	InterfaceDriver string `cli:",options=interface_dirver" mapconv:",filters=interface_driver_to_value" validate:"required,interface_driver"`
+
+	BootAfterCreate bool
+	CDROMID         types.ID `cli:"cdrom-id,aliases=iso-image-id"`
+	PrivateHostID   types.ID
+
+	NetworkInterface     server.NetworkInterface    `mapconv:"-" validate:"omitempty"`
+	NetworkInterfaceData string                     `cli:"network-interfaces" mapconv:"-"`
+	NetworkInterfaces    []*server.NetworkInterface `cli:"-" mapconv:",omitempty,recursive"`
+
+	Disk      diskApplyParameter    `mapconv:"-" validate:"omitempty"`
+	DisksData string                `cli:"disks" mapconv:"-"`
+	Disks     []*diskApplyParameter `cli:"-" mapconv:",omitempty,recursive"`
+	DiskIDs   []types.ID            `cli:"disk-ids" mapconv:"-"`
+
+	NoWait bool
+}
+
+type diskApplyParameter struct {
+	ID types.ID
+
+	Name            string   // 省略時はサーバ名が利用される
+	Description     string   `validate:"description"`
+	Tags            []string `validate:"tags"`
+	IconID          types.ID
+	DiskPlan        string `cli:",options=disk_plan" mapconv:"DiskPlanID,filters=disk_plan_to_value" validate:"omitempty,disk_plan"`
+	Connection      string `cli:",options=disk_connection" validate:"omitempty,disk_connection"`
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+	ServerID        types.ID
+	SizeGB          int `cli:"size,aliases=size-gb"`
+	DistantFrom     []types.ID
+	OSType          string `cli:",options=os_type" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
+
+	EditDisk common.EditRequest `cli:"edit,category=edit" mapconv:"EditParameter,omitempty"`
+	NoWait   bool
 }
 
 func newCreateParameter() *createParameter {
 	return &createParameter{
-		CPU:        1,
-		Memory:     1,
-		Commitment: types.Commitments.Standard.String(),
-		Generation: "default",
+		CPU:             1,
+		Memory:          1,
+		Commitment:      types.Commitments.Standard.String(),
+		Generation:      "default",
+		InterfaceDriver: types.InterfaceDrivers.VirtIO.String(),
 	}
 }
 
 func init() {
 	Resource.AddCommand(createCommand)
+}
+
+func validateCreateParameter(_ cli.Context, parameter interface{}) error {
+	if err := validate.Exec(parameter); err != nil {
+		return err
+	}
+
+	p, ok := parameter.(*createParameter)
+	if !ok {
+		return fmt.Errorf("invalid parameter: %v", parameter)
+	}
+
+	var errs []error
+	// conflict with
+	targets := []*validate.Target{
+		{FlagName: "--network-interface", Value: p.NetworkInterface},
+		{FlagName: "--network-interfaces", Value: p.NetworkInterfaceData},
+	}
+	if err := validate.ConflictWith(targets...); err != nil {
+		errs = append(errs, err)
+	}
+
+	targets = []*validate.Target{
+		{FlagName: "--disk", Value: p.Disk},
+		{FlagName: "--disks", Value: p.Disks},
+		{FlagName: "--disk-ids", Value: p.DiskIDs},
+	}
+	if err := validate.ConflictWith(targets...); err != nil {
+		errs = append(errs, err)
+	}
+
+	if !util.IsEmpty(p.NetworkInterface) {
+		if err := p.NetworkInterface.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for _, nic := range p.NetworkInterfaces {
+		if err := nic.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return validate.NewValidationError(errs...)
+}
+
+// Customize パラメータ変換処理
+func (p *createParameter) Customize(ctx cli.Context) error {
+	// network interfaces
+	if !util.IsEmpty(p.NetworkInterface) {
+		p.NetworkInterfaces = append(p.NetworkInterfaces, &p.NetworkInterface)
+	}
+	if p.NetworkInterfaceData != "" {
+		var nics []*server.NetworkInterface
+		if err := util.MarshalJSONFromPathOrContent(p.NetworkInterfaceData, &nics); err != nil {
+			return err
+		}
+		p.NetworkInterfaces = append(p.NetworkInterfaces, nics...)
+	}
+
+	// disk
+	if !util.IsEmpty(p.Disk) {
+		p.Disks = append(p.Disks, &p.Disk)
+	}
+	if p.DisksData != "" {
+		var disks []*diskApplyParameter
+		if err := util.MarshalJSONFromPathOrContent(p.DisksData, &disks); err != nil {
+			return err
+		}
+		p.Disks = append(p.Disks, disks...)
+	}
+	if len(p.DiskIDs) > 0 {
+		diskService := disk.New(ctx.Client())
+		for _, diskID := range p.DiskIDs {
+			disk, err := diskService.Read(&disk.ReadRequest{
+				Zone: p.Zone,
+				ID:   diskID,
+			})
+			if err != nil {
+				return err
+			}
+			p.Disks = append(p.Disks, &diskApplyParameter{
+				ID:          diskID,
+				Name:        disk.Name,
+				Description: disk.Description,
+				Tags:        disk.Tags,
+				IconID:      disk.IconID,
+				Connection:  disk.Connection.String(),
+				NoWait:      p.NoWait,
+			})
+		}
+	}
+
+	// set default value to disk
+	for _, disk := range p.Disks {
+		if disk.Name == "" {
+			disk.Name = p.Name
+		}
+		if disk.DiskPlan == "" {
+			disk.DiskPlan = "ssd"
+		}
+		if disk.Connection == "" {
+			disk.Connection = types.DiskConnections.VirtIO.String()
+		}
+
+		if err := disk.EditDisk.Customize(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/cmd/commands/server/delete.go
+++ b/pkg/cmd/commands/server/delete.go
@@ -38,6 +38,8 @@ type deleteParameter struct {
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 
 	FailIfNotFound bool
+	Force          bool `cli:",short=f"`
+	WithDisks      bool
 }
 
 func newDeleteParameter() *deleteParameter {

--- a/pkg/cmd/commands/server/zz_create_gen.go
+++ b/pkg/cmd/commands/server/zz_create_gen.go
@@ -47,6 +47,45 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.IntVarP(&p.Memory, "memory", "", p.Memory, "")
 	fs.StringVarP(&p.Commitment, "commitment", "", p.Commitment, "options: [standard/dedicatedcpu]")
 	fs.StringVarP(&p.Generation, "generation", "", p.Generation, "options: [default/g100/g200]")
+	fs.StringVarP(&p.InterfaceDriver, "interface-driver", "", p.InterfaceDriver, "options: [interface_dirver]")
+	fs.BoolVarP(&p.BootAfterCreate, "boot-after-create", "", p.BootAfterCreate, "")
+	fs.VarP(core.NewIDFlag(&p.CDROMID, &p.CDROMID), "cdrom-id", "", "(aliases: --iso-image-id)")
+	fs.VarP(core.NewIDFlag(&p.PrivateHostID, &p.PrivateHostID), "private-host-id", "", "")
+	fs.StringVarP(&p.NetworkInterface.Upstream, "network-interface-upstream", "", p.NetworkInterface.Upstream, "")
+	fs.VarP(core.NewIDFlag(&p.NetworkInterface.PacketFilterID, &p.NetworkInterface.PacketFilterID), "network-interface-packet-filter-id", "", "")
+	fs.StringVarP(&p.NetworkInterface.UserIPAddress, "network-interface-user-ip-address", "", p.NetworkInterface.UserIPAddress, "")
+	fs.StringVarP(&p.NetworkInterfaceData, "network-interfaces", "", p.NetworkInterfaceData, "")
+	fs.VarP(core.NewIDFlag(&p.Disk.ID, &p.Disk.ID), "disk-id", "", "")
+	fs.StringVarP(&p.Disk.Name, "disk-name", "", p.Disk.Name, "")
+	fs.StringVarP(&p.Disk.Description, "disk-description", "", p.Disk.Description, "")
+	fs.StringSliceVarP(&p.Disk.Tags, "disk-tags", "", p.Disk.Tags, "")
+	fs.VarP(core.NewIDFlag(&p.Disk.IconID, &p.Disk.IconID), "disk-icon-id", "", "")
+	fs.StringVarP(&p.Disk.DiskPlan, "disk-disk-plan", "", p.Disk.DiskPlan, "options: [ssd/hdd]")
+	fs.StringVarP(&p.Disk.Connection, "disk-connection", "", p.Disk.Connection, "options: [virtio/ide]")
+	fs.VarP(core.NewIDFlag(&p.Disk.SourceDiskID, &p.Disk.SourceDiskID), "disk-source-disk-id", "", "")
+	fs.VarP(core.NewIDFlag(&p.Disk.SourceArchiveID, &p.Disk.SourceArchiveID), "disk-source-archive-id", "", "")
+	fs.VarP(core.NewIDFlag(&p.Disk.ServerID, &p.Disk.ServerID), "disk-server-id", "", "")
+	fs.IntVarP(&p.Disk.SizeGB, "disk-size", "", p.Disk.SizeGB, "(aliases: --size-gb)")
+	fs.VarP(core.NewIDSliceFlag(&p.Disk.DistantFrom, &p.Disk.DistantFrom), "disk-distant-from", "", "")
+	fs.StringVarP(&p.Disk.OSType, "disk-os-type", "", p.Disk.OSType, "options: [centos/centos8/centos7/ubuntu/ubuntu2004/ubuntu1804/ubuntu1604/debian/debian10/debian9/coreos/rancheros/k3os/kusanagi/freebsd/windows2016/windows2016-rds/windows2016-rds-office/windows2016-sql-web/windows2016-sql-standard/windows2016-sql-standard-all/windows2016-sql2017-standard/windows2016-sql2017-enterprise/windows2016-sql2017-standard-all/windows2019/windows2019-rds/windows2019-rds-office2019/windows2019-sql2017-web/windows2019-sql2019-web/windows2019-sql2017-standard/windows2019-sql2019-standard/windows2019-sql2017-enterprise/windows2019-sql2019-enterprise/windows2019-sql2017-standard-all/windows2019-sql2019-standard-all]")
+	fs.StringVarP(&p.Disk.EditDisk.HostName, "disk-edit-host-name", "", p.Disk.EditDisk.HostName, "")
+	fs.StringVarP(&p.Disk.EditDisk.Password, "disk-edit-password", "", p.Disk.EditDisk.Password, "")
+	fs.BoolVarP(&p.Disk.EditDisk.DisablePWAuth, "disk-edit-disable-pw-auth", "", p.Disk.EditDisk.DisablePWAuth, "")
+	fs.BoolVarP(&p.Disk.EditDisk.EnableDHCP, "disk-edit-enable-dhcp", "", p.Disk.EditDisk.EnableDHCP, "")
+	fs.BoolVarP(&p.Disk.EditDisk.ChangePartitionUUID, "disk-edit-change-partition-uuid", "", p.Disk.EditDisk.ChangePartitionUUID, "")
+	fs.StringVarP(&p.Disk.EditDisk.IPAddress, "disk-edit-ip-address", "", p.Disk.EditDisk.IPAddress, "")
+	fs.IntVarP(&p.Disk.EditDisk.NetworkMaskLen, "disk-edit-network-mask-len", "", p.Disk.EditDisk.NetworkMaskLen, "")
+	fs.StringVarP(&p.Disk.EditDisk.DefaultRoute, "disk-edit-default-route", "", p.Disk.EditDisk.DefaultRoute, "")
+	fs.StringSliceVarP(&p.Disk.EditDisk.SSHKeys, "disk-edit-ssh-keys", "", p.Disk.EditDisk.SSHKeys, "")
+	fs.VarP(core.NewIDSliceFlag(&p.Disk.EditDisk.SSHKeyIDs, &p.Disk.EditDisk.SSHKeyIDs), "disk-edit-ssh-key-ids", "", "")
+	fs.BoolVarP(&p.Disk.EditDisk.IsSSHKeysEphemeral, "disk-edit-make-ssh-keys-ephemeral", "", p.Disk.EditDisk.IsSSHKeysEphemeral, "")
+	fs.VarP(core.NewIDSliceFlag(&p.Disk.EditDisk.NoteIDs, &p.Disk.EditDisk.NoteIDs), "disk-edit-note-ids", "", "")
+	fs.StringVarP(&p.Disk.EditDisk.NotesData, "disk-edit-notes", "", p.Disk.EditDisk.NotesData, "")
+	fs.BoolVarP(&p.Disk.EditDisk.IsNotesEphemeral, "disk-edit-make-notes-ephemeral", "", p.Disk.EditDisk.IsNotesEphemeral, "")
+	fs.BoolVarP(&p.Disk.NoWait, "disk-no-wait", "", p.Disk.NoWait, "")
+	fs.StringVarP(&p.DisksData, "disks", "", p.DisksData, "")
+	fs.VarP(core.NewIDSliceFlag(&p.DiskIDs, &p.DiskIDs), "disk-ids", "", "")
+	fs.BoolVarP(&p.NoWait, "no-wait", "", p.NoWait, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 
@@ -60,6 +99,10 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "format"
 	case "core":
 		name = "cpu"
+	case "iso-image-id":
+		name = "cdrom-id"
+	case "size-gb":
+		name = "disk-size"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -78,6 +121,45 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("memory"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("commitment"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("generation"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("interface-driver"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("boot-after-create"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("cdrom-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("private-host-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("network-interface-upstream"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("network-interface-packet-filter-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("network-interface-user-ip-address"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("network-interfaces"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-name"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-description"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-tags"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-icon-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-disk-plan"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-connection"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-source-disk-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-source-archive-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-server-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-size"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-distant-from"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-os-type"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-host-name"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-password"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-disable-pw-auth"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-enable-dhcp"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-change-partition-uuid"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-ip-address"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-network-mask-len"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-ssh-keys"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-ssh-key-ids"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-make-ssh-keys-ephemeral"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-note-ids"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-notes"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-make-notes-ephemeral"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-no-wait"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disks"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-ids"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("no-wait"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Server options",
 			Flags: fs,
@@ -115,6 +197,10 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 func (p *createParameter) setCompletionFunc(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("commitment", util.FlagCompletionFunc("standard", "dedicatedcpu"))
 	cmd.RegisterFlagCompletionFunc("generation", util.FlagCompletionFunc("default", "g100", "g200"))
+	cmd.RegisterFlagCompletionFunc("interface-driver", util.FlagCompletionFunc("interface_dirver"))
+	cmd.RegisterFlagCompletionFunc("disk-disk-plan", util.FlagCompletionFunc("ssd", "hdd"))
+	cmd.RegisterFlagCompletionFunc("disk-connection", util.FlagCompletionFunc("virtio", "ide"))
+	cmd.RegisterFlagCompletionFunc("disk-os-type", util.FlagCompletionFunc("centos", "centos8", "centos7", "ubuntu", "ubuntu2004", "ubuntu1804", "ubuntu1604", "debian", "debian10", "debian9", "coreos", "rancheros", "k3os", "kusanagi", "freebsd", "windows2016", "windows2016-rds", "windows2016-rds-office", "windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all", "windows2016-sql2017-standard", "windows2016-sql2017-enterprise", "windows2016-sql2017-standard-all", "windows2019", "windows2019-rds", "windows2019-rds-office2019", "windows2019-sql2017-web", "windows2019-sql2019-web", "windows2019-sql2017-standard", "windows2019-sql2019-standard", "windows2019-sql2017-enterprise", "windows2019-sql2019-enterprise", "windows2019-sql2017-standard-all", "windows2019-sql2019-standard-all"))
 
 }
 

--- a/pkg/cmd/commands/server/zz_delete_gen.go
+++ b/pkg/cmd/commands/server/zz_delete_gen.go
@@ -33,6 +33,8 @@ func (p *deleteParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&p.GenerateSkeleton, "generate-skeleton", "", p.GenerateSkeleton, "Output skeleton of parameters with JSON format (aliases: --skeleton)")
 	fs.BoolVarP(&p.AssumeYes, "assumeyes", "y", p.AssumeYes, "Assume that the answer to any question which would be asked is yes")
 	fs.BoolVarP(&p.FailIfNotFound, "fail-if-not-found", "", p.FailIfNotFound, "")
+	fs.BoolVarP(&p.Force, "force", "f", p.Force, "")
+	fs.BoolVarP(&p.WithDisks, "with-disks", "", p.WithDisks, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 
@@ -51,6 +53,8 @@ func (p *deleteParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("server", pflag.ContinueOnError)
 		fs.AddFlag(cmd.LocalFlags().Lookup("zone"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("fail-if-not-found"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("force"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("with-disks"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Server options",
 			Flags: fs,

--- a/pkg/cmd/commands/server/zz_update_gen.go
+++ b/pkg/cmd/commands/server/zz_update_gen.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/pointer"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -37,6 +38,27 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("icon-id") {
 		p.IconID = nil
 	}
+	if !fs.Changed("cpu") {
+		p.CPU = nil
+	}
+	if !fs.Changed("memory") {
+		p.Memory = nil
+	}
+	if !fs.Changed("commitment") {
+		p.Commitment = nil
+	}
+	if !fs.Changed("generation") {
+		p.Generation = nil
+	}
+	if !fs.Changed("interface-driver") {
+		p.InterfaceDriver = nil
+	}
+	if !fs.Changed("cdrom-id") {
+		p.CDROMID = nil
+	}
+	if !fs.Changed("private-host-id") {
+		p.PrivateHostID = nil
+	}
 }
 
 func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
@@ -52,6 +74,27 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	if p.IconID == nil {
 		p.IconID = pointer.NewID(types.ID(0))
 	}
+	if p.CPU == nil {
+		p.CPU = pointer.NewInt(0)
+	}
+	if p.Memory == nil {
+		p.Memory = pointer.NewInt(0)
+	}
+	if p.Commitment == nil {
+		p.Commitment = pointer.NewString("")
+	}
+	if p.Generation == nil {
+		p.Generation = pointer.NewString("")
+	}
+	if p.InterfaceDriver == nil {
+		p.InterfaceDriver = pointer.NewString("")
+	}
+	if p.CDROMID == nil {
+		p.CDROMID = pointer.NewID(types.ID(0))
+	}
+	if p.PrivateHostID == nil {
+		p.PrivateHostID = pointer.NewID(types.ID(0))
+	}
 	fs.StringVarP(&p.Zone, "zone", "", p.Zone, "")
 	fs.StringVarP(&p.Parameters, "parameters", "", p.Parameters, "Input parameters in JSON format")
 	fs.BoolVarP(&p.GenerateSkeleton, "generate-skeleton", "", p.GenerateSkeleton, "Output skeleton of parameters with JSON format (aliases: --skeleton)")
@@ -66,6 +109,17 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.Description, "description", "", "", "")
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
+	fs.IntVarP(p.CPU, "cpu", "", 0, "(aliases: --core)")
+	fs.IntVarP(p.Memory, "memory", "", 0, "")
+	fs.StringVarP(p.Commitment, "commitment", "", "", "options: [standard/dedicatedcpu]")
+	fs.StringVarP(p.Generation, "generation", "", "", "options: [default/g100/g200]")
+	fs.StringVarP(p.InterfaceDriver, "interface-driver", "", "", "options: [interface_dirver]")
+	fs.VarP(core.NewIDFlag(p.CDROMID, p.CDROMID), "cdrom-id", "", "(aliases: --iso-image-id)")
+	fs.VarP(core.NewIDFlag(p.PrivateHostID, p.PrivateHostID), "private-host-id", "", "")
+	fs.StringVarP(&p.NetworkInterfaceData, "network-interfaces", "", p.NetworkInterfaceData, "")
+	fs.StringVarP(&p.DisksData, "disks", "", p.DisksData, "")
+	fs.BoolVarP(&p.NoWait, "no-wait", "", p.NoWait, "")
+	fs.BoolVarP(&p.ForceShutdown, "force-shutdown", "", p.ForceShutdown, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 
@@ -77,6 +131,10 @@ func (p *updateParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "core":
+		name = "cpu"
+	case "iso-image-id":
+		name = "cdrom-id"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -91,6 +149,17 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("description"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("tags"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("icon-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("cpu"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("memory"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("commitment"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("generation"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("interface-driver"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("cdrom-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("private-host-id"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("network-interfaces"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disks"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("no-wait"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("force-shutdown"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Server options",
 			Flags: fs,
@@ -126,6 +195,9 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *updateParameter) setCompletionFunc(cmd *cobra.Command) {
+	cmd.RegisterFlagCompletionFunc("commitment", util.FlagCompletionFunc("standard", "dedicatedcpu"))
+	cmd.RegisterFlagCompletionFunc("generation", util.FlagCompletionFunc("default", "g100", "g200"))
+	cmd.RegisterFlagCompletionFunc("interface-driver", util.FlagCompletionFunc("interface_dirver"))
 
 }
 

--- a/pkg/vdef/definitions.go
+++ b/pkg/vdef/definitions.go
@@ -72,6 +72,10 @@ var definitions = map[string][]*definition{
 		{key: types.GSLBHealthCheckProtocols.Ping.String(), value: types.GSLBHealthCheckProtocols.Ping},
 		{key: types.GSLBHealthCheckProtocols.TCP.String(), value: types.GSLBHealthCheckProtocols.TCP},
 	},
+	"interface_driver": {
+		{key: "virtio", value: types.InterfaceDrivers.VirtIO},
+		{key: "e1000", value: types.InterfaceDrivers.E1000},
+	},
 	"internet_network_mask_len": {
 		{key: 28, value: 28},
 		{key: 27, value: 27},

--- a/vendor/github.com/sacloud/libsacloud/v2/helper/service/server/delete_request.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/helper/service/server/delete_request.go
@@ -23,6 +23,7 @@ type DeleteRequest struct {
 	Zone string   `request:"-" validate:"required"`
 	ID   types.ID `request:"-" validate:"required"`
 
+	WithDisks      bool `request:"-"` // ディスクを一緒に削除するか
 	FailIfNotFound bool `request:"-"`
 	Force          bool `request:"-"` // trueの場合は電源OFF(強制終了)してから削除
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/helper/service/server/delete_service.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/helper/service/server/delete_service.go
@@ -57,8 +57,19 @@ func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) err
 		}
 	}
 
-	if err := client.Delete(ctx, req.Zone, req.ID); err != nil {
-		return service.HandleNotFoundError(err, !req.FailIfNotFound)
+	if req.WithDisks {
+		var diskIDs []types.ID
+		for _, disk := range target.Disks {
+			diskIDs = append(diskIDs, disk.ID)
+		}
+		if err := client.DeleteWithDisks(ctx, req.Zone, req.ID, &sacloud.ServerDeleteWithDisksRequest{IDs: diskIDs}); err != nil {
+			return service.HandleNotFoundError(err, !req.FailIfNotFound)
+		}
+	} else {
+		if err := client.Delete(ctx, req.Zone, req.ID); err != nil {
+			return service.HandleNotFoundError(err, !req.FailIfNotFound)
+		}
 	}
+
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,7 +43,7 @@ github.com/olekukonko/tablewriter
 github.com/pmezard/go-difflib/difflib
 # github.com/sacloud/ftps v1.1.0
 github.com/sacloud/ftps
-# github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204035447-11e66e151098
+# github.com/sacloud/libsacloud/v2 v2.8.11-0.20201204095741-a902ffb85f95
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/helper/api
 github.com/sacloud/libsacloud/v2/helper/builder


### PR DESCRIPTION
libsacloudの修正を取り込み

- https://github.com/sacloud/libsacloud/pull/677
- https://github.com/sacloud/libsacloud/pull/687
- https://github.com/sacloud/libsacloud/pull/663

Note: `server create`にはNICの設定(`--network-interfaces`)やディスクの設定(`--disks`)を簡易に行うための`network-interface-*`や`--disk-*`が用意されている。
これはそれぞれの先頭の要素に対する操作を簡略化するもので、配列要素をJSONで指定せずフラグで設定できるようにしたもの。

`server update`にはこれらを用意していないが、パケットフィルタの着脱などで必要になるかもしれない。
現状では利用頻度は高くないとおもられるため当面は実装せず今後要望が出るようであれば対応を検討する。