### PR TITLE
Release only when tagged as vN.N.N

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: 'v[0-9]+.[0-9]+.[0-9]+*'
+    tags: 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   GOPROXY: https://proxy.golang.org


### PR DESCRIPTION
fixes #753 

GoReleaserでのリリースを`vN.N.N`形式のタグが打たれた時だけにする。
alpha/beta/rc版のリリースができないが手動で対応する。

またDockerイメージのリリースについてはこれまで通り`vN.N.N*`で行うようにする。