### PR TITLE
Pass output func to query package

### DIFF
--- a/pkg/output/json_output.go
+++ b/pkg/output/json_output.go
@@ -97,11 +97,8 @@ func (o *jsonOutput) printWithQuery(values []interface{}) error {
 		return fmt.Errorf("JSONOutput:Query: loading query from %q Failed: %s", o.query, err)
 	}
 
-	results, err := query.Executor(o.driver)(values, q)
-	if err != nil {
-		return err
-	}
-	return o.printOutput(results)
+	// query.Executorに出力用のfuncを渡して出力までしてもらう
+	return query.Executor(o.driver)(values, q, o.printOutput)
 }
 
 func (o *jsonOutput) printOutput(v interface{}) error {

--- a/pkg/query/driver.go
+++ b/pkg/query/driver.go
@@ -19,7 +19,7 @@ const (
 	DriverGoJQ     = "jq"
 )
 
-type ExecFunc func(v interface{}, query string) (result interface{}, err error)
+type ExecFunc func(v interface{}, query string, printer func(interface{}) error) error
 
 // Executor 指定のドライバーに対応したクエリ実行funcを返す
 func Executor(driver string) ExecFunc {


### PR DESCRIPTION
fixes #800 

gojqの各出力が常に[]interface{}としてラップして扱われていた問題を修正

outputパッケージでは`--query-driver`の値に応じて`pkg/query`を呼び出し、結果を出力していたが、outputパッケージ側ではjmespathで[]interface{}が返されたのか、gojqが複数の値を返したのか判断できないため、`pkg/query`に出力用funcを渡してそちらで出力してもらうようにした。

```sh
# 修正前
$ usacloud server list --query ".[].Name"
[
    "example1",
    "example2" 
]

# 修正後
$ usacloud server list --query ".[].Name"
"example1"
"example2"
```