### PR TITLE
Disable some global flags with WASM

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,16 +44,6 @@ type Config struct {
 
 var DefaultProcessTimeoutSec = 60 * 60 * 2 // 2時間
 
-// InitConfig 指定のFlagSetにConfigへ値を設定するためのフラグを登録する
-func InitConfig(flags *pflag.FlagSet) {
-	initCredentialConfig(flags)
-	initOutputConfig(flags)
-	initDebugConfig(flags)
-	// misc flags
-	flags.IntP("process-timeout-sec", "", 0, "number of seconds before the command execution is timed out")
-	flags.BoolP("version", "v", false, "show version info")
-}
-
 // LoadConfigValue 指定のフラグセットからフラグを読み取り*Flagsを組み立てて返す
 func LoadConfigValue(flags *pflag.FlagSet, errW io.Writer, skipLoadingProfile bool) (*Config, error) {
 	o := &Config{
@@ -67,23 +57,6 @@ func LoadConfigValue(flags *pflag.FlagSet, errW io.Writer, skipLoadingProfile bo
 
 	o.loadConfig(flags, errW)
 	return o, o.Validate(false)
-}
-
-func initCredentialConfig(fs *pflag.FlagSet) {
-	fs.StringP("profile", "", "", "the name of saved credentials")
-	fs.StringP("token", "", "", "the API token used when calling SAKURA Cloud API")
-	fs.StringP("secret", "", "", "the API secret used when calling SAKURA Cloud API")
-	fs.StringSliceP("zones", "", []string{}, "permitted zone names")
-}
-
-func initOutputConfig(fs *pflag.FlagSet) {
-	fs.BoolP("no-color", "", false, "disable ANSI color output")
-}
-
-func initDebugConfig(fs *pflag.FlagSet) {
-	fs.BoolP("trace", "", false, "enable trace logs for API calling")
-	fs.BoolP("fake", "", false, "enable fake API driver")
-	fs.StringP("fake-store", "", "", "path to file store used by the fake API driver")
 }
 
 func (o *Config) IsEmpty() bool {

--- a/pkg/config/init_flags.go
+++ b/pkg/config/init_flags.go
@@ -1,0 +1,46 @@
+// Copyright 2017-2020 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !wasm
+
+package config
+
+import "github.com/spf13/pflag"
+
+// InitConfig 指定のFlagSetにConfigへ値を設定するためのフラグを登録する
+func InitConfig(flags *pflag.FlagSet) {
+	initCredentialConfig(flags)
+	initOutputConfig(flags)
+	initDebugConfig(flags)
+	// misc flags
+	flags.IntP("process-timeout-sec", "", 0, "number of seconds before the command execution is timed out")
+	flags.BoolP("version", "v", false, "show version info")
+}
+
+func initCredentialConfig(fs *pflag.FlagSet) {
+	fs.StringP("profile", "", "", "the name of saved credentials")
+	fs.StringP("token", "", "", "the API token used when calling SAKURA Cloud API")
+	fs.StringP("secret", "", "", "the API secret used when calling SAKURA Cloud API")
+	fs.StringSliceP("zones", "", []string{}, "permitted zone names")
+}
+
+func initOutputConfig(fs *pflag.FlagSet) {
+	fs.BoolP("no-color", "", false, "disable ANSI color output")
+}
+
+func initDebugConfig(fs *pflag.FlagSet) {
+	fs.BoolP("trace", "", false, "enable trace logs for API calling")
+	fs.BoolP("fake", "", false, "enable fake API driver")
+	fs.StringP("fake-store", "", "", "path to file store used by the fake API driver")
+}

--- a/pkg/config/init_flags_wasm.go
+++ b/pkg/config/init_flags_wasm.go
@@ -1,0 +1,28 @@
+// +build wasm
+
+package config
+
+import "github.com/spf13/pflag"
+
+// InitConfig 指定のFlagSetにConfigへ値を設定するためのフラグを登録する
+func InitConfig(flags *pflag.FlagSet) {
+	initCredentialConfig(flags)
+	initOutputConfig(flags)
+	initDebugConfig(flags)
+	// misc flags
+	flags.IntP("process-timeout-sec", "", 0, "number of seconds before the command execution is timed out")
+	flags.BoolP("version", "v", false, "show version info")
+}
+
+func initCredentialConfig(fs *pflag.FlagSet) {
+	fs.StringP("token", "", "", "the API token used when calling SAKURA Cloud API")
+	fs.StringP("secret", "", "", "the API secret used when calling SAKURA Cloud API")
+}
+
+func initOutputConfig(fs *pflag.FlagSet) {
+	fs.BoolP("no-color", "", false, "disable ANSI color output")
+}
+
+func initDebugConfig(fs *pflag.FlagSet) {
+	fs.BoolP("fake", "", false, "enable fake API driver")
+}


### PR DESCRIPTION
from #770 

WASMの場合に以下のフラグを無効にする。

- `--profile`
- `--zones`
- `--trace`
- `--fake-store`

v1.1以降で対応するか検討する。