### PR TITLE
Use docker/build-push-action@v2

### DIFF
--- a/.github/workflows/publish_docker_image.yaml
+++ b/.github/workflows/publish_docker_image.yaml
@@ -5,18 +5,31 @@ on:
     tags: 'v[0-9]+.[0-9]+.[0-9]+*'
 jobs:
   push_to_registry:
-    name: Push Docker image to GitHub Container Registry
+    name: Push Docker image to GitHub Container Registry(latest)
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
+      -
+        name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to GitHub Container Registry
-        uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+          images: ghcr.io/sacloud/usacloud
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
           registry: ghcr.io
-          repository: ${{ github.repository }}
-          tag_with_ref: true
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: true

--- a/.github/workflows/publish_latest_docker_image.yaml
+++ b/.github/workflows/publish_latest_docker_image.yaml
@@ -9,15 +9,22 @@ jobs:
     name: Push Docker image to GitHub Container Registry(latest)
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
+      -
+        name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to GitHub Container Registry
-        uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
           registry: ghcr.io
-          repository: ${{ github.repository }}
-          tags: latest
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          tags: ghcr.io/sacloud/usacloud:latest
+          push: true


### PR DESCRIPTION
GitHub Container Registry向けのDockerイメージのbuild/pushで[docker/build-push-action@v2](https://github.com/docker/build-push-action/)を利用する。
(v1からのアップグレード)