### PR TITLE
Added --argument-match-mode option

### DIFF
--- a/pkg/config/init_flags.go
+++ b/pkg/config/init_flags.go
@@ -23,8 +23,8 @@ func InitConfig(flags *pflag.FlagSet) {
 	initCredentialConfig(flags)
 	initOutputConfig(flags)
 	initDebugConfig(flags)
+	initBehaviorConfig(flags)
 	// misc flags
-	flags.IntP("process-timeout-sec", "", 0, "number of seconds before the command execution is timed out")
 	flags.BoolP("version", "v", false, "show version info")
 }
 
@@ -43,4 +43,9 @@ func initDebugConfig(fs *pflag.FlagSet) {
 	fs.BoolP("trace", "", false, "enable trace logs for API calling")
 	fs.BoolP("fake", "", false, "enable fake API driver")
 	fs.StringP("fake-store", "", "", "path to file store used by the fake API driver")
+}
+
+func initBehaviorConfig(fs *pflag.FlagSet) {
+	fs.IntP("process-timeout-sec", "", 0, "number of seconds before the command execution is timed out")
+	fs.StringP("argument-match-mode", "", "", "how to compare the argument and resource name when identifying the resource to be manipulated  options: [partial/exact]")
 }


### PR DESCRIPTION
closes #783 

引数からリソースを特定する際に`Name`のマッチ方法を変更可能にする

### 概要

現在は引数がID or Name or Tagsにマッチしたら処理対象としているが、Nameの場合は部分一致となっている。  
この動作が問題になるケースがある。

ケース例: シンプル監視

シンプル監視に以下のようなリソースがある場合、`usacloud simple-monitor read example.com`はエラーとなる。

- `example.com`
- `www.example.com`

このため、オプションでマッチ方法を構成可能にして対応する。

### 実装

- プロファイルに`ArgumentMatchMode`という項目を追加する。値は以下を指定可能
  - `partial`(デフォルト): 部分一致
  - `exact`: 完全一致

Note: v1時点ではデフォルト値は`partial`とするが、将来的に変更する可能性あり。

- グローバルオプション `--argument-match-mode`を追加する。指定可能な値は上記と同じ
- 環境変数`SAKURACLOUD_ARGUMENT_MATCH_MODE`での指定も可とする

#### やらないこと

- このPRではGlob対応は行わない
- このPRでは正規表現対応は行わない

### 実装にあたっての検討事項

<details>

- グローバルオプションに追加すべきか?
- 完全一致にGlob対応を入れるべきか?
  -> Globに対応すると`ArgumentMatchMode`を頻繁に切り替える必要性は低くなるはず(グローバルオプションを追加しなくて済むかも)
- 正規表現は必要か?

</details>
