### PR TITLE
Fix cannot load current config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,7 +88,7 @@ func (o *Config) IsEmpty() bool {
 func (o *Config) loadConfig(flags *pflag.FlagSet, errW io.Writer) {
 	// プロファイルだけ先に環境変数を読んでおく
 	if o.Profile == "" {
-		o.Profile = stringFromEnvMulti([]string{"SAKURACLOUD_PROFILE", "USACLOUD_PROFILE"}, "default")
+		o.Profile = stringFromEnvMulti([]string{"SAKURACLOUD_PROFILE", "USACLOUD_PROFILE"}, "")
 	}
 
 	o.loadFromProfile(flags, errW)


### PR DESCRIPTION
`config.loadFromProfile()` は `o.Profile` が空の場合にcurrentプロファイルを読むようになっているため、 `config.loadConfig()` で、 `config.loadFromProfile()` より前に `o.Profile` を "default" にしてしまうと、currentプロファイルを読めないバグを修正しました。
https://github.com/sacloud/usacloud/blob/44661f3a73399ceaba009ffa66ae0ad105eab1c5/pkg/config/profile.go#L27-L50