### PR TITLE
Added GOOS/GOARCH into User-Agent string

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -16,20 +16,17 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
 
-	"github.com/sacloud/libsacloud/v2"
 	"github.com/sacloud/libsacloud/v2/helper/api"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/usacloud/pkg/config"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/validate"
-	"github.com/sacloud/usacloud/pkg/version"
 	"github.com/spf13/pflag"
 )
 
@@ -152,7 +149,7 @@ func (c *cliContext) Client() sacloud.APICaller {
 		RetryMax:             o.RetryMax,
 		RetryWaitMax:         o.RetryWaitMax,
 		RetryWaitMin:         o.RetryWaitMin,
-		UserAgent:            fmt.Sprintf("Usacloud/v%s (+https://github.com/sacloud/usacloud) libsacloud/%s", version.Version, libsacloud.Version),
+		UserAgent:            UserAgent,
 		TraceAPI:             o.EnableAPITrace(),
 		TraceHTTP:            o.EnableHTTPTrace(),
 		FakeMode:             o.FakeMode,

--- a/pkg/cli/user_agent.go
+++ b/pkg/cli/user_agent.go
@@ -1,0 +1,31 @@
+// Copyright 2017-2020 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/sacloud/libsacloud/v2"
+	"github.com/sacloud/usacloud/pkg/version"
+)
+
+var UserAgent = fmt.Sprintf(
+	"Usacloud/v%s (%s/%s; +https://github.com/sacloud/usacloud) libsacloud/%s",
+	version.Version,
+	runtime.GOOS,
+	runtime.GOARCH,
+	libsacloud.Version,
+)


### PR DESCRIPTION
closes #762 

User-AgentにGOOS/GOARCHを追加する。

- macOSの場合: `User-Agent: Usacloud/v1.0.0-rc.1 (darwin/amd64; +https://github.com/sacloud/usacloud) libsacloud/2.8.10`
- WASMの場合: `Usacloud/v1.0.0-rc.1 (js/wasm; +https://github.com/sacloud/usacloud) libsacloud/2.8.10`