### PR TITLE
Show completion command on help

### DIFF
--- a/pkg/cmd/core/usage.go
+++ b/pkg/cmd/core/usage.go
@@ -45,6 +45,12 @@ func buildRootCommandUsages(rootCmd *cobra.Command, resources []*Resource) strin
 			usages = append(usages, fmt.Sprintf(line, name, cmd.Short))
 		}
 	}
+	// completionを追加
+	if cmd := lookupCmd(rootCmd, "completion"); cmd != nil {
+		t := fmt.Sprintf("%%-%ds", cmd.NamePadding())
+		name := fmt.Sprintf(t, cmd.Name())
+		usages = append(usages, fmt.Sprintf(line, name, cmd.Short))
+	}
 	return strings.TrimRight(strings.Join(usages, "\n"), "\n")
 }
 


### PR DESCRIPTION
`usacloud completion`コマンドがヘルプでの一覧表示に表示されない問題を修正

```console
$ usacloud -h
CLI to manage to resources on the SAKURA Cloud

Usage:
  usacloud [global options] <command> <sub-command> [options] [arguments] [flags]
  usacloud [command]

Available Commands:
 [...略...]
 === Other commands ===
    rest               
    self               
    completion         Generate completion script

Copyright 2017-2020 The Usacloud Authors
```

```console
$ usacloud completion -h

To load completions:

Bash:

$ source <(usacloud completion bash)

# To load completions for each session, execute once:
Linux:
  $ usacloud completion bash > /etc/bash_completion.d/usacloud
MacOS:
  $ usacloud completion bash > /usr/local/etc/bash_completion.d/usacloud

Zsh:

# If shell completion is not already enabled in your environment you will need
# to enable it.  You can execute the following once:

$ echo "autoload -U compinit; compinit" >> ~/.zshrc

# To load completions for each session, execute once:
$ usacloud completion zsh > "${fpath[1]}/_usacloud"

# You will need to start a new shell for this setup to take effect.

Fish:

$ usacloud completion fish | source

# To load completions for each session, execute once:
$ usacloud completion fish > ~/.config/fish/completions/usacloud.fish

Usage:
  usacloud completion [bash|zsh|fish|powershell]

Flags:
  -h, --help   help for completion
```