### PR TITLE
Command definitions

### DIFF
--- a/pkg/cmd/commands/archive/list.go
+++ b/pkg/cmd/commands/archive/list.go
@@ -43,7 +43,7 @@ type listParameter struct {
 	cflag.FilterByNamesParameter `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.FilterByTagsParameter  `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.FilterByScopeParameter `cli:",squash" mapconv:",omitempty,squash"`
-	OSType                       string `cli:",category=filter,options=os_type_simple,order=100" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
+	OSType                       string `cli:",category=filter,options=os_type,display_options=os_type_simple,order=100" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
 }
 
 func newListParameter() *listParameter {

--- a/pkg/cmd/commands/archive/zz_list_gen.go
+++ b/pkg/cmd/commands/archive/zz_list_gen.go
@@ -133,7 +133,7 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 
 func (p *listParameter) setCompletionFunc(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("scope", util.FlagCompletionFunc("user", "shared"))
-	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "ubuntu", "ubuntu2004", "debian", "debian10", "coreos", "rancheros", "k3os", "freebsd", "..."))
+	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "centos7", "ubuntu", "ubuntu2004", "ubuntu1804", "ubuntu1604", "debian", "debian10", "debian9", "coreos", "rancheros", "k3os", "kusanagi", "freebsd", "windows2016", "windows2016-rds", "windows2016-rds-office", "windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all", "windows2016-sql2017-standard", "windows2016-sql2017-enterprise", "windows2016-sql2017-standard-all", "windows2019", "windows2019-rds", "windows2019-rds-office2019", "windows2019-sql2017-web", "windows2019-sql2019-web", "windows2019-sql2017-standard", "windows2019-sql2019-standard", "windows2019-sql2017-enterprise", "windows2019-sql2019-enterprise", "windows2019-sql2017-standard-all", "windows2019-sql2019-standard-all"))
 
 }
 

--- a/pkg/cmd/commands/autobackup/create.go
+++ b/pkg/cmd/commands/autobackup/create.go
@@ -45,7 +45,7 @@ type createParameter struct {
 
 	DiskID           types.ID `validate:"required"`
 	Weekdays         []string `cli:",options=weekdays" mapconv:"BackupSpanWeekdays,omitempty,filters=weekdays" validate:"required,weekdays"`
-	MaxNumOfArchives int      `mapconv:"MaximumNumberOfArchives" validate:"required,min=1,max=10"`
+	MaxNumOfArchives int      `cli:"max-backup-num" mapconv:"MaximumNumberOfArchives" validate:"required,min=1,max=10"`
 }
 
 func newCreateParameter() *createParameter {

--- a/pkg/cmd/commands/autobackup/update.go
+++ b/pkg/cmd/commands/autobackup/update.go
@@ -45,7 +45,7 @@ type updateParameter struct {
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
 	Weekdays         *[]string `cli:",options=weekdays" mapconv:"BackupSpanWeekdays,omitempty,filters=weekdays" validate:"omitempty,weekdays"`
-	MaxNumOfArchives *int      `mapconv:"MaximumNumberOfArchives" validate:"omitempty,min=1,max=10"`
+	MaxNumOfArchives *int      `cli:"max-backup-num" mapconv:"MaximumNumberOfArchives" validate:"omitempty,min=1,max=10"`
 }
 
 func newUpdateParameter() *updateParameter {

--- a/pkg/cmd/commands/autobackup/zz_create_gen.go
+++ b/pkg/cmd/commands/autobackup/zz_create_gen.go
@@ -45,7 +45,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
 	fs.VarP(core.NewIDFlag(&p.DiskID, &p.DiskID), "disk-id", "", "")
 	fs.StringSliceVarP(&p.Weekdays, "weekdays", "", p.Weekdays, "options: [all/sun/mon/tue/wed/thu/fri/sat]")
-	fs.IntVarP(&p.MaxNumOfArchives, "max-num-of-archives", "", p.MaxNumOfArchives, "")
+	fs.IntVarP(&p.MaxNumOfArchives, "max-backup-num", "", p.MaxNumOfArchives, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 
@@ -81,7 +81,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("auto-backup", pflag.ContinueOnError)
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-id"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("max-num-of-archives"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("max-backup-num"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("weekdays"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Auto-Backup-specific options",

--- a/pkg/cmd/commands/autobackup/zz_update_gen.go
+++ b/pkg/cmd/commands/autobackup/zz_update_gen.go
@@ -41,7 +41,7 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("weekdays") {
 		p.Weekdays = nil
 	}
-	if !fs.Changed("max-num-of-archives") {
+	if !fs.Changed("max-backup-num") {
 		p.MaxNumOfArchives = nil
 	}
 }
@@ -80,7 +80,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
 	fs.StringSliceVarP(p.Weekdays, "weekdays", "", nil, "options: [all/sun/mon/tue/wed/thu/fri/sat]")
-	fs.IntVarP(p.MaxNumOfArchives, "max-num-of-archives", "", 0, "")
+	fs.IntVarP(p.MaxNumOfArchives, "max-backup-num", "", 0, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 
@@ -115,7 +115,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("auto-backup", pflag.ContinueOnError)
 		fs.SortFlags = false
-		fs.AddFlag(cmd.LocalFlags().Lookup("max-num-of-archives"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("max-backup-num"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("weekdays"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Auto-Backup-specific options",

--- a/pkg/cmd/commands/cdrom/list.go
+++ b/pkg/cmd/commands/cdrom/list.go
@@ -42,7 +42,7 @@ type listParameter struct {
 
 	cflag.FilterByNamesParameter `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.FilterByTagsParameter  `cli:",squash" mapconv:",omitempty,squash"`
-	OSType                       string `cli:",category=filter,options=os_type_simple" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
+	OSType                       string `cli:",category=filter,options=os_type,display_options=os_type_simple" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
 	cflag.FilterByScopeParameter `cli:",squash" mapconv:",omitempty,squash"`
 }
 

--- a/pkg/cmd/commands/cdrom/zz_list_gen.go
+++ b/pkg/cmd/commands/cdrom/zz_list_gen.go
@@ -132,7 +132,7 @@ func (p *listParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *listParameter) setCompletionFunc(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "ubuntu", "ubuntu2004", "debian", "debian10", "coreos", "rancheros", "k3os", "freebsd", "..."))
+	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "centos7", "ubuntu", "ubuntu2004", "ubuntu1804", "ubuntu1604", "debian", "debian10", "debian9", "coreos", "rancheros", "k3os", "kusanagi", "freebsd", "windows2016", "windows2016-rds", "windows2016-rds-office", "windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all", "windows2016-sql2017-standard", "windows2016-sql2017-enterprise", "windows2016-sql2017-standard-all", "windows2019", "windows2019-rds", "windows2019-rds-office2019", "windows2019-sql2017-web", "windows2019-sql2019-web", "windows2019-sql2017-standard", "windows2019-sql2019-standard", "windows2019-sql2017-enterprise", "windows2019-sql2019-enterprise", "windows2019-sql2017-standard-all", "windows2019-sql2019-standard-all"))
 	cmd.RegisterFlagCompletionFunc("scope", util.FlagCompletionFunc("user", "shared"))
 
 }

--- a/pkg/cmd/commands/common/types.go
+++ b/pkg/cmd/commands/common/types.go
@@ -25,13 +25,13 @@ type EditRequest struct {
 	HostName string `cli:",category=diskedit,order=10"`
 	Password string `cli:",category=diskedit,order=20"`
 
-	IPAddress      string `cli:",category=diskedit,order=30"`
-	NetworkMaskLen int    `cli:",category=diskedit,order=31"`
-	DefaultRoute   string `cli:",category=diskedit,order=32"`
+	IPAddress      string `cli:"ip-address,category=diskedit,order=30"`
+	NetworkMaskLen int    `cli:"netmask,aliases=network-mask-len,category=diskedit,order=31"`
+	DefaultRoute   string `cli:"gateway,aliases=default-route,category=diskedit,order=32"`
 
-	DisablePWAuth       bool `cli:",category=diskedit,order=40"`
-	EnableDHCP          bool `cli:",category=diskedit,order=50"`
-	ChangePartitionUUID bool `cli:",category=diskedit,order=60"`
+	DisablePWAuth       bool `cli:"disable-pw-auth,category=diskedit,order=40"`
+	EnableDHCP          bool `cli:"enable-dhcp,category=diskedit,order=50"`
+	ChangePartitionUUID bool `cli:"change-partition-uuid,category=diskedit,order=60"`
 
 	SSHKeys            []string   `cli:"ssh-keys,category=diskedit,order=70"`
 	SSHKeyIDs          []types.ID `cli:"ssh-key-ids,category=diskedit,order=71"`

--- a/pkg/cmd/commands/containerregistry/create.go
+++ b/pkg/cmd/commands/containerregistry/create.go
@@ -45,7 +45,7 @@ type createParameter struct {
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
 
 	AccessLevel    string `cli:",options=container_registry_access_levels" mapconv:",filters=container_registry_access_levels_to_value" validate:"required,container_registry_access_levels"`
-	SubDomainLabel string `validate:"required"`
+	SubDomainLabel string `cli:"subdomain-label" validate:"required"`
 	VirtualDomain  string `validate:"omitempty,fqdn"`
 
 	UsersData string                    `cli:"users" mapconv:"-"`

--- a/pkg/cmd/commands/containerregistry/update.go
+++ b/pkg/cmd/commands/containerregistry/update.go
@@ -47,7 +47,7 @@ type updateParameter struct {
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
 	AccessLevel    *string `cli:",options=container_registry_access_levels" mapconv:",omitempty,filters=dereference,container_registry_access_levels_to_value" validate:"omitempty,container_registry_access_levels"`
-	SubDomainLabel *string `validate:"omitempty"`
+	SubDomainLabel *string `cli:"subdomain-label" validate:"omitempty"`
 	VirtualDomain  *string `validate:"omitempty,fqdn"`
 
 	UsersData *string                    `cli:"users" mapconv:"-"`

--- a/pkg/cmd/commands/containerregistry/zz_create_gen.go
+++ b/pkg/cmd/commands/containerregistry/zz_create_gen.go
@@ -43,7 +43,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
 	fs.StringVarP(&p.AccessLevel, "access-level", "", p.AccessLevel, "options: [readwrite/readonly/none]")
-	fs.StringVarP(&p.SubDomainLabel, "sub-domain-label", "", p.SubDomainLabel, "")
+	fs.StringVarP(&p.SubDomainLabel, "subdomain-label", "", p.SubDomainLabel, "")
 	fs.StringVarP(&p.VirtualDomain, "virtual-domain", "", p.VirtualDomain, "")
 	fs.StringVarP(&p.UsersData, "users", "", p.UsersData, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
@@ -81,7 +81,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("container-registry", pflag.ContinueOnError)
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("access-level"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("sub-domain-label"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("subdomain-label"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("users"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("virtual-domain"))
 		sets = append(sets, &core.FlagSet{

--- a/pkg/cmd/commands/containerregistry/zz_update_gen.go
+++ b/pkg/cmd/commands/containerregistry/zz_update_gen.go
@@ -41,7 +41,7 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("access-level") {
 		p.AccessLevel = nil
 	}
-	if !fs.Changed("sub-domain-label") {
+	if !fs.Changed("subdomain-label") {
 		p.SubDomainLabel = nil
 	}
 	if !fs.Changed("virtual-domain") {
@@ -91,7 +91,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
 	fs.StringVarP(p.AccessLevel, "access-level", "", "", "options: [readwrite/readonly/none]")
-	fs.StringVarP(p.SubDomainLabel, "sub-domain-label", "", "", "")
+	fs.StringVarP(p.SubDomainLabel, "subdomain-label", "", "", "")
 	fs.StringVarP(p.VirtualDomain, "virtual-domain", "", "", "")
 	fs.StringVarP(p.UsersData, "users", "", "", "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
@@ -129,7 +129,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("container-registry", pflag.ContinueOnError)
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("access-level"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("sub-domain-label"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("subdomain-label"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("users"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("virtual-domain"))
 		sets = append(sets, &core.FlagSet{

--- a/pkg/cmd/commands/database/create.go
+++ b/pkg/cmd/commands/database/create.go
@@ -48,10 +48,10 @@ type createParameter struct {
 
 	SwitchID       types.ID `cli:",category=network,order=10" validate:"required"`
 	IPAddresses    []string `cli:"ip-address,aliases=ipaddress,category=network,order=20" validate:"required,min=1,max=2,dive,ipv4"`
-	NetworkMaskLen int      `cli:",category=network,order=30" validate:"required,min=1,max=32"`
-	DefaultRoute   string   `cli:",category=network,order=40" validate:"omitempty,ipv4"`
+	NetworkMaskLen int      `cli:"netmask,aliases=network-mask-len,category=network,order=30" validate:"required,min=1,max=32"`
+	DefaultRoute   string   `cli:"gateway,aliases=default-route,category=network,order=40" validate:"omitempty,ipv4"`
 	Port           int      `cli:",category=network,order=50" validate:"omitempty,min=1,max=65535"`
-	SourceNetwork  []string `cli:",category=network,order=60" validate:"omitempty,dive,cidrv4"`
+	SourceNetwork  []string `cli:"source-range,aliases=source-network,category=network,order=60" validate:"omitempty,dive,cidrv4"`
 
 	Username string `cli:",category=user,order=10" validate:"required"`
 	Password string `cli:",category=user,order=20" validate:"required"`

--- a/pkg/cmd/commands/database/update.go
+++ b/pkg/cmd/commands/database/update.go
@@ -44,7 +44,7 @@ type updateParameter struct {
 	cflag.TagsUpdateParameter   `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
-	SourceNetwork *[]string `cli:",category=network" validate:"omitempty,dive,cidrv4"`
+	SourceNetwork *[]string `cli:"source-range,aliases=source-network,category=network" validate:"omitempty,dive,cidrv4"`
 
 	EnableReplication     *bool     `cli:",category=replication,order=10"`
 	ReplicaUserPassword   *string   `cli:",category=replication,order=20" validate:"omitempty,required_with=EnableReplication"`

--- a/pkg/cmd/commands/database/zz_create_gen.go
+++ b/pkg/cmd/commands/database/zz_create_gen.go
@@ -47,10 +47,10 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.PlanID, "plan", "", p.PlanID, "options: [10g/30g/90g/240g/500g/1t]")
 	fs.VarP(core.NewIDFlag(&p.SwitchID, &p.SwitchID), "switch-id", "", "")
 	fs.StringSliceVarP(&p.IPAddresses, "ip-address", "", p.IPAddresses, "(aliases: --ipaddress)")
-	fs.IntVarP(&p.NetworkMaskLen, "network-mask-len", "", p.NetworkMaskLen, "")
-	fs.StringVarP(&p.DefaultRoute, "default-route", "", p.DefaultRoute, "")
+	fs.IntVarP(&p.NetworkMaskLen, "netmask", "", p.NetworkMaskLen, "(aliases: --network-mask-len)")
+	fs.StringVarP(&p.DefaultRoute, "gateway", "", p.DefaultRoute, "(aliases: --default-route)")
 	fs.IntVarP(&p.Port, "port", "", p.Port, "")
-	fs.StringSliceVarP(&p.SourceNetwork, "source-network", "", p.SourceNetwork, "")
+	fs.StringSliceVarP(&p.SourceNetwork, "source-range", "", p.SourceNetwork, "(aliases: --source-network)")
 	fs.StringVarP(&p.Username, "username", "", p.Username, "")
 	fs.StringVarP(&p.Password, "password", "", p.Password, "")
 	fs.BoolVarP(&p.EnableReplication, "enable-replication", "", p.EnableReplication, "")
@@ -74,6 +74,12 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "format"
 	case "ipaddress":
 		name = "ip-address"
+	case "network-mask-len":
+		name = "netmask"
+	case "default-route":
+		name = "gateway"
+	case "source-network":
+		name = "source-range"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -133,10 +139,10 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("switch-id"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("gateway"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("port"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("source-network"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("source-range"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Network options",
 			Flags: fs,

--- a/pkg/cmd/commands/database/zz_update_gen.go
+++ b/pkg/cmd/commands/database/zz_update_gen.go
@@ -38,7 +38,7 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("icon-id") {
 		p.IconID = nil
 	}
-	if !fs.Changed("source-network") {
+	if !fs.Changed("source-range") {
 		p.SourceNetwork = nil
 	}
 	if !fs.Changed("enable-replication") {
@@ -115,7 +115,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.Description, "description", "", "", "")
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
-	fs.StringSliceVarP(p.SourceNetwork, "source-network", "", nil, "")
+	fs.StringSliceVarP(p.SourceNetwork, "source-range", "", nil, "(aliases: --source-network)")
 	fs.BoolVarP(p.EnableReplication, "enable-replication", "", false, "")
 	fs.StringVarP(p.ReplicaUserPassword, "replica-user-password", "", "", "")
 	fs.BoolVarP(p.EnableWebUI, "enable-web-ui", "", false, "")
@@ -135,6 +135,8 @@ func (p *updateParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "source-network":
+		name = "source-range"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -181,7 +183,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("network", pflag.ContinueOnError)
 		fs.SortFlags = false
-		fs.AddFlag(cmd.LocalFlags().Lookup("source-network"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("source-range"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Network options",
 			Flags: fs,

--- a/pkg/cmd/commands/disk/create.go
+++ b/pkg/cmd/commands/disk/create.go
@@ -48,9 +48,9 @@ type createParameter struct {
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
 	DiskPlan              string `cli:",options=disk_plan,category=plan,order=10" mapconv:"DiskPlanID,filters=disk_plan_to_value" validate:"required,disk_plan"`
 	SizeGB                int    `cli:"size,category=plan,order=20"`
-	Connection            string `cli:",options=disk_connection,category=plan,order=30" validate:"required,disk_connection"`
+	Connection            string `cli:"connector,aliases=connection,options=disk_connection,category=plan,order=30" validate:"required,disk_connection"`
 
-	OSType          string   `cli:",options=os_type_simple,category=source,order=10" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
+	OSType          string   `cli:",options=os_type,display_options=os_type_simple,category=source,order=10" mapconv:",omitempty,filters=os_type_to_value" validate:"omitempty,os_type"`
 	SourceDiskID    types.ID `cli:",category=source,order=20"`
 	SourceArchiveID types.ID `cli:",category=source,order=30"`
 

--- a/pkg/cmd/commands/disk/update.go
+++ b/pkg/cmd/commands/disk/update.go
@@ -46,7 +46,7 @@ type updateParameter struct {
 	cflag.TagsUpdateParameter   `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
-	Connection            *string            `cli:",options=disk_connection,category=plan" validate:"omitempty,disk_connection"`
+	Connection            *string            `cli:"connector,aliases=connection,options=disk_connection,category=plan" validate:"omitempty,disk_connection"`
 	EditDisk              common.EditRequest `cli:",category=edit" mapconv:"EditParameter,omitempty"`
 	cflag.NoWaitParameter `cli:",squash" mapconv:",squash"`
 }

--- a/pkg/cmd/commands/disk/zz_create_gen.go
+++ b/pkg/cmd/commands/disk/zz_create_gen.go
@@ -45,7 +45,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
 	fs.StringVarP(&p.DiskPlan, "disk-plan", "", p.DiskPlan, "options: [ssd/hdd]")
 	fs.IntVarP(&p.SizeGB, "size", "", p.SizeGB, "")
-	fs.StringVarP(&p.Connection, "connection", "", p.Connection, "options: [virtio/ide]")
+	fs.StringVarP(&p.Connection, "connector", "", p.Connection, "options: [virtio/ide] (aliases: --connection)")
 	fs.StringVarP(&p.OSType, "os-type", "", p.OSType, "options: [centos/centos8/ubuntu/ubuntu2004/debian/debian10/coreos/rancheros/k3os/freebsd/...]")
 	fs.VarP(core.NewIDFlag(&p.SourceDiskID, &p.SourceDiskID), "source-disk-id", "", "")
 	fs.VarP(core.NewIDFlag(&p.SourceArchiveID, &p.SourceArchiveID), "source-archive-id", "", "")
@@ -54,8 +54,8 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.EditDisk.HostName, "edit-disk-host-name", "", p.EditDisk.HostName, "")
 	fs.StringVarP(&p.EditDisk.Password, "edit-disk-password", "", p.EditDisk.Password, "")
 	fs.StringVarP(&p.EditDisk.IPAddress, "edit-disk-ip-address", "", p.EditDisk.IPAddress, "")
-	fs.IntVarP(&p.EditDisk.NetworkMaskLen, "edit-disk-network-mask-len", "", p.EditDisk.NetworkMaskLen, "")
-	fs.StringVarP(&p.EditDisk.DefaultRoute, "edit-disk-default-route", "", p.EditDisk.DefaultRoute, "")
+	fs.IntVarP(&p.EditDisk.NetworkMaskLen, "edit-disk-netmask", "", p.EditDisk.NetworkMaskLen, "(aliases: --network-mask-len)")
+	fs.StringVarP(&p.EditDisk.DefaultRoute, "edit-disk-gateway", "", p.EditDisk.DefaultRoute, "(aliases: --default-route)")
 	fs.BoolVarP(&p.EditDisk.DisablePWAuth, "edit-disk-disable-pw-auth", "", p.EditDisk.DisablePWAuth, "")
 	fs.BoolVarP(&p.EditDisk.EnableDHCP, "edit-disk-enable-dhcp", "", p.EditDisk.EnableDHCP, "")
 	fs.BoolVarP(&p.EditDisk.ChangePartitionUUID, "edit-disk-change-partition-uuid", "", p.EditDisk.ChangePartitionUUID, "")
@@ -77,6 +77,12 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "connection":
+		name = "connector"
+	case "network-mask-len":
+		name = "edit-disk-netmask"
+	case "default-route":
+		name = "edit-disk-gateway"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -102,7 +108,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-plan"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("size"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("connection"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("connector"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Plan options",
 			Flags: fs,
@@ -126,8 +132,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-host-name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-password"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-network-mask-len"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-netmask"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-gateway"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-disable-pw-auth"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-enable-dhcp"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-change-partition-uuid"))
@@ -207,8 +213,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 
 func (p *createParameter) setCompletionFunc(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("disk-plan", util.FlagCompletionFunc("ssd", "hdd"))
-	cmd.RegisterFlagCompletionFunc("connection", util.FlagCompletionFunc("virtio", "ide"))
-	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "ubuntu", "ubuntu2004", "debian", "debian10", "coreos", "rancheros", "k3os", "freebsd", "..."))
+	cmd.RegisterFlagCompletionFunc("connector", util.FlagCompletionFunc("virtio", "ide"))
+	cmd.RegisterFlagCompletionFunc("os-type", util.FlagCompletionFunc("centos", "centos8", "centos7", "ubuntu", "ubuntu2004", "ubuntu1804", "ubuntu1604", "debian", "debian10", "debian9", "coreos", "rancheros", "k3os", "kusanagi", "freebsd", "windows2016", "windows2016-rds", "windows2016-rds-office", "windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all", "windows2016-sql2017-standard", "windows2016-sql2017-enterprise", "windows2016-sql2017-standard-all", "windows2019", "windows2019-rds", "windows2019-rds-office2019", "windows2019-sql2017-web", "windows2019-sql2019-web", "windows2019-sql2017-standard", "windows2019-sql2019-standard", "windows2019-sql2017-enterprise", "windows2019-sql2019-enterprise", "windows2019-sql2017-standard-all", "windows2019-sql2019-standard-all"))
 
 }
 

--- a/pkg/cmd/commands/disk/zz_edit_gen.go
+++ b/pkg/cmd/commands/disk/zz_edit_gen.go
@@ -41,8 +41,8 @@ func (p *editParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.EditDisk.HostName, "host-name", "", p.EditDisk.HostName, "")
 	fs.StringVarP(&p.EditDisk.Password, "password", "", p.EditDisk.Password, "")
 	fs.StringVarP(&p.EditDisk.IPAddress, "ip-address", "", p.EditDisk.IPAddress, "")
-	fs.IntVarP(&p.EditDisk.NetworkMaskLen, "network-mask-len", "", p.EditDisk.NetworkMaskLen, "")
-	fs.StringVarP(&p.EditDisk.DefaultRoute, "default-route", "", p.EditDisk.DefaultRoute, "")
+	fs.IntVarP(&p.EditDisk.NetworkMaskLen, "netmask", "", p.EditDisk.NetworkMaskLen, "(aliases: --network-mask-len)")
+	fs.StringVarP(&p.EditDisk.DefaultRoute, "gateway", "", p.EditDisk.DefaultRoute, "(aliases: --default-route)")
 	fs.BoolVarP(&p.EditDisk.DisablePWAuth, "disable-pw-auth", "", p.EditDisk.DisablePWAuth, "")
 	fs.BoolVarP(&p.EditDisk.EnableDHCP, "enable-dhcp", "", p.EditDisk.EnableDHCP, "")
 	fs.BoolVarP(&p.EditDisk.ChangePartitionUUID, "change-partition-uuid", "", p.EditDisk.ChangePartitionUUID, "")
@@ -64,6 +64,10 @@ func (p *editParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag.N
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "network-mask-len":
+		name = "netmask"
+	case "default-route":
+		name = "gateway"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -77,8 +81,8 @@ func (p *editParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("host-name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("password"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("gateway"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("disable-pw-auth"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("enable-dhcp"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("change-partition-uuid"))

--- a/pkg/cmd/commands/disk/zz_update_gen.go
+++ b/pkg/cmd/commands/disk/zz_update_gen.go
@@ -38,7 +38,7 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("icon-id") {
 		p.IconID = nil
 	}
-	if !fs.Changed("connection") {
+	if !fs.Changed("connector") {
 		p.Connection = nil
 	}
 }
@@ -73,12 +73,12 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.Description, "description", "", "", "")
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
-	fs.StringVarP(p.Connection, "connection", "", "", "options: [virtio/ide]")
+	fs.StringVarP(p.Connection, "connector", "", "", "options: [virtio/ide] (aliases: --connection)")
 	fs.StringVarP(&p.EditDisk.HostName, "edit-disk-host-name", "", p.EditDisk.HostName, "")
 	fs.StringVarP(&p.EditDisk.Password, "edit-disk-password", "", p.EditDisk.Password, "")
 	fs.StringVarP(&p.EditDisk.IPAddress, "edit-disk-ip-address", "", p.EditDisk.IPAddress, "")
-	fs.IntVarP(&p.EditDisk.NetworkMaskLen, "edit-disk-network-mask-len", "", p.EditDisk.NetworkMaskLen, "")
-	fs.StringVarP(&p.EditDisk.DefaultRoute, "edit-disk-default-route", "", p.EditDisk.DefaultRoute, "")
+	fs.IntVarP(&p.EditDisk.NetworkMaskLen, "edit-disk-netmask", "", p.EditDisk.NetworkMaskLen, "(aliases: --network-mask-len)")
+	fs.StringVarP(&p.EditDisk.DefaultRoute, "edit-disk-gateway", "", p.EditDisk.DefaultRoute, "(aliases: --default-route)")
 	fs.BoolVarP(&p.EditDisk.DisablePWAuth, "edit-disk-disable-pw-auth", "", p.EditDisk.DisablePWAuth, "")
 	fs.BoolVarP(&p.EditDisk.EnableDHCP, "edit-disk-enable-dhcp", "", p.EditDisk.EnableDHCP, "")
 	fs.BoolVarP(&p.EditDisk.ChangePartitionUUID, "edit-disk-change-partition-uuid", "", p.EditDisk.ChangePartitionUUID, "")
@@ -100,6 +100,12 @@ func (p *updateParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "connection":
+		name = "connector"
+	case "network-mask-len":
+		name = "edit-disk-netmask"
+	case "default-route":
+		name = "edit-disk-gateway"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -123,7 +129,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("plan", pflag.ContinueOnError)
 		fs.SortFlags = false
-		fs.AddFlag(cmd.LocalFlags().Lookup("connection"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("connector"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Plan options",
 			Flags: fs,
@@ -136,8 +142,8 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-host-name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-password"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-network-mask-len"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-netmask"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-gateway"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-disable-pw-auth"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-enable-dhcp"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("edit-disk-change-partition-uuid"))
@@ -204,7 +210,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *updateParameter) setCompletionFunc(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc("connection", util.FlagCompletionFunc("virtio", "ide"))
+	cmd.RegisterFlagCompletionFunc("connector", util.FlagCompletionFunc("virtio", "ide"))
 
 }
 

--- a/pkg/cmd/commands/gslb/create.go
+++ b/pkg/cmd/commands/gslb/create.go
@@ -48,7 +48,7 @@ type createParameter struct {
 		Protocol     string `validate:"required,gslb_protocol"`
 		HostHeader   string
 		Path         string
-		ResponseCode int
+		ResponseCode int `cli:"status,aliases=response-code"`
 		Port         int `validate:"omitempty,min=1,max=65535"`
 	} `cli:",category=health"`
 

--- a/pkg/cmd/commands/gslb/update.go
+++ b/pkg/cmd/commands/gslb/update.go
@@ -50,7 +50,7 @@ type updateParameter struct {
 		Protocol     *string `validate:"omitempty,gslb_protocol"`
 		HostHeader   *string
 		Path         *string
-		ResponseCode *int
+		ResponseCode *int `cli:"status,aliases=response-code"`
 		Port         *int `validate:"omitempty,min=1,max=65535"`
 	} `cli:",category=health" mapconv:",omitempty"`
 

--- a/pkg/cmd/commands/gslb/zz_create_gen.go
+++ b/pkg/cmd/commands/gslb/zz_create_gen.go
@@ -44,7 +44,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.HealthCheck.Protocol, "health-check-protocol", "", p.HealthCheck.Protocol, "")
 	fs.StringVarP(&p.HealthCheck.HostHeader, "health-check-host-header", "", p.HealthCheck.HostHeader, "")
 	fs.StringVarP(&p.HealthCheck.Path, "health-check-path", "", p.HealthCheck.Path, "")
-	fs.IntVarP(&p.HealthCheck.ResponseCode, "health-check-response-code", "", p.HealthCheck.ResponseCode, "")
+	fs.IntVarP(&p.HealthCheck.ResponseCode, "health-check-status", "", p.HealthCheck.ResponseCode, "(aliases: --response-code)")
 	fs.IntVarP(&p.HealthCheck.Port, "health-check-port", "", p.HealthCheck.Port, "")
 	fs.IntVarP(&p.DelayLoop, "delay-loop", "", p.DelayLoop, "")
 	fs.BoolVarP(&p.Weighted, "weighted", "", p.Weighted, "")
@@ -61,6 +61,8 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "response-code":
+		name = "health-check-status"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -99,7 +101,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-path"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-port"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-protocol"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-response-code"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-status"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("delay-loop"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("weighted"))
 		sets = append(sets, &core.FlagSet{

--- a/pkg/cmd/commands/gslb/zz_update_gen.go
+++ b/pkg/cmd/commands/gslb/zz_update_gen.go
@@ -46,7 +46,7 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("health-check-path") {
 		p.HealthCheck.Path = nil
 	}
-	if !fs.Changed("health-check-response-code") {
+	if !fs.Changed("health-check-status") {
 		p.HealthCheck.ResponseCode = nil
 	}
 	if !fs.Changed("health-check-port") {
@@ -122,7 +122,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.HealthCheck.Protocol, "health-check-protocol", "", "", "")
 	fs.StringVarP(p.HealthCheck.HostHeader, "health-check-host-header", "", "", "")
 	fs.StringVarP(p.HealthCheck.Path, "health-check-path", "", "", "")
-	fs.IntVarP(p.HealthCheck.ResponseCode, "health-check-response-code", "", 0, "")
+	fs.IntVarP(p.HealthCheck.ResponseCode, "health-check-status", "", 0, "(aliases: --response-code)")
 	fs.IntVarP(p.HealthCheck.Port, "health-check-port", "", 0, "")
 	fs.IntVarP(p.DelayLoop, "delay-loop", "", 0, "")
 	fs.BoolVarP(p.Weighted, "weighted", "", false, "")
@@ -139,6 +139,8 @@ func (p *updateParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "response-code":
+		name = "health-check-status"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -177,7 +179,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-path"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-port"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-protocol"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-response-code"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-status"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("delay-loop"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("weighted"))
 		sets = append(sets, &core.FlagSet{

--- a/pkg/cmd/commands/internet/add_subnet.go
+++ b/pkg/cmd/commands/internet/add_subnet.go
@@ -40,7 +40,7 @@ type addSubnetParameter struct {
 	cflag.ConfirmParameter `cli:",squash" mapconv:"-"`
 	cflag.OutputParameter  `cli:",squash" mapconv:"-"`
 
-	NetworkMaskLen int    `cli:",options=internet_network_mask_len" validate:"required,internet_network_mask_len"`
+	NetworkMaskLen int    `cli:"netmask,aliases=network-mask-len,options=internet_network_mask_len" validate:"required,internet_network_mask_len"`
 	NextHop        string `validate:"required,ipv4"`
 }
 

--- a/pkg/cmd/commands/internet/create.go
+++ b/pkg/cmd/commands/internet/create.go
@@ -42,7 +42,7 @@ type createParameter struct {
 	cflag.TagsParameter   `cli:",squash" mapconv:",squash"`
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
 
-	NetworkMaskLen int `cli:",options=internet_network_mask_len" validate:"required,internet_network_mask_len"`
+	NetworkMaskLen int `cli:"netmask,aliases=network-mask-len,options=internet_network_mask_len" validate:"required,internet_network_mask_len"`
 	BandWidthMbps  int `cli:"band-width,aliases=band-width-mbps,options=internet_bandwidth" validate:"required,internet_bandwidth"`
 
 	EnableIPv6            bool `cli:"enable-ipv6"`

--- a/pkg/cmd/commands/internet/zz_add_subnet_gen.go
+++ b/pkg/cmd/commands/internet/zz_add_subnet_gen.go
@@ -39,7 +39,7 @@ func (p *addSubnetParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.FormatFile, "format-file", "", p.FormatFile, "Output format in Go templates(from file)")
 	fs.StringVarP(&p.Query, "query", "", p.Query, "JMESPath query")
 	fs.StringVarP(&p.QueryFile, "query-file", "", p.QueryFile, "JMESPath query(from file)")
-	fs.IntVarP(&p.NetworkMaskLen, "network-mask-len", "", p.NetworkMaskLen, "options: [28/27/26/25/24]")
+	fs.IntVarP(&p.NetworkMaskLen, "netmask", "", p.NetworkMaskLen, "options: [28/27/26/25/24] (aliases: --network-mask-len)")
 	fs.StringVarP(&p.NextHop, "next-hop", "", p.NextHop, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
@@ -52,6 +52,8 @@ func (p *addSubnetParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pf
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "network-mask-len":
+		name = "netmask"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -62,7 +64,7 @@ func (p *addSubnetParameter) buildFlagsUsage(cmd *cobra.Command) {
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("internet", pflag.ContinueOnError)
 		fs.SortFlags = false
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("next-hop"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Internet-specific options",
@@ -111,7 +113,7 @@ func (p *addSubnetParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *addSubnetParameter) setCompletionFunc(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc("network-mask-len", util.FlagCompletionFunc("28", "27", "26", "25", "24"))
+	cmd.RegisterFlagCompletionFunc("netmask", util.FlagCompletionFunc("28", "27", "26", "25", "24"))
 
 }
 

--- a/pkg/cmd/commands/internet/zz_create_gen.go
+++ b/pkg/cmd/commands/internet/zz_create_gen.go
@@ -43,7 +43,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Description, "description", "", p.Description, "")
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
-	fs.IntVarP(&p.NetworkMaskLen, "network-mask-len", "", p.NetworkMaskLen, "options: [28/27/26/25/24]")
+	fs.IntVarP(&p.NetworkMaskLen, "netmask", "", p.NetworkMaskLen, "options: [28/27/26/25/24] (aliases: --network-mask-len)")
 	fs.IntVarP(&p.BandWidthMbps, "band-width", "", p.BandWidthMbps, "options: [100/250/500/1000/1500/2000/2500/3000/5000] (aliases: --band-width-mbps)")
 	fs.BoolVarP(&p.EnableIPv6, "enable-ipv6", "", p.EnableIPv6, "")
 	fs.BoolVarP(&p.NoWait, "no-wait", "", p.NoWait, "")
@@ -59,6 +59,8 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "network-mask-len":
+		name = "netmask"
 	case "band-width-mbps":
 		name = "band-width"
 	}
@@ -86,7 +88,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("band-width"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("enable-ipv6"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("not-found-retry"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Internet-specific options",
@@ -145,7 +147,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *createParameter) setCompletionFunc(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc("network-mask-len", util.FlagCompletionFunc("28", "27", "26", "25", "24"))
+	cmd.RegisterFlagCompletionFunc("netmask", util.FlagCompletionFunc("28", "27", "26", "25", "24"))
 	cmd.RegisterFlagCompletionFunc("band-width", util.FlagCompletionFunc("100", "250", "500", "1000", "1500", "2000", "2500", "3000", "5000"))
 
 }

--- a/pkg/cmd/commands/loadbalancer/create.go
+++ b/pkg/cmd/commands/loadbalancer/create.go
@@ -53,11 +53,11 @@ type createParameter struct {
 	VRID           int      `cli:"vrid,category=network,order=10"`
 	SwitchID       types.ID `cli:",category=network,order=20" validate:"required"`
 	IPAddresses    []string `cli:"ip-address,aliases=ipaddress,category=network,order=30" validate:"required,min=1,max=2,dive,ipv4"`
-	NetworkMaskLen int      `cli:",category=network,order=40" validate:"required,min=1,max=32"`
-	DefaultRoute   string   `cli:",category=network,order=50" validate:"omitempty,ipv4"`
+	NetworkMaskLen int      `cli:"netmask,aliases=network-mask-len,category=network,order=40" validate:"required,min=1,max=32"`
+	DefaultRoute   string   `cli:"gateway,aliases=default-route,category=network,order=50" validate:"omitempty,ipv4"`
 	Port           int      `cli:",category=network,order=60" validate:"omitempty,min=1,max=65535"`
 
-	VirtualIPAddressesData string                                 `cli:"virtual-ip-addresses,category=network,order=70" mapconv:"-"`
+	VirtualIPAddressesData string                                 `cli:"virtual-ip-addresses,aliases=vips,category=network,order=70" mapconv:"-"`
 	VirtualIPAddresses     sacloud.LoadBalancerVirtualIPAddresses `cli:"-"`
 
 	cflag.NoWaitParameter `cli:",squash" mapconv:",squash"`

--- a/pkg/cmd/commands/loadbalancer/update.go
+++ b/pkg/cmd/commands/loadbalancer/update.go
@@ -47,7 +47,7 @@ type updateParameter struct {
 	cflag.TagsUpdateParameter   `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
-	VirtualIPAddressesData *string                                 `cli:"virtual-ip-addresses,category=network" mapconv:"-"`
+	VirtualIPAddressesData *string                                 `cli:"virtual-ip-addresses,aliases=vips,category=network" mapconv:"-"`
 	VirtualIPAddresses     *sacloud.LoadBalancerVirtualIPAddresses `cli:"-"`
 	cflag.NoWaitParameter  `cli:",squash" mapconv:",squash"`
 }

--- a/pkg/cmd/commands/loadbalancer/zz_create_gen.go
+++ b/pkg/cmd/commands/loadbalancer/zz_create_gen.go
@@ -47,10 +47,10 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.IntVarP(&p.VRID, "vrid", "", p.VRID, "")
 	fs.VarP(core.NewIDFlag(&p.SwitchID, &p.SwitchID), "switch-id", "", "")
 	fs.StringSliceVarP(&p.IPAddresses, "ip-address", "", p.IPAddresses, "(aliases: --ipaddress)")
-	fs.IntVarP(&p.NetworkMaskLen, "network-mask-len", "", p.NetworkMaskLen, "")
-	fs.StringVarP(&p.DefaultRoute, "default-route", "", p.DefaultRoute, "")
+	fs.IntVarP(&p.NetworkMaskLen, "netmask", "", p.NetworkMaskLen, "(aliases: --network-mask-len)")
+	fs.StringVarP(&p.DefaultRoute, "gateway", "", p.DefaultRoute, "(aliases: --default-route)")
 	fs.IntVarP(&p.Port, "port", "", p.Port, "")
-	fs.StringVarP(&p.VirtualIPAddressesData, "virtual-ip-addresses", "", p.VirtualIPAddressesData, "")
+	fs.StringVarP(&p.VirtualIPAddressesData, "virtual-ip-addresses", "", p.VirtualIPAddressesData, "(aliases: --vips)")
 	fs.BoolVarP(&p.NoWait, "no-wait", "", p.NoWait, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
@@ -65,6 +65,12 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "format"
 	case "ipaddress":
 		name = "ip-address"
+	case "network-mask-len":
+		name = "netmask"
+	case "default-route":
+		name = "gateway"
+	case "vips":
+		name = "virtual-ip-addresses"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -101,8 +107,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("vrid"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("switch-id"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("gateway"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("port"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("virtual-ip-addresses"))
 		sets = append(sets, &core.FlagSet{

--- a/pkg/cmd/commands/loadbalancer/zz_update_gen.go
+++ b/pkg/cmd/commands/loadbalancer/zz_update_gen.go
@@ -72,7 +72,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.Description, "description", "", "", "")
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
-	fs.StringVarP(p.VirtualIPAddressesData, "virtual-ip-addresses", "", "", "")
+	fs.StringVarP(p.VirtualIPAddressesData, "virtual-ip-addresses", "", "", "(aliases: --vips)")
 	fs.BoolVarP(&p.NoWait, "no-wait", "", p.NoWait, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
@@ -85,6 +85,8 @@ func (p *updateParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "vips":
+		name = "virtual-ip-addresses"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/pkg/cmd/commands/localrouter/create.go
+++ b/pkg/cmd/commands/localrouter/create.go
@@ -52,8 +52,8 @@ type createParameter struct {
 
 	Interface struct {
 		VirtualIPAddress string   `validate:"omitempty,ipv4"`
-		IPAddress        []string `validate:"omitempty,min=2,max=2,dive,ipv4"`
-		NetworkMaskLen   int      `validate:"omitempty,min=8,max=28"`
+		IPAddress        []string `cli:"ip-addresses" validate:"omitempty,min=2,max=2,dive,ipv4"`
+		NetworkMaskLen   int      `cli:"netmask,aliases=network-mask-len" validate:"omitempty,min=8,max=28"`
 		VRID             int      `validate:"omitempty"`
 	} `cli:",squash"`
 

--- a/pkg/cmd/commands/localrouter/update.go
+++ b/pkg/cmd/commands/localrouter/update.go
@@ -54,9 +54,9 @@ type updateParameter struct {
 
 	Interface struct {
 		VirtualIPAddress *string   `validate:"omitempty,ipv4"`
-		IPAddress        *[]string `validate:"omitempty,min=2,max=2,dive,ipv4"`
-		NetworkMaskLen   *int      `validate:"omitempty,min=8,max=28"`
-		VRID             *int      `validate:"omitempty"`
+		IPAddress        *[]string `cli:"ip-addresses" validate:"omitempty,min=2,max=2,dive,ipv4"`
+		NetworkMaskLen   *int      `cli:"netmask,aliases=network-mask-len" validate:"omitempty,min=8,max=28"`
+		VRID             *int      `cli:"vrid" validate:"omitempty"`
 	} `cli:",squash"`
 
 	PeersData *string                     `cli:"peers" mapconv:"-"`

--- a/pkg/cmd/commands/localrouter/zz_create_gen.go
+++ b/pkg/cmd/commands/localrouter/zz_create_gen.go
@@ -45,8 +45,8 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Switch.Category, "switch-category", "", p.Switch.Category, "")
 	fs.StringVarP(&p.Switch.ZoneID, "switch-zone-id", "", p.Switch.ZoneID, "")
 	fs.StringVarP(&p.Interface.VirtualIPAddress, "virtual-ip-address", "", p.Interface.VirtualIPAddress, "")
-	fs.StringSliceVarP(&p.Interface.IPAddress, "ip-address", "", p.Interface.IPAddress, "")
-	fs.IntVarP(&p.Interface.NetworkMaskLen, "network-mask-len", "", p.Interface.NetworkMaskLen, "")
+	fs.StringSliceVarP(&p.Interface.IPAddress, "ip-addresses", "", p.Interface.IPAddress, "")
+	fs.IntVarP(&p.Interface.NetworkMaskLen, "netmask", "", p.Interface.NetworkMaskLen, "(aliases: --network-mask-len)")
 	fs.IntVarP(&p.Interface.VRID, "vrid", "", p.Interface.VRID, "")
 	fs.StringVarP(&p.PeersData, "peers", "", p.PeersData, "")
 	fs.StringVarP(&p.StaticRoutesData, "static-routes", "", p.StaticRoutesData, "")
@@ -61,6 +61,8 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "network-mask-len":
+		name = "netmask"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -84,8 +86,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("local-router", pflag.ContinueOnError)
 		fs.SortFlags = false
-		fs.AddFlag(cmd.LocalFlags().Lookup("ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("ip-addresses"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("peers"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("static-routes"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("switch-category"))

--- a/pkg/cmd/commands/localrouter/zz_update_gen.go
+++ b/pkg/cmd/commands/localrouter/zz_update_gen.go
@@ -49,10 +49,10 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("virtual-ip-address") {
 		p.Interface.VirtualIPAddress = nil
 	}
-	if !fs.Changed("ip-address") {
+	if !fs.Changed("ip-addresses") {
 		p.Interface.IPAddress = nil
 	}
-	if !fs.Changed("network-mask-len") {
+	if !fs.Changed("netmask") {
 		p.Interface.NetworkMaskLen = nil
 	}
 	if !fs.Changed("vrid") {
@@ -123,8 +123,8 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.Switch.Category, "switch-category", "", "", "")
 	fs.StringVarP(p.Switch.ZoneID, "switch-zone-id", "", "", "")
 	fs.StringVarP(p.Interface.VirtualIPAddress, "virtual-ip-address", "", "", "")
-	fs.StringSliceVarP(p.Interface.IPAddress, "ip-address", "", nil, "")
-	fs.IntVarP(p.Interface.NetworkMaskLen, "network-mask-len", "", 0, "")
+	fs.StringSliceVarP(p.Interface.IPAddress, "ip-addresses", "", nil, "")
+	fs.IntVarP(p.Interface.NetworkMaskLen, "netmask", "", 0, "(aliases: --network-mask-len)")
 	fs.IntVarP(p.Interface.VRID, "vrid", "", 0, "")
 	fs.StringVarP(p.PeersData, "peers", "", "", "")
 	fs.StringVarP(p.StaticRoutesData, "static-routes", "", "", "")
@@ -139,6 +139,8 @@ func (p *updateParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "network-mask-len":
+		name = "netmask"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -162,8 +164,8 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("local-router", pflag.ContinueOnError)
 		fs.SortFlags = false
-		fs.AddFlag(cmd.LocalFlags().Lookup("ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("ip-addresses"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("peers"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("static-routes"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("switch-category"))

--- a/pkg/cmd/commands/nfs/create.go
+++ b/pkg/cmd/commands/nfs/create.go
@@ -48,8 +48,8 @@ type createParameter struct {
 
 	SwitchID       types.ID `cli:",category=network,order=10" validate:"required"`
 	IPAddresses    []string `cli:"ip-address,aliases=ipaddress,category=network,order=20" validate:"required,min=1,max=2,dive,ipv4"`
-	NetworkMaskLen int      `cli:",category=network,order=30" validate:"required,min=1,max=32"`
-	DefaultRoute   string   `cli:",category=network,order=40" validate:"omitempty,ipv4"`
+	NetworkMaskLen int      `cli:"netmask,aliases=network-mask-len,category=network,order=30" validate:"required,min=1,max=32"`
+	DefaultRoute   string   `cli:"gateway,aliases=default-route,category=network,order=40" validate:"omitempty,ipv4"`
 
 	cflag.NoWaitParameter `cli:",squash" mapconv:",squash"`
 }

--- a/pkg/cmd/commands/nfs/zz_create_gen.go
+++ b/pkg/cmd/commands/nfs/zz_create_gen.go
@@ -47,8 +47,8 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.IntVarP(&p.Size, "size", "", p.Size, "")
 	fs.VarP(core.NewIDFlag(&p.SwitchID, &p.SwitchID), "switch-id", "", "")
 	fs.StringSliceVarP(&p.IPAddresses, "ip-address", "", p.IPAddresses, "(aliases: --ipaddress)")
-	fs.IntVarP(&p.NetworkMaskLen, "network-mask-len", "", p.NetworkMaskLen, "")
-	fs.StringVarP(&p.DefaultRoute, "default-route", "", p.DefaultRoute, "")
+	fs.IntVarP(&p.NetworkMaskLen, "netmask", "", p.NetworkMaskLen, "(aliases: --network-mask-len)")
+	fs.StringVarP(&p.DefaultRoute, "gateway", "", p.DefaultRoute, "(aliases: --default-route)")
 	fs.BoolVarP(&p.NoWait, "no-wait", "", p.NoWait, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
@@ -63,6 +63,10 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "format"
 	case "ipaddress":
 		name = "ip-address"
+	case "network-mask-len":
+		name = "netmask"
+	case "default-route":
+		name = "gateway"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -99,8 +103,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("switch-id"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("network-mask-len"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("netmask"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("gateway"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Network options",
 			Flags: fs,

--- a/pkg/cmd/commands/server/zz_create_gen.go
+++ b/pkg/cmd/commands/server/zz_create_gen.go
@@ -51,7 +51,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&p.BootAfterCreate, "boot-after-create", "", p.BootAfterCreate, "")
 	fs.VarP(core.NewIDFlag(&p.CDROMID, &p.CDROMID), "cdrom-id", "", "(aliases: --iso-image-id)")
 	fs.VarP(core.NewIDFlag(&p.PrivateHostID, &p.PrivateHostID), "private-host-id", "", "")
-	fs.StringVarP(&p.NetworkInterface.Upstream, "network-interface-upstream", "", p.NetworkInterface.Upstream, "")
+	fs.StringVarP(&p.NetworkInterface.Upstream, "network-interface-upstream", "", p.NetworkInterface.Upstream, "options: [shared/disconnected/(switch-id)]")
 	fs.VarP(core.NewIDFlag(&p.NetworkInterface.PacketFilterID, &p.NetworkInterface.PacketFilterID), "network-interface-packet-filter-id", "", "")
 	fs.StringVarP(&p.NetworkInterface.UserIPAddress, "network-interface-user-ip-address", "", p.NetworkInterface.UserIPAddress, "")
 	fs.StringVarP(&p.NetworkInterfaceData, "network-interfaces", "", p.NetworkInterfaceData, "")
@@ -71,8 +71,8 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Disk.EditDisk.HostName, "disk-edit-host-name", "", p.Disk.EditDisk.HostName, "")
 	fs.StringVarP(&p.Disk.EditDisk.Password, "disk-edit-password", "", p.Disk.EditDisk.Password, "")
 	fs.StringVarP(&p.Disk.EditDisk.IPAddress, "disk-edit-ip-address", "", p.Disk.EditDisk.IPAddress, "")
-	fs.IntVarP(&p.Disk.EditDisk.NetworkMaskLen, "disk-edit-network-mask-len", "", p.Disk.EditDisk.NetworkMaskLen, "")
-	fs.StringVarP(&p.Disk.EditDisk.DefaultRoute, "disk-edit-default-route", "", p.Disk.EditDisk.DefaultRoute, "")
+	fs.IntVarP(&p.Disk.EditDisk.NetworkMaskLen, "disk-edit-netmask", "", p.Disk.EditDisk.NetworkMaskLen, "(aliases: --network-mask-len)")
+	fs.StringVarP(&p.Disk.EditDisk.DefaultRoute, "disk-edit-gateway", "", p.Disk.EditDisk.DefaultRoute, "(aliases: --default-route)")
 	fs.BoolVarP(&p.Disk.EditDisk.DisablePWAuth, "disk-edit-disable-pw-auth", "", p.Disk.EditDisk.DisablePWAuth, "")
 	fs.BoolVarP(&p.Disk.EditDisk.EnableDHCP, "disk-edit-enable-dhcp", "", p.Disk.EditDisk.EnableDHCP, "")
 	fs.BoolVarP(&p.Disk.EditDisk.ChangePartitionUUID, "disk-edit-change-partition-uuid", "", p.Disk.EditDisk.ChangePartitionUUID, "")
@@ -103,6 +103,10 @@ func (p *createParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "cdrom-id"
 	case "size-gb":
 		name = "disk-size"
+	case "network-mask-len":
+		name = "disk-edit-netmask"
+	case "default-route":
+		name = "disk-edit-gateway"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -180,8 +184,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-host-name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-password"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-ip-address"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-network-mask-len"))
-		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-netmask"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-gateway"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-disable-pw-auth"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-enable-dhcp"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("disk-edit-change-partition-uuid"))
@@ -264,9 +268,10 @@ func (p *createParameter) setCompletionFunc(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("commitment", util.FlagCompletionFunc("standard", "dedicatedcpu"))
 	cmd.RegisterFlagCompletionFunc("generation", util.FlagCompletionFunc("default", "g100", "g200"))
 	cmd.RegisterFlagCompletionFunc("interface-driver", util.FlagCompletionFunc("virtio", "e1000"))
+	cmd.RegisterFlagCompletionFunc("network-interface-upstream", util.FlagCompletionFunc("shared", "disconnected"))
 	cmd.RegisterFlagCompletionFunc("disk-disk-plan", util.FlagCompletionFunc("ssd", "hdd"))
 	cmd.RegisterFlagCompletionFunc("disk-connection", util.FlagCompletionFunc("virtio", "ide"))
-	cmd.RegisterFlagCompletionFunc("disk-os-type", util.FlagCompletionFunc("centos", "centos8", "ubuntu", "ubuntu2004", "debian", "debian10", "coreos", "rancheros", "k3os", "freebsd", "..."))
+	cmd.RegisterFlagCompletionFunc("disk-os-type", util.FlagCompletionFunc("centos", "centos8", "centos7", "ubuntu", "ubuntu2004", "ubuntu1804", "ubuntu1604", "debian", "debian10", "debian9", "coreos", "rancheros", "k3os", "kusanagi", "freebsd", "windows2016", "windows2016-rds", "windows2016-rds-office", "windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all", "windows2016-sql2017-standard", "windows2016-sql2017-enterprise", "windows2016-sql2017-standard-all", "windows2019", "windows2019-rds", "windows2019-rds-office2019", "windows2019-sql2017-web", "windows2019-sql2019-web", "windows2019-sql2017-standard", "windows2019-sql2019-standard", "windows2019-sql2017-enterprise", "windows2019-sql2019-enterprise", "windows2019-sql2017-standard-all", "windows2019-sql2019-standard-all"))
 
 }
 

--- a/pkg/cmd/commands/swytch/update.go
+++ b/pkg/cmd/commands/swytch/update.go
@@ -45,7 +45,7 @@ type updateParameter struct {
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
 	NetworkMaskLen *int    `cli:"display-network-mask-len"`
-	DefaultRoute   *string `cli:"display-default-route"`
+	DefaultRoute   *string `cli:"display-gateway,aliases=display-default-route"`
 }
 
 func newUpdateParameter() *updateParameter {

--- a/pkg/cmd/commands/swytch/zz_update_gen.go
+++ b/pkg/cmd/commands/swytch/zz_update_gen.go
@@ -40,7 +40,7 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("display-network-mask-len") {
 		p.NetworkMaskLen = nil
 	}
-	if !fs.Changed("display-default-route") {
+	if !fs.Changed("display-gateway") {
 		p.DefaultRoute = nil
 	}
 }
@@ -79,7 +79,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
 	fs.IntVarP(p.NetworkMaskLen, "display-network-mask-len", "", 0, "")
-	fs.StringVarP(p.DefaultRoute, "display-default-route", "", "", "")
+	fs.StringVarP(p.DefaultRoute, "display-gateway", "", "", "(aliases: --display-default-route)")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 
@@ -91,6 +91,8 @@ func (p *updateParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag
 		name = "output-type"
 	case "fmt":
 		name = "format"
+	case "display-default-route":
+		name = "display-gateway"
 	}
 	return pflag.NormalizedName(name)
 }
@@ -114,7 +116,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("switch", pflag.ContinueOnError)
 		fs.SortFlags = false
-		fs.AddFlag(cmd.LocalFlags().Lookup("display-default-route"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("display-gateway"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("display-network-mask-len"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Switch-specific options",

--- a/tools/clitag/parse_tag.go
+++ b/tools/clitag/parse_tag.go
@@ -21,13 +21,14 @@ import (
 )
 
 const (
-	aliasesKey   = "aliases"
-	shortHandKey = "short"
-	descKey      = "desc"
-	squashKey    = "squash"
-	categoryKey  = "category"
-	orderKey     = "order"
-	optionsKey   = "options"
+	aliasesKey        = "aliases"
+	shortHandKey      = "short"
+	descKey           = "desc"
+	squashKey         = "squash"
+	categoryKey       = "category"
+	orderKey          = "order"
+	optionsKey        = "options"
+	displayOptionsKey = "display_options"
 )
 
 func (p *Parser) parseTag(t string) (Tag, error) {
@@ -96,6 +97,16 @@ func (p *Parser) parseTag(t string) (Tag, error) {
 					}
 					// 登録済みでなければキーをそのまま登録
 					tag.Options = append(tag.Options, o)
+				}
+			case displayOptionsKey:
+				options := strings.Split(val, " ")
+				for _, o := range options {
+					if registered, ok := p.Config.OptionsMap[o]; ok {
+						tag.DisplayOptions = append(tag.DisplayOptions, registered...)
+						continue
+					}
+					// 登録済みでなければキーをそのまま登録
+					tag.DisplayOptions = append(tag.DisplayOptions, o)
 				}
 			default:
 				return tag, fmt.Errorf("got invalid tag key: %q", token)

--- a/tools/clitag/types.go
+++ b/tools/clitag/types.go
@@ -38,16 +38,17 @@ type StructField struct {
 // - Category: (empty)
 // - Order: 0
 type Tag struct {
-	FlagName    string
-	FieldName   string
-	Aliases     []string
-	Shorthand   string
-	Description string
-	Squash      bool
-	Ignore      bool
-	Category    string
-	Order       int
-	Options     []string // 設定可能な値のリスト
+	FlagName       string
+	FieldName      string
+	Aliases        []string
+	Shorthand      string
+	Description    string
+	Squash         bool
+	Ignore         bool
+	Category       string
+	Order          int
+	Options        []string // 設定可能な値のリスト
+	DisplayOptions []string // 表示用
 }
 
 // LongDescription DescriptionにAliasesとOptionsを連結して返す
@@ -89,5 +90,9 @@ func (t Tag) OptionsString() string {
 		return ""
 	}
 
-	return fmt.Sprintf("options: [%s]", strings.Join(t.Options, "/"))
+	options := t.Options
+	if len(t.DisplayOptions) > 0 {
+		options = t.DisplayOptions
+	}
+	return fmt.Sprintf("options: [%s]", strings.Join(options, "/"))
 }


### PR DESCRIPTION
closes #675 #502 

定義類の見直し

- Terraformと項目名を揃える
- DescriptionをTerraformから移植(将来的にlibsacloud側に定義を移行する)

### 主な修正内容

- `network-mask-len` => `netmask`
- `default-route` => `gateway`

※修正前のものもエイリアスとして残しておく

#### 修正しなかったもの

- `network-interface`: Terraformでは`network_interface`ブロックがあったが、Usacloudでは必要な箇所を除き省略している(トップレベルに`--ip-address`や`--netmask`がある)
