### PR TITLE
Added --query-driver to rest command

### DIFF
--- a/pkg/cmd/commands/rest/zz_request_gen.go
+++ b/pkg/cmd/commands/rest/zz_request_gen.go
@@ -33,6 +33,7 @@ func (p *requestParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Method, "method", "X", p.Method, "(*required) options: [get/post/put/delete/GET/POST/PUT/DELETE]")
 	fs.StringVarP(&p.Data, "data", "d", p.Data, "")
 	fs.StringVarP(&p.Query, "query", "", p.Query, "JMESPath query")
+	fs.StringVarP(&p.QueryDriver, "query-driver", "", p.QueryDriver, "Name of the driver that handles queries to JSON output options: [jmespath/jq]")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 
@@ -59,6 +60,7 @@ func (p *requestParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("output", pflag.ContinueOnError)
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("query"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("query-driver"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Output options",
 			Flags: fs,

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -72,12 +72,15 @@ func ByGoJQ(input interface{}, query string, printer func(interface{}) error) (e
 	return nil
 }
 
-func convertInputToMap(input interface{}) []interface{} {
+func convertInputToMap(input interface{}) interface{} {
 	var inputs []interface{}
-	ins, ok := input.([]interface{})
-	if ok {
-		inputs = ins
-	} else {
+
+	switch input := input.(type) {
+	case map[string]interface{}:
+		return input // 既にmap[string]interface{}の場合はそのまま返す
+	case []interface{}:
+		inputs = input
+	default:
 		inputs = []interface{}{input}
 	}
 


### PR DESCRIPTION
closes #803 

`rest`コマンドで`--query-driver`を利用可能にする。
合わせて`pkg/query`がrestコマンドからの出力に対応していなかった問題を修正。