### PR TITLE
ESME: Web OTP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/rhysd/go-github-selfupdate v1.2.3
-	github.com/sacloud/libsacloud/v2 v2.14.1
+	github.com/sacloud/libsacloud/v2 v2.15.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
-github.com/sacloud/libsacloud/v2 v2.14.1 h1:LWyrFyNxHFZJJhVFuPuX/i01EuMrsZynYn+4Sde7rUE=
-github.com/sacloud/libsacloud/v2 v2.14.1/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
+github.com/sacloud/libsacloud/v2 v2.15.0 h1:sJFpBfieIoBvC1mt5YDhR2686jX1hjk2CqClsZ6lZa8=
+github.com/sacloud/libsacloud/v2 v2.15.0/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cmd/commands/esme/send_message.go
+++ b/pkg/cmd/commands/esme/send_message.go
@@ -48,6 +48,7 @@ type sendMessageParameter struct {
 
 	Destination string `cli:",aliases=dest" validate:"required"`
 	Sender      string `validate:"required"`
+	DomainName  string `validate:"omitempty,fqdn"`
 	OTP         string
 }
 
@@ -63,6 +64,7 @@ func (p *sendMessageParameter) ExampleParameters(ctx cli.Context) interface{} {
 	return &sendMessageParameter{
 		Destination: "81zzzzzzzzzz",
 		Sender:      "example-sender",
+		DomainName:  "www.example.com",
 		OTP:         "your-otp",
 	}
 }

--- a/pkg/cmd/commands/esme/send_message_test.go
+++ b/pkg/cmd/commands/esme/send_message_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017-2021 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esme
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sacloud/usacloud/pkg/validate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendMessageParameter_Validate(t *testing.T) {
+	validate.InitializeValidator([]string{"is1a"})
+
+	cases := []struct {
+		in  *sendMessageParameter
+		err error
+	}{
+		// default
+		{
+			in: newSendMessageParameter(),
+			err: errors.New(strings.Join([]string{
+				"validation error:",
+				"\t--destination: required",
+				"\t--sender: required",
+			}, "\n")),
+		},
+		// valid
+		{
+			in: &sendMessageParameter{
+				Destination: "819012345678",
+				Sender:      "example",
+			},
+			err: nil,
+		},
+		// with invalid domain-name
+		{
+			in: &sendMessageParameter{
+				Destination: "819012345678",
+				Sender:      "example",
+				DomainName:  "example",
+			},
+			err: errors.New(strings.Join([]string{
+				"validation error:",
+				"\t--domain-name: fqdn",
+			}, "\n")),
+		},
+		// with valid domain-name
+		{
+			in: &sendMessageParameter{
+				Destination: "819012345678",
+				Sender:      "example",
+				DomainName:  "www.example.com",
+			},
+			err: nil,
+		},
+		// with valid domain-name
+		// see: https://github.com/sacloud/usacloud/pull/824
+		{
+			in: &sendMessageParameter{
+				Destination: "819012345678",
+				Sender:      "example",
+				DomainName:  "www.example.com.",
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		err := validate.Exec(tc.in)
+		require.Equal(t, tc.err, err)
+	}
+}

--- a/pkg/cmd/commands/esme/zz_send_message_gen.go
+++ b/pkg/cmd/commands/esme/zz_send_message_gen.go
@@ -39,6 +39,7 @@ func (p *sendMessageParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.QueryDriver, "query-driver", "", p.QueryDriver, "Name of the driver that handles queries to JSON output options: [jmespath/jq]")
 	fs.StringVarP(&p.Destination, "destination", "", p.Destination, "(*required) (aliases: --dest)")
 	fs.StringVarP(&p.Sender, "sender", "", p.Sender, "(*required) ")
+	fs.StringVarP(&p.DomainName, "domain-name", "", p.DomainName, "")
 	fs.StringVarP(&p.OTP, "otp", "", p.OTP, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
@@ -64,6 +65,7 @@ func (p *sendMessageParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("esme", pflag.ContinueOnError)
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("destination"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("domain-name"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("otp"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("sender"))
 		sets = append(sets, &core.FlagSet{

--- a/vendor/github.com/sacloud/libsacloud/v2/helper/service/esme/send_message_request.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/helper/service/esme/send_message_request.go
@@ -26,6 +26,7 @@ type SendMessageRequest struct {
 	Destination string `validate:"required"`
 	Sender      string `validate:"required"`
 	OTP         string
+	DomainName  string
 }
 
 func (req *SendMessageRequest) Validate() error {
@@ -37,11 +38,13 @@ func (req *SendMessageRequest) ToRequestParameter() interface{} {
 		return &sacloud.ESMESendMessageWithGeneratedOTPRequest{
 			Destination: req.Destination,
 			Sender:      req.Sender,
+			DomainName:  req.DomainName,
 		}
 	}
 	return &sacloud.ESMESendMessageWithInputtedOTPRequest{
 		Destination: req.Destination,
 		Sender:      req.Sender,
+		DomainName:  req.DomainName,
 		OTP:         req.OTP,
 	}
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/esme.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/naked/esme.go
@@ -44,6 +44,7 @@ type ESME struct {
 type ESMESendSMSRequest struct {
 	Destination  string              `json:"destination,omitempty" yaml:"destination,omitempty" structs:",omitempty"` // 宛先 現在は81(+81)開始固定
 	Sender       string              `json:"sender,omitempty" yaml:"sender,omitempty" structs:",omitempty"`           // 送信者名 本文中に反映される
+	DomainName   string              `json:"domain_name,omitempty" yaml:"domain_name,omitempty" structs:",omitempty"` // Web OTPを利用する際に本文中に記載されるオリジン(FQDNで指定)
 	OTPOperation types.EOTPOperation `json:"otpOperation,omitempty" yaml:"otp_operation,omitempty" structs:",omitempty"`
 	OTP          string              `json:"otp,omitempty" yaml:"otp,omitempty" structs:",omitempty"` // ワンタイムパスワード、OTPOperationがinputの場合に使用する
 }

--- a/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/sacloud/zz_models.go
@@ -9166,6 +9166,7 @@ func (o *ESMESendMessageResult) SetOTP(v string) {
 type ESMESendMessageWithGeneratedOTPRequest struct {
 	Destination string
 	Sender      string
+	DomainName  string
 }
 
 // Validate validates by field tags
@@ -9178,10 +9179,12 @@ func (o *ESMESendMessageWithGeneratedOTPRequest) setDefaults() interface{} {
 	return &struct {
 		Destination  string
 		Sender       string
+		DomainName   string
 		OTPOperation types.EOTPOperation
 	}{
 		Destination:  o.GetDestination(),
 		Sender:       o.GetSender(),
+		DomainName:   o.GetDomainName(),
 		OTPOperation: "generate",
 	}
 }
@@ -9206,6 +9209,16 @@ func (o *ESMESendMessageWithGeneratedOTPRequest) SetSender(v string) {
 	o.Sender = v
 }
 
+// GetDomainName returns value of DomainName
+func (o *ESMESendMessageWithGeneratedOTPRequest) GetDomainName() string {
+	return o.DomainName
+}
+
+// SetDomainName sets value to DomainName
+func (o *ESMESendMessageWithGeneratedOTPRequest) SetDomainName(v string) {
+	o.DomainName = v
+}
+
 /*************************************************
 * ESMESendMessageWithInputtedOTPRequest
 *************************************************/
@@ -9214,6 +9227,7 @@ func (o *ESMESendMessageWithGeneratedOTPRequest) SetSender(v string) {
 type ESMESendMessageWithInputtedOTPRequest struct {
 	Destination string
 	Sender      string
+	DomainName  string
 	OTP         string
 }
 
@@ -9227,11 +9241,13 @@ func (o *ESMESendMessageWithInputtedOTPRequest) setDefaults() interface{} {
 	return &struct {
 		Destination  string
 		Sender       string
+		DomainName   string
 		OTP          string
 		OTPOperation types.EOTPOperation
 	}{
 		Destination:  o.GetDestination(),
 		Sender:       o.GetSender(),
+		DomainName:   o.GetDomainName(),
 		OTP:          o.GetOTP(),
 		OTPOperation: "input",
 	}
@@ -9255,6 +9271,16 @@ func (o *ESMESendMessageWithInputtedOTPRequest) GetSender() string {
 // SetSender sets value to Sender
 func (o *ESMESendMessageWithInputtedOTPRequest) SetSender(v string) {
 	o.Sender = v
+}
+
+// GetDomainName returns value of DomainName
+func (o *ESMESendMessageWithInputtedOTPRequest) GetDomainName() string {
+	return o.DomainName
+}
+
+// SetDomainName sets value to DomainName
+func (o *ESMESendMessageWithInputtedOTPRequest) SetDomainName(v string) {
+	o.DomainName = v
 }
 
 // GetOTP returns value of OTP

--- a/vendor/github.com/sacloud/libsacloud/v2/version.go
+++ b/vendor/github.com/sacloud/libsacloud/v2/version.go
@@ -15,4 +15,4 @@
 package libsacloud
 
 // Version バージョン
-const Version = "2.14.0"
+const Version = "2.15.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/pmezard/go-difflib/difflib
 github.com/rhysd/go-github-selfupdate/selfupdate
 # github.com/sacloud/ftps v1.1.0
 github.com/sacloud/ftps
-# github.com/sacloud/libsacloud/v2 v2.14.1
+# github.com/sacloud/libsacloud/v2 v2.15.0
 ## explicit
 github.com/sacloud/libsacloud/v2
 github.com/sacloud/libsacloud/v2/helper/api


### PR DESCRIPTION
Web OTPでSMS本文に埋め込まれるドメイン名を指定するパラメータ`--domain-name`を追加する。

利用例:
```bash
$ usacloud esme send-message <ID or Name> --destination=81xxxxxxxxxx --sender=example --domain-name=www.example.com
```

Note: --domain-nameにおいて`www.example.com.`のような末尾にドットがあるパターンを許容してしまうがAPI側でBadRequestになる。これはバリデーションで利用している`go-playground/validator.v10`の`fqdn`を利用していることに由来する。API側でエラーにしてくれることから現時点ではこの問題を許容し、要望が出るようであれば改めて対応を検討する。