### PR TITLE
Fixes reading profile error when running on WASM

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,6 +65,10 @@ build: bin/usacloud
 bin/usacloud: $(GO_FILES)
 	OS="`go env GOOS`" ARCH="`go env GOARCH`" ARCHIVE= BUILD_LDFLAGS=$(BUILD_LDFLAGS) sh -c "'$(CURDIR)/scripts/build.sh'"
 
+build-wasm: bin/usacloud.wasm
+bin/usacloud.wasm: $(GO_FILES)
+	OS="js" ARCH="wasm" ARCHIVE= BUILD_LDFLAGS=$(BUILD_LDFLAGS) sh -c "'$(CURDIR)/scripts/build.sh'"
+
 build-x: build-darwin build-windows build-linux build-bsd
 
 build-darwin: bin/usacloud_darwin-amd64.zip

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -151,31 +151,6 @@ func (o *Config) loadFromEnv() {
 	}
 }
 
-func (o *Config) loadFromProfile(flags *pflag.FlagSet, errW io.Writer) {
-	if flags.Changed("profile") {
-		v, err := flags.GetString("profile")
-		if err != nil {
-			fmt.Fprintf(errW, "[WARN] reading value of %q flag is failed: %s", "profile", err) // nolint
-			return
-		}
-		o.Profile = v
-	}
-
-	profileName := o.Profile
-	if profileName == "" {
-		current, err := profile.CurrentName()
-		if err != nil {
-			fmt.Fprintf(errW, "[WARN] loading profile %q is failed: %s", profileName, err) // nolint
-			return
-		}
-		profileName = current
-	}
-	if err := profile.Load(profileName, o); err != nil {
-		fmt.Fprintf(errW, "[WARN] loading profile %q is failed: %s", profileName, err) // nolint
-		return
-	}
-}
-
 func (o *Config) loadFromFlags(flags *pflag.FlagSet, errW io.Writer) {
 	if flags.Changed("token") {
 		v, err := flags.GetString("token")

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -1,0 +1,50 @@
+// Copyright 2017-2020 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !wasm
+
+package config
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/profile"
+	"github.com/spf13/pflag"
+)
+
+func (o *Config) loadFromProfile(flags *pflag.FlagSet, errW io.Writer) {
+	if flags.Changed("profile") {
+		v, err := flags.GetString("profile")
+		if err != nil {
+			fmt.Fprintf(errW, "[WARN] reading value of %q flag is failed: %s", "profile", err) // nolint
+			return
+		}
+		o.Profile = v
+	}
+
+	profileName := o.Profile
+	if profileName == "" {
+		current, err := profile.CurrentName()
+		if err != nil {
+			fmt.Fprintf(errW, "[WARN] loading profile %q is failed: %s", profileName, err) // nolint
+			return
+		}
+		profileName = current
+	}
+	if err := profile.Load(profileName, o); err != nil {
+		fmt.Fprintf(errW, "[WARN] loading profile %q is failed: %s", profileName, err) // nolint
+		return
+	}
+}

--- a/pkg/config/profile_wasm.go
+++ b/pkg/config/profile_wasm.go
@@ -1,0 +1,27 @@
+// Copyright 2017-2020 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build wasm
+
+package config
+
+import (
+	"io"
+
+	"github.com/spf13/pflag"
+)
+
+func (o *Config) loadFromProfile(flags *pflag.FlagSet, errW io.Writer) {
+	// noop
+}


### PR DESCRIPTION
fixes #523 

プロファイル読み込み部分でエラー(`"getent": executable file not found in $PATH`)となっていた問題を修正。

WASMではプロファイル読み込みを行わないようにする。
現状だと`--profile`フラグなどが残っているが指定しても無視される。
v1.1以降でフラグ定義もビルドタグで切り替えるようにする。