### PR TITLE
Commands: set default command to 'edit'

### DIFF
--- a/pkg/cmd/commands/config/resource.go
+++ b/pkg/cmd/commands/config/resource.go
@@ -21,7 +21,7 @@ import (
 var Resource = &core.Resource{
 	Name:               "config",
 	Aliases:            []string{"profile"},
-	DefaultCommandName: "show",
+	DefaultCommandName: "edit",
 	Category:           core.ResourceCategoryConfig,
 	IsGlobalResource:   true,
 	SkipLoadingProfile: true,


### PR DESCRIPTION
v0との互換性維持のために`usacloud config`でのデフォルトコマンドを`edit`に変更する。

```bash
$ usacloud config

# 以下と同等
$ usacloud config edit
$ usacloud config edit `usacloud config current`
```