### PR TITLE
Remove macos-11.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, macos-11.0, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-10.15, windows-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
CIのパフォーマンス低下が続いているため、GitHub Actionsでのテスト対象から一時的に`macos-11.0`を外す。

Previewが外れたら再度追加する。

https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources