### PR TITLE
 Added --version flag to vpc-router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.6 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
-	github.com/sacloud/libsacloud/v2 v2.10.1-0.20210114075109-0773ceb51e1b
+	github.com/sacloud/libsacloud/v2 v2.12.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
-github.com/sacloud/libsacloud/v2 v2.10.1-0.20210114075109-0773ceb51e1b h1:dacseUR6WXFtTH/4YsGPb9Zlc5cpUH1F6yJtv4tyvL0=
-github.com/sacloud/libsacloud/v2 v2.10.1-0.20210114075109-0773ceb51e1b/go.mod h1:6n5aYgZXT165LMQME0hECHfgbgVry/tYMhBzSFnNoFk=
+github.com/sacloud/libsacloud/v2 v2.12.0 h1:qWT6zwokflhIUtral+fNvuUcT3ALY5P7qN2aNN+3D1Q=
+github.com/sacloud/libsacloud/v2 v2.12.0/go.mod h1:6n5aYgZXT165LMQME0hECHfgbgVry/tYMhBzSFnNoFk=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cmd/commands/vpcrouter/columns.go
+++ b/pkg/cmd/commands/vpcrouter/columns.go
@@ -26,6 +26,7 @@ var defaultColumnDefs = []output.ColumnDef{
 	ccol.Tags,
 	ccol.Description,
 	{Name: "Plan", Template: `{{ .PlanID | vpc_router_plan_to_key }}`},
+	{Name: "Version"},
 	{Name: "VRID", Template: `{{ if .Settings }}{{ if gt .Settings.VRID 0 }}{{ .Settings.VRID }}{{ end }}{{ end }}`},
 	{Name: "Upstream", Template: `{{ with index .OriginalValue.Interfaces 0 }}{{ .UpstreamType }}{{ end }}`},
 	{

--- a/pkg/cmd/commands/vpcrouter/create.go
+++ b/pkg/cmd/commands/vpcrouter/create.go
@@ -48,7 +48,8 @@ type createParameter struct {
 	cflag.TagsParameter   `cli:",squash" mapconv:",squash"`
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
 
-	Plan string `cli:"plan,options=vpc_router_plan_premium,category=plan" mapconv:"PlanID,filters=vpc_router_plan_premium_to_value" validate:"required,vpc_router_plan_premium"`
+	Plan    string `cli:"plan,options=vpc_router_plan_premium,category=plan" mapconv:"PlanID,filters=vpc_router_plan_premium_to_value" validate:"required,vpc_router_plan_premium"`
+	Version int    `validate:"required,oneof=1 2"`
 
 	PublicNetworkInterface vpcrouter.PremiumNICSetting `cli:",category=network,order=10" mapconv:"NICSetting,omitempty"`
 
@@ -63,7 +64,8 @@ type createParameter struct {
 
 func newCreateParameter() *createParameter {
 	return &createParameter{
-		Plan: "premium",
+		Plan:    "premium",
+		Version: 2,
 	}
 }
 
@@ -91,6 +93,7 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 		TagsParameter:   examples.Tags,
 		IconIDParameter: examples.IconID,
 		Plan:            examples.OptionsString("vpc_router_plan_premium"),
+		Version:         2,
 		PublicNetworkInterface: vpcrouter.PremiumNICSetting{
 			SwitchID:         examples.ID,
 			IPAddresses:      examples.IPAddresses,

--- a/pkg/cmd/commands/vpcrouter/create_standard.go
+++ b/pkg/cmd/commands/vpcrouter/create_standard.go
@@ -48,6 +48,8 @@ type createStandardParameter struct {
 	cflag.TagsParameter   `cli:",squash" mapconv:",squash"`
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
 
+	Version int `validate:"required,oneof=1 2"`
+
 	PrivateNetworkInterfacesData string                                    `cli:"private-network-interfaces" mapconv:"-"`
 	PrivateNetworkInterfaces     []*vpcrouter.AdditionalStandardNICSetting `cli:"-" mapconv:"AdditionalNICSettings"`
 
@@ -58,7 +60,9 @@ type createStandardParameter struct {
 }
 
 func newCreateStandardParameter() *createStandardParameter {
-	return &createStandardParameter{}
+	return &createStandardParameter{
+		Version: 2,
+	}
 }
 
 func init() {
@@ -84,6 +88,7 @@ func (p *createStandardParameter) ExampleParameters(ctx cli.Context) interface{}
 		DescParameter:   examples.Description,
 		TagsParameter:   examples.Tags,
 		IconIDParameter: examples.IconID,
+		Version:         2,
 		PrivateNetworkInterfaces: []*vpcrouter.AdditionalStandardNICSetting{
 			{
 				SwitchID:       examples.ID,

--- a/pkg/cmd/commands/vpcrouter/zz_create_gen.go
+++ b/pkg/cmd/commands/vpcrouter/zz_create_gen.go
@@ -43,6 +43,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
 	fs.StringVarP(&p.Plan, "plan", "", p.Plan, "(*required) options: [premium/highspec/highspec4000]")
+	fs.IntVarP(&p.Version, "version", "", p.Version, "(*required) ")
 	fs.VarP(core.NewIDFlag(&p.PublicNetworkInterface.SwitchID, &p.PublicNetworkInterface.SwitchID), "public-network-interface-switch-id", "", "")
 	fs.StringSliceVarP(&p.PublicNetworkInterface.IPAddresses, "public-network-interface-ip-addresses", "", p.PublicNetworkInterface.IPAddresses, "")
 	fs.StringVarP(&p.PublicNetworkInterface.VirtualIPAddress, "public-network-interface-virtual-ip-address", "", p.PublicNetworkInterface.VirtualIPAddress, "")
@@ -126,6 +127,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("static-route"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("syslog-host"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("users"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("version"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("vrid"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Vpc-Router-specific options",

--- a/pkg/cmd/commands/vpcrouter/zz_create_standard_gen.go
+++ b/pkg/cmd/commands/vpcrouter/zz_create_standard_gen.go
@@ -41,6 +41,7 @@ func (p *createStandardParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Description, "description", "", p.Description, "")
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
+	fs.IntVarP(&p.Version, "version", "", p.Version, "(*required) ")
 	fs.StringVarP(&p.PrivateNetworkInterfacesData, "private-network-interfaces", "", p.PrivateNetworkInterfacesData, "")
 	fs.IntVarP(&p.RouterSetting.VRID, "vrid", "", p.RouterSetting.VRID, "")
 	fs.BoolVarP(&p.RouterSetting.InternetConnectionEnabled, "internet-connection-enabled", "", p.RouterSetting.InternetConnectionEnabled, "")
@@ -111,6 +112,7 @@ func (p *createStandardParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("static-route"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("syslog-host"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("users"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("version"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("vrid"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Vpc-Router-specific options",

--- a/vendor/github.com/sacloud/libsacloud/v2/helper/builder/vpcrouter/builder.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/helper/builder/vpcrouter/builder.go
@@ -35,6 +35,7 @@ type Builder struct {
 	Tags                  types.Tags
 	IconID                types.ID
 	PlanID                types.ID
+	Version               int
 	NICSetting            NICSettingHolder
 	AdditionalNICSettings []AdditionalNICSettingHolder
 	RouterSetting         *RouterSetting
@@ -185,6 +186,7 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.VPCRouter, e
 				PlanID:      b.PlanID,
 				Switch:      b.NICSetting.getConnectedSwitch(),
 				IPAddresses: b.NICSetting.getIPAddresses(),
+				Version:     b.Version,
 				Settings: &sacloud.VPCRouterSetting{
 					VRID:                      b.RouterSetting.VRID,
 					InternetConnectionEnabled: b.RouterSetting.InternetConnectionEnabled,

--- a/vendor/github.com/sacloud/libsacloud/v2/helper/service/vpcrouter/apply_request.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/helper/service/vpcrouter/apply_request.go
@@ -35,7 +35,8 @@ type ApplyRequest struct {
 	Tags        types.Tags
 	IconID      types.ID
 
-	PlanID                types.ID                     `validate:"required"`
+	PlanID                types.ID `validate:"required"`
+	Version               int
 	NICSetting            NICSettingHolder             // StandardNICSetting または PremiumNICSetting を指定する
 	AdditionalNICSettings []AdditionalNICSettingHolder // AdditionalStandardNICSetting または AdditionalPremiumNICSetting を指定する
 	RouterSetting         *RouterSetting
@@ -71,6 +72,7 @@ func (req *ApplyRequest) Builder(caller sacloud.APICaller) *vpcRouterBuilder.Bui
 		Tags:                  req.Tags,
 		IconID:                req.IconID,
 		PlanID:                req.PlanID,
+		Version:               req.Version,
 		NICSetting:            req.nicSetting(),
 		AdditionalNICSettings: req.additionalNICSetting(),
 		RouterSetting:         req.routerSetting(),

--- a/vendor/github.com/sacloud/libsacloud/v2/helper/service/vpcrouter/create_request.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/helper/service/vpcrouter/create_request.go
@@ -28,6 +28,7 @@ type CreateRequest struct {
 	IconID      types.ID
 
 	PlanID                types.ID `validate:"required"`
+	Version               int
 	NICSetting            *PremiumNICSetting
 	AdditionalNICSettings []*AdditionalPremiumNICSetting
 	RouterSetting         *RouterSetting
@@ -51,6 +52,7 @@ func (req *CreateRequest) ApplyRequest() *ApplyRequest {
 		Tags:                  req.Tags,
 		IconID:                req.IconID,
 		PlanID:                req.PlanID,
+		Version:               req.Version,
 		NICSetting:            req.NICSetting,
 		AdditionalNICSettings: additionalNICs,
 		RouterSetting:         req.RouterSetting,

--- a/vendor/github.com/sacloud/libsacloud/v2/helper/service/vpcrouter/create_standard_request.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/helper/service/vpcrouter/create_standard_request.go
@@ -27,6 +27,8 @@ type CreateStandardRequest struct {
 	Tags        types.Tags
 	IconID      types.ID
 
+	Version int
+
 	AdditionalNICSettings []*AdditionalStandardNICSetting
 	RouterSetting         *RouterSetting
 	NoWait                bool
@@ -49,6 +51,7 @@ func (req *CreateStandardRequest) ApplyRequest() *ApplyRequest {
 		Tags:                  req.Tags,
 		IconID:                req.IconID,
 		PlanID:                types.VPCRouterPlans.Standard,
+		Version:               req.Version,
 		NICSetting:            &StandardNICSetting{},
 		AdditionalNICSettings: additionalNICs,
 		RouterSetting:         req.RouterSetting,

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_database.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_database.go
@@ -325,6 +325,17 @@ var (
 			MaxLen:  0,
 			Reboot:  "static",
 		},
+		{
+			Type:    "string",
+			Name:    "MariaDB/server.cnf/mysqld/event_scheduler",
+			Label:   "event_scheduler",
+			Text:    "イベントスケジュールの有効無効を設定します。",
+			Example: "ON",
+			Min:     0,
+			Max:     0,
+			MaxLen:  0,
+			Reboot:  "dynamic",
+		},
 	}
 	fakeDatabaseParameterMetaForPostgreSQL = []*sacloud.DatabaseParameterMeta{
 		{
@@ -337,6 +348,17 @@ var (
 			Max:     1000,
 			MaxLen:  0,
 			Reboot:  "static",
+		},
+		{
+			Type:    "number",
+			Name:    "postgres/postgresql.conf/work_mem",
+			Label:   "work_mem",
+			Text:    "クエリワークスペースに使用するメモリの最大量を設定します。",
+			Example: "4096",
+			Min:     64,
+			Max:     2147483647,
+			MaxLen:  10,
+			Reboot:  "dynamic",
 		},
 	}
 )

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_vpc_router.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/fake/ops_vpc_router.go
@@ -51,6 +51,9 @@ func (o *VPCRouterOp) Create(ctx context.Context, zone string, param *sacloud.VP
 	result.Availability = types.Availabilities.Migrating
 	result.ZoneID = zoneIDs[zone]
 	result.SettingsHash = ""
+	if result.Version == 0 {
+		result.Version = 2
+	}
 
 	ifOp := NewInterfaceOp()
 	swOp := NewSwitchOp()

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/appliance.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/appliance.go
@@ -33,11 +33,17 @@ type ApplianceRemark struct {
 	DBConf          *ApplianceRemarkDBConf        `json:",omitempty" yaml:"db_conf,omitempty" structs:",omitempty"`        // for database
 	SourceAppliance *ApplianceSource              `json:",omitempty" yaml:"db_conf,omitempty" structs:",omitempty"`        // for database
 	MobileGateway   *ApplianceRemarkMobileGateway `json:",omitempty" yaml:"mobile_gateway,omitempty" structs:",omitempty"` // for mobile gateway
+	Router          *ApplianceRemarkRouter        `json:",omitempty" yaml:"router,omitempty" structs:",omitempty"`         // for vpc router
 }
 
 // ApplianceRemarkMobileGateway モバイルゲートウェイのグローバルIP
 type ApplianceRemarkMobileGateway struct {
 	GlobalAddress string
+}
+
+// ApplianceRemarkRouter VPCルータのバージョンなど
+type ApplianceRemarkRouter struct {
+	VPCRouterVersion int `json:",omitempty" yaml:"vpc_router_version,omitempty" structs:",omitempty"`
 }
 
 // ApplianceSource クローン元アプライアンス データベースのクローン時に利用

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
@@ -25891,6 +25891,7 @@ type VPCRouter struct {
 	IconID                  types.ID `mapconv:"Icon.ID"`
 	CreatedAt               time.Time
 	PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
+	Version                 int                         `mapconv:"Remark.Router.VPCRouterVersion"`
 	Settings                *VPCRouterSetting           `mapconv:",omitempty,recursive"`
 	SettingsHash            string                      `json:",omitempty" mapconv:",omitempty"`
 	InstanceHostName        string                      `mapconv:"Instance.Host.Name"`
@@ -25918,6 +25919,7 @@ func (o *VPCRouter) setDefaults() interface{} {
 		IconID                  types.ID `mapconv:"Icon.ID"`
 		CreatedAt               time.Time
 		PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
+		Version                 int                         `mapconv:"Remark.Router.VPCRouterVersion"`
 		Settings                *VPCRouterSetting           `mapconv:",omitempty,recursive"`
 		SettingsHash            string                      `json:",omitempty" mapconv:",omitempty"`
 		InstanceHostName        string                      `mapconv:"Instance.Host.Name"`
@@ -25936,6 +25938,7 @@ func (o *VPCRouter) setDefaults() interface{} {
 		IconID:                  o.GetIconID(),
 		CreatedAt:               o.GetCreatedAt(),
 		PlanID:                  o.GetPlanID(),
+		Version:                 o.GetVersion(),
 		Settings:                o.GetSettings(),
 		SettingsHash:            o.GetSettingsHash(),
 		InstanceHostName:        o.GetInstanceHostName(),
@@ -26075,6 +26078,19 @@ func (o *VPCRouter) GetPlanID() types.ID {
 // SetPlanID sets value to PlanID
 func (o *VPCRouter) SetPlanID(v types.ID) {
 	o.PlanID = v
+}
+
+// GetVersion returns value of Version
+func (o *VPCRouter) GetVersion() int {
+	if o.Version == 0 {
+		return 2
+	}
+	return o.Version
+}
+
+// SetVersion sets value to Version
+func (o *VPCRouter) SetVersion(v int) {
+	o.Version = v
 }
 
 // GetSettings returns value of Settings
@@ -27497,6 +27513,7 @@ type VPCRouterCreateRequest struct {
 	PlanID      types.ID                  `mapconv:"Plan.ID"`
 	Switch      *ApplianceConnectedSwitch `json:",omitempty" mapconv:"Remark.Switch,recursive"`
 	IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress"`
+	Version     int                       `mapconv:"Remark.Router.VPCRouterVersion"`
 	Settings    *VPCRouterSetting         `mapconv:",omitempty,recursive"`
 }
 
@@ -27515,6 +27532,7 @@ func (o *VPCRouterCreateRequest) setDefaults() interface{} {
 		PlanID      types.ID                  `mapconv:"Plan.ID"`
 		Switch      *ApplianceConnectedSwitch `json:",omitempty" mapconv:"Remark.Switch,recursive"`
 		IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress"`
+		Version     int                       `mapconv:"Remark.Router.VPCRouterVersion"`
 		Settings    *VPCRouterSetting         `mapconv:",omitempty,recursive"`
 		Class       string
 	}{
@@ -27525,6 +27543,7 @@ func (o *VPCRouterCreateRequest) setDefaults() interface{} {
 		PlanID:      o.GetPlanID(),
 		Switch:      o.GetSwitch(),
 		IPAddresses: o.GetIPAddresses(),
+		Version:     o.GetVersion(),
 		Settings:    o.GetSettings(),
 		Class:       "vpcrouter",
 	}
@@ -27618,6 +27637,19 @@ func (o *VPCRouterCreateRequest) GetIPAddresses() []string {
 // SetIPAddresses sets value to IPAddresses
 func (o *VPCRouterCreateRequest) SetIPAddresses(v []string) {
 	o.IPAddresses = v
+}
+
+// GetVersion returns value of Version
+func (o *VPCRouterCreateRequest) GetVersion() int {
+	if o.Version == 0 {
+		return 2
+	}
+	return o.Version
+}
+
+// SetVersion sets value to Version
+func (o *VPCRouterCreateRequest) SetVersion(v int) {
+	o.Version = v
 }
 
 // GetSettings returns value of Settings

--- a/vendor/github.com/sacloud/libsacloud/v2/version.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/version.go
@@ -15,4 +15,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "2.10.0"
+const Version = "2.12.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/olekukonko/tablewriter
 github.com/pmezard/go-difflib/difflib
 # github.com/sacloud/ftps v1.1.0
 github.com/sacloud/ftps
-# github.com/sacloud/libsacloud/v2 v2.10.1-0.20210114075109-0773ceb51e1b
+# github.com/sacloud/libsacloud/v2 v2.12.0
 ## explicit
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/helper/api


### PR DESCRIPTION
VPCルータ作成時に`--version`を指定可能にする。
省略した場合のデフォルトは`2`。

```sh
$ usacloud vpc-router create-standard --name example --version 2
```