### PR TITLE
Fix parameter loader

### DIFF
--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -347,7 +347,7 @@ func (c *Command) handleCommonParameters(ctx cli.Context, cmd *cobra.Command) (b
 			return false, generateSkeleton(ctx, c.currentParameter)
 		}
 		// --parameters/--parameter-fileフラグの処理
-		if err := loadParameters(ctx, cmd, cp); err != nil {
+		if err := c.loadParameters(ctx, cmd, cp); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/cmd/core/parameter_loader.go
+++ b/pkg/cmd/core/parameter_loader.go
@@ -17,6 +17,7 @@ package core
 import (
 	"encoding/json"
 	"os"
+	"reflect"
 
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/spf13/cobra"
@@ -25,18 +26,21 @@ import (
 	"github.com/sacloud/usacloud/pkg/util"
 )
 
-func loadParameters(ctx cli.Context, cmd *cobra.Command, parameters cflag.CommonParameterValueHolder) error {
+func (c *Command) loadParameters(ctx cli.Context, cmd *cobra.Command, parameters cflag.CommonParameterValueHolder) error {
 	p := parameters.ParametersFlagValue()
-
 	if p == "" {
 		return nil
 	}
+
+	// c.currentParameterの実体をParameterInitializerで再度初期化
+	// Note: ポインタごと置き換えるとコマンドラインフラグのパースがうまく動かないため実体を差し替える
+	reflect.ValueOf(c.currentParameter).Elem().Set(reflect.ValueOf(c.ParameterInitializer()).Elem())
 
 	data, err := util.BytesFromPathOrContent(p)
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(data, parameters); err != nil {
+	if err := json.Unmarshal(data, c.currentParameter); err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
fixes #787 

`--parameters`指定時にコマンドライン で指定したスライス項目が2重になってしまう問題を修正