### PR TITLE
Re-parse flags after processing --parameters flag

### DIFF
--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -290,7 +290,7 @@ func (c *Command) initCommandContext(cmd *cobra.Command, args []string) (cli.Con
 	c.completeParameterValue(cmd, ctx, c.currentParameter)
 
 	// パラメータファイルの処理やスケルトン出力など
-	needContinue, err := c.handleCommonParameters(ctx)
+	needContinue, err := c.handleCommonParameters(ctx, cmd)
 	if needContinue {
 		needContinue, err = c.handleExampleParameters(ctx)
 	}
@@ -318,14 +318,14 @@ func (c *Command) printCommandWarning(ctx cli.Context) {
 	}
 }
 
-func (c *Command) handleCommonParameters(ctx cli.Context) (bool, error) {
+func (c *Command) handleCommonParameters(ctx cli.Context, cmd *cobra.Command) (bool, error) {
 	if cp, ok := c.currentParameter.(cflag.CommonParameterValueHolder); ok {
 		// パラメータスケルトンの生成
 		if cp.GenerateSkeletonFlagValue() {
 			return false, generateSkeleton(ctx, c.currentParameter)
 		}
 		// --parameters/--parameter-fileフラグの処理
-		if err := loadParameters(cp); err != nil {
+		if err := loadParameters(ctx, cmd, cp); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/cmd/core/parameter_loader.go
+++ b/pkg/cmd/core/parameter_loader.go
@@ -16,12 +16,16 @@ package core
 
 import (
 	"encoding/json"
+	"os"
+
+	"github.com/sacloud/usacloud/pkg/cli"
+	"github.com/spf13/cobra"
 
 	"github.com/sacloud/usacloud/pkg/cmd/cflag"
 	"github.com/sacloud/usacloud/pkg/util"
 )
 
-func loadParameters(parameters cflag.CommonParameterValueHolder) error {
+func loadParameters(ctx cli.Context, cmd *cobra.Command, parameters cflag.CommonParameterValueHolder) error {
 	p := parameters.ParametersFlagValue()
 
 	if p == "" {
@@ -32,5 +36,20 @@ func loadParameters(parameters cflag.CommonParameterValueHolder) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, parameters)
+	if err := json.Unmarshal(data, parameters); err != nil {
+		return nil
+	}
+
+	// os.Argsを元にもう一度フラグをパースする
+	// 参照: cobra.Command#ExecuteC
+	var flags []string
+	if cmd.TraverseChildren {
+		_, flags, err = cmd.Traverse(os.Args[1:])
+	} else {
+		_, flags, err = cmd.Find(os.Args[1:])
+	}
+	if err != nil {
+		return err
+	}
+	return cmd.ParseFlags(flags)
 }


### PR DESCRIPTION
fixes #750 

`--parameters`の処理を行った後でフラグのパースを再度行うことでフラグの値を優先させる。