### PR TITLE
Ignore some commands for WASM

### DIFF
--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sacloud/usacloud/pkg/cmd/commands/bill"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/bridge"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/cdrom"
-	"github.com/sacloud/usacloud/pkg/cmd/commands/config"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/containerregistry"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/coupon"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/database"
@@ -51,7 +50,6 @@ import (
 	"github.com/sacloud/usacloud/pkg/cmd/commands/proxylb"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/region"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/rest"
-	"github.com/sacloud/usacloud/pkg/cmd/commands/self"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/server"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/serverplan"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/serviceclass"
@@ -114,9 +112,7 @@ var Resources = core.Resources{
 	vpcrouter.Resource,
 	zone.Resource,
 	// libsacloud service以外のマニュアル実装分
-	config.Resource,
 	rest.Resource,
-	self.Resource,
 	webaccelerator.Resource,
 }
 

--- a/pkg/cmd/resources_other.go
+++ b/pkg/cmd/resources_other.go
@@ -1,0 +1,29 @@
+// Copyright 2017-2020 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !wasm
+
+package cmd
+
+import (
+	"github.com/sacloud/usacloud/pkg/cmd/commands/config"
+	"github.com/sacloud/usacloud/pkg/cmd/commands/self"
+)
+
+func init() {
+	Resources = append(Resources,
+		config.Resource,
+		self.Resource,
+	)
+}


### PR DESCRIPTION
from #727 

`GOOS=js GOARCH=wasm`時にいくつかのコマンドを無効にする。

- `config`
- `self`

#724 ではサブコマンド単位でWASMでの無効化を行ったが、このPRではリソースごと無効にしている。

### 実行例

```sh
$ `go env GOROOT`/misc/wasm/go_js_wasm_exec usacloud -v
1.0.0-dev js/wasm, build ed6fdbdd

$ `go env GOROOT`/misc/wasm/go_js_wasm_exec usacloud -h
CLI to manage to resources on the SAKURA Cloud

Usage:
  usacloud [global options] <command> <sub-command> [options] [arguments] [flags]
  usacloud [command]

Available Commands:
 === Authentication ===
    auth-status        

 === Computing ===
    private-host       
    server             

 === Storage ===
    archive            
    auto-backup        
    cdrom              
    disk               

 === Networking ===
    bridge             
    interface          
    internet           
    ipaddress          
    ipv6addr           
    ipv6net            
    local-router       
    packet-filter      
    subnet             
    switch             

 === Appliance ===
    database           
    load-balancer      
    mobile-gateway     
    nfs                
    vpc-router         

 === Common service items ===
    dns                
    gslb               
    proxy-lb           
    simple-monitor     

 === Billing ===
    bill               

 === Other services ===
    coupon             
    icon               
    license            
    note               
    region             
    ssh-key            
    zone               
    rest               
    web-accelerator    

 === Service/Product informations ===
    disk-plan          
    internet-plan      
    license-info       
    private-host-plan  
    server-plan        
    service-class      

Flags:
      --profile string            the name of saved credentials
      --token string              the API token used when calling SAKURA Cloud API
      --secret string             the API secret used when calling SAKURA Cloud API
      --zones strings             permitted zone names
      --no-color                  disable ANSI color output
      --trace                     enable trace logs for API calling
      --fake                      enable fake API driver
      --fake-store string         path to file store used by the fake API driver
      --process-timeout-sec int   number of seconds before the command execution is timed out
  -v, --version                   show version info
  -h, --help                      help for usacloud

Use "usacloud [command] --help" for more information about a command.

Copyright 2017-2020 The Usacloud Authors
```