### PR TITLE
Resource categories

### DIFF
--- a/pkg/cmd/commands/coupon/resource.go
+++ b/pkg/cmd/commands/coupon/resource.go
@@ -24,7 +24,7 @@ import (
 var Resource = &core.Resource{
 	Name:               "coupon",
 	ServiceType:        reflect.TypeOf(&coupon.Service{}),
-	Category:           core.ResourceCategoryOther,
+	Category:           core.ResourceCategoryBilling,
 	IsGlobalResource:   true,
 	DefaultCommandName: "list",
 }

--- a/pkg/cmd/commands/icon/resource.go
+++ b/pkg/cmd/commands/icon/resource.go
@@ -24,6 +24,6 @@ import (
 var Resource = &core.Resource{
 	Name:             "icon",
 	ServiceType:      reflect.TypeOf(&icon.Service{}),
-	Category:         core.ResourceCategoryOther,
+	Category:         core.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/cmd/commands/iface/resource.go
+++ b/pkg/cmd/commands/iface/resource.go
@@ -25,5 +25,5 @@ var Resource = &core.Resource{
 	Name:        "interface",
 	Aliases:     []string{"iface"},
 	ServiceType: reflect.TypeOf(&iface.Service{}),
-	Category:    core.ResourceCategoryNetworking,
+	Category:    core.ResourceCategoryNetworkingSub,
 }

--- a/pkg/cmd/commands/ipaddress/resource.go
+++ b/pkg/cmd/commands/ipaddress/resource.go
@@ -25,5 +25,5 @@ var Resource = &core.Resource{
 	Name:        "ipaddress",
 	Aliases:     []string{"ip-address"},
 	ServiceType: reflect.TypeOf(&ipaddress.Service{}),
-	Category:    core.ResourceCategoryNetworking,
+	Category:    core.ResourceCategoryNetworkingSub,
 }

--- a/pkg/cmd/commands/ipv6addr/resource.go
+++ b/pkg/cmd/commands/ipv6addr/resource.go
@@ -24,5 +24,5 @@ import (
 var Resource = &core.Resource{
 	Name:        "ipv6addr",
 	ServiceType: reflect.TypeOf(&ipv6addr.Service{}),
-	Category:    core.ResourceCategoryNetworking,
+	Category:    core.ResourceCategoryNetworkingSub,
 }

--- a/pkg/cmd/commands/ipv6net/resource.go
+++ b/pkg/cmd/commands/ipv6net/resource.go
@@ -24,5 +24,5 @@ import (
 var Resource = &core.Resource{
 	Name:        "ipv6net",
 	ServiceType: reflect.TypeOf(&ipv6net.Service{}),
-	Category:    core.ResourceCategoryNetworking,
+	Category:    core.ResourceCategoryNetworkingSub,
 }

--- a/pkg/cmd/commands/license/resource.go
+++ b/pkg/cmd/commands/license/resource.go
@@ -24,6 +24,6 @@ import (
 var Resource = &core.Resource{
 	Name:             "license",
 	ServiceType:      reflect.TypeOf(&license.Service{}),
-	Category:         core.ResourceCategoryOther,
+	Category:         core.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/cmd/commands/note/resource.go
+++ b/pkg/cmd/commands/note/resource.go
@@ -25,6 +25,6 @@ var Resource = &core.Resource{
 	Name:             "note",
 	Aliases:          []string{"startup-script"},
 	ServiceType:      reflect.TypeOf(&note.Service{}),
-	Category:         core.ResourceCategoryOther,
+	Category:         core.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/cmd/commands/region/resource.go
+++ b/pkg/cmd/commands/region/resource.go
@@ -26,5 +26,5 @@ var Resource = &core.Resource{
 	Aliases:          []string{"regions"},
 	ServiceType:      reflect.TypeOf(&region.Service{}),
 	IsGlobalResource: true,
-	Category:         core.ResourceCategoryOther,
+	Category:         core.ResourceCategoryZone,
 }

--- a/pkg/cmd/commands/sshkey/resource.go
+++ b/pkg/cmd/commands/sshkey/resource.go
@@ -25,6 +25,6 @@ var Resource = &core.Resource{
 	Name:             "ssh-key",
 	Aliases:          []string{"sshkey"},
 	ServiceType:      reflect.TypeOf(&sshkey.Service{}),
-	Category:         core.ResourceCategoryOther,
+	Category:         core.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/cmd/commands/subnet/resource.go
+++ b/pkg/cmd/commands/subnet/resource.go
@@ -24,5 +24,5 @@ import (
 var Resource = &core.Resource{
 	Name:        "subnet",
 	ServiceType: reflect.TypeOf(&subnet.Service{}),
-	Category:    core.ResourceCategoryNetworking,
+	Category:    core.ResourceCategoryNetworkingSub,
 }

--- a/pkg/cmd/commands/webaccelerator/resource.go
+++ b/pkg/cmd/commands/webaccelerator/resource.go
@@ -24,7 +24,7 @@ var Resource = &core.Resource{
 	Name:             "web-accelerator",
 	Aliases:          []string{"web-accel", "webaccel"},
 	IsGlobalResource: true,
-	Category:         core.ResourceCategoryOther,
+	Category:         core.ResourceCategoryWebAccel,
 }
 
 func listAllFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {

--- a/pkg/cmd/commands/zone/resource.go
+++ b/pkg/cmd/commands/zone/resource.go
@@ -26,5 +26,5 @@ var Resource = &core.Resource{
 	Aliases:          []string{"zones"},
 	ServiceType:      reflect.TypeOf(&zone.Service{}),
 	IsGlobalResource: true,
-	Category:         core.ResourceCategoryOther,
+	Category:         core.ResourceCategoryZone,
 }

--- a/pkg/cmd/core/resource_categories.go
+++ b/pkg/cmd/core/resource_categories.go
@@ -18,88 +18,102 @@ var (
 	ResourceCategoryConfig = Category{
 		Key:         "config",
 		DisplayName: "Configuration",
-		Order:       3,
+		Order:       10,
 	}
+
 	ResourceCategoryAuth = Category{
 		Key:         "auth",
 		DisplayName: "Authentication",
-		Order:       5,
+		Order:       20,
 	}
+
 	ResourceCategoryComputing = Category{
 		Key:         "computing",
 		DisplayName: "Computing",
-		Order:       10,
+		Order:       30,
 	}
 
 	ResourceCategoryStorage = Category{
 		Key:         "storage",
 		DisplayName: "Storage",
-		Order:       20,
+		Order:       40,
 	}
 
 	ResourceCategoryNetworking = Category{
 		Key:         "networking",
 		DisplayName: "Networking",
-		Order:       30,
+		Order:       50,
+	}
+
+	ResourceCategoryNetworkingSub = Category{
+		Key:         "networking-sub",
+		DisplayName: "Networking(SubResources)",
+		Order:       55,
 	}
 
 	ResourceCategoryAppliance = Category{
 		Key:         "appliance",
 		DisplayName: "Appliance",
-		Order:       40,
+		Order:       60,
 	}
 
 	ResourceCategorySecureMobile = Category{
 		Key:         "securemobile",
 		DisplayName: "SecureMobile",
-		Order:       45,
+		Order:       70,
 	}
 	ResourceCategoryCommonServiceItem = Category{
 		Key:         "commonserviceitem",
 		DisplayName: "Common service items",
-		Order:       50,
+		Order:       80,
 	}
 
 	ResourceCategoryCommonItem = Category{
 		Key:         "commonitem",
 		DisplayName: "Common items",
-		Order:       60,
+		Order:       90,
 	}
 
 	ResourceCategoryBilling = Category{
 		Key:         "billing",
 		DisplayName: "Billing",
-		Order:       70,
-	}
-
-	ResourceCategoryCoupon = Category{
-		Key:         "coupon",
-		DisplayName: "Coupon",
-		Order:       75,
+		Order:       100,
 	}
 
 	ResourceCategoryLab = Category{
 		Key:         "lab",
 		DisplayName: "Lab",
-		Order:       78,
+		Order:       110,
 	}
 
-	ResourceCategoryOther = Category{
+	ResourceCategoryWebAccel = Category{
+		Key:         "webaccel",
+		DisplayName: "WebAccelerator",
+		Order:       120,
+	}
+
+	ResourceCategoryMisc = Category{
 		Key:         "misc",
 		DisplayName: "Other services",
-		Order:       80,
+		Order:       130,
+	}
+
+	ResourceCategoryZone = Category{
+		Key:         "zone",
+		DisplayName: "Region/Zone information",
+		Order:       140,
 	}
 
 	ResourceCategoryInformation = Category{
 		Key:         "information",
-		DisplayName: "Service/Product informations",
-		Order:       90,
+		DisplayName: "Service/Product information",
+		Order:       150,
 	}
 
-	ResourceCategorySummary = Category{
-		Key:         "summary",
-		DisplayName: "Summary",
-		Order:       100,
+	ResourceCategoryOther = Category{
+		Key:         "other",
+		DisplayName: "Other commands",
+		Order:       160,
 	}
 
 	ResourceCategories = []Category{
@@ -108,13 +122,14 @@ var (
 		ResourceCategoryComputing,
 		ResourceCategoryStorage,
 		ResourceCategoryNetworking,
+		ResourceCategoryNetworkingSub,
 		ResourceCategoryAppliance,
 		ResourceCategoryCommonServiceItem,
 		ResourceCategoryCommonItem,
 		ResourceCategoryBilling,
-		ResourceCategoryCoupon,
-		ResourceCategoryOther,
+		ResourceCategoryMisc,
+		ResourceCategoryZone,
 		ResourceCategoryInformation,
-		ResourceCategorySummary,
+		ResourceCategoryOther,
 	}
 )


### PR DESCRIPTION
リソースのカテゴリーを整理する。

```console
$ usacloud -h

CLI to manage to resources on the SAKURA Cloud

Usage:
  usacloud [global options] <command> <sub-command> [options] [arguments] [flags]
  usacloud [command]

Available Commands:
 === Configuration ===
    config             

 === Authentication ===
    auth-status        

 === Computing ===
    private-host       
    server             

 === Storage ===
    archive            
    auto-backup        
    cdrom              
    disk               

 === Networking ===
    bridge             
    internet           
    local-router       
    packet-filter      
    switch             

 === Networking(SubResources) ===
    interface          
    ipaddress          
    ipv6addr           
    ipv6net            
    subnet             

 === Appliance ===
    database           
    load-balancer      
    mobile-gateway     
    nfs                
    vpc-router         

 === Common service items ===
    dns                
    gslb               
    proxy-lb           
    simple-monitor     

 === Billing ===
    bill               
    coupon             

 === Other services ===
    icon               
    license            
    note               
    ssh-key            

 === Region/Zone information ===
    region             
    zone               

 === Service/Product information ===
    disk-plan          
    internet-plan      
    license-info       
    private-host-plan  
    server-plan        
    service-class      

 === Other commands ===
    rest               
    self               

```