### PR TITLE
Validate --output-type

### DIFF
--- a/pkg/cmd/cflag/output_parameter.go
+++ b/pkg/cmd/cflag/output_parameter.go
@@ -15,7 +15,7 @@
 package cflag
 
 type OutputParameter struct {
-	OutputType string `cli:",short=o,aliases=out,category=output,desc=Output format: one of the following [table/json/yaml]"`
+	OutputType string `cli:",short=o,aliases=out,category=output,desc=Output format: one of the following [table/json/yaml]" validate:"omitempty,output_type"`
 	Quiet      bool   `cli:",short=q,category=output,desc=Output IDs only"`
 	Format     string `cli:",aliases=fmt,category=output,desc=Output format in Go templates"`
 	FormatFile string `cli:",category=output,desc=Output format in Go templates(from file)"`


### PR DESCRIPTION
closes #642 

`--output-type`のバリデーションを行う。