### PR TITLE
Supports wasm-terminal

### DIFF
--- a/pkg/term/terminal_wasm.go
+++ b/pkg/term/terminal_wasm.go
@@ -1,4 +1,4 @@
-// +build !wasm
+// +build wasm
 
 // Copyright 2017-2020 The Usacloud Authors
 //
@@ -16,16 +16,8 @@
 
 package term
 
-import (
-	"os"
-
-	"github.com/mattn/go-isatty"
-)
-
 // IsTerminal 標準入力/出力が端末か判定する
 func IsTerminal() bool {
-	is := func(fd uintptr) bool {
-		return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
-	}
-	return is(os.Stdin.Fd()) && is(os.Stdout.Fd())
+	// Note: usacon(github.com/sacloud/usacon)向けにtrueを返しておく
+	return true
 }

--- a/pkg/util/confirm.go
+++ b/pkg/util/confirm.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -39,11 +40,10 @@ func Confirm(msg string, in In, out io.Writer) (bool, error) {
 		return false, err
 	}
 
-	var input string
-	_, err = fmt.Fscanln(in, &input)
-	if err != nil {
-		return false, err
-	}
+	scanner := bufio.NewScanner(in)
+	scanner.Scan()
+	input := scanner.Text()
+
 	return input == "y" || input == "yes", nil
 }
 

--- a/pkg/util/io.go
+++ b/pkg/util/io.go
@@ -1,5 +1,3 @@
-// +build !wasm
-
 // Copyright 2017-2020 The Usacloud Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package term
+package util
 
-import (
-	"os"
+import "os"
 
-	"github.com/mattn/go-isatty"
-)
-
-// IsTerminal 標準入力/出力が端末か判定する
-func IsTerminal() bool {
-	is := func(fd uintptr) bool {
-		return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+// FileOrStdin ファイルパス、または標準入力をオープンする
+//
+// pathに空文字または"-"を指定した場合に標準入力が利用される
+func FileOrStdin(path string) (file *os.File, deferFunc func(), err error) {
+	if path == "" || path == "-" {
+		file = os.Stdin
+		deferFunc = func() {}
+	} else {
+		file, err = os.Open(path)
+		if err != nil {
+			return
+		}
+		deferFunc = func() {
+			file.Close() // nolint
+		}
 	}
-	return is(os.Stdin.Fd()) && is(os.Stdout.Fd())
+	return
 }


### PR DESCRIPTION
closes #728 

[usacon](https://github.com/sacloud/usacon)で使用しているwasm-terminalでの対話入力をサポートする。

Note: `term.IsTerminal()`でGOARCHがwasmの場合は常にtrueを返す実装にしているがusacon以外で使用する際に問題になるかもしれない。現状ではusacon以外の環境は想定していないためこの実装としている。