### PR TITLE
Colorize output of the rest command

### DIFF
--- a/pkg/cmd/commands/rest/request.go
+++ b/pkg/cmd/commands/rest/request.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sacloud/usacloud/pkg/query"
-
+	"github.com/hokaccha/go-prettyjson"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/cmd/core"
+	"github.com/sacloud/usacloud/pkg/query"
 	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/sacloud/usacloud/pkg/validate"
 )
@@ -152,11 +152,15 @@ func requestFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) 
 
 	if len(results) > 0 {
 		printFn := func(v interface{}) error {
-			formattedJSON, err := json.MarshalIndent(v, "", "    ")
+			formatter := prettyjson.NewFormatter()
+			formatter.DisabledColor = ctx.Option().NoColor
+			formatter.Indent = 4
+
+			data, err := formatter.Marshal(v)
 			if err != nil {
 				return err
 			}
-			_, err = fmt.Fprintln(ctx.IO().Out(), string(formattedJSON))
+			_, err = fmt.Fprintln(ctx.IO().Out(), string(data))
 			return err
 		}
 

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017-2021 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package query
 
 import "testing"


### PR DESCRIPTION
closes #808 

`rest`コマンドの出力をANSIカラー対応させる。

Note:
`pkg/output`とコードが重複しているが、現状では重複はこの部分のみなため許容する。
今後重複箇所が増えるようであれば切り出しを行う。