### PR TITLE
Set 'dev' tag to docker image to be built for each commit

### DIFF
--- a/.github/workflows/publish_dev_docker_image.yaml
+++ b/.github/workflows/publish_dev_docker_image.yaml
@@ -1,12 +1,12 @@
 # from https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images#publishing-images-to-github-packages
-name: Publish Docker image(latest)
+name: Publish Docker image(dev)
 on:
   push:
     branches:
       - main
 jobs:
   push_to_registry:
-    name: Push Docker image to GitHub Container Registry(latest)
+    name: Push Docker image to GitHub Container Registry(dev)
     runs-on: ubuntu-latest
     steps:
       -
@@ -26,5 +26,5 @@ jobs:
         name: Build and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:
-          tags: ghcr.io/sacloud/usacloud:latest
+          tags: ghcr.io/sacloud/usacloud:dev
           push: true

--- a/.github/workflows/publish_docker_image.yaml
+++ b/.github/workflows/publish_docker_image.yaml
@@ -31,5 +31,5 @@ jobs:
         name: Build and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: ${{ steps.docker_meta.outputs.tags }},ghcr.io/sacloud/usacloud:latest
           push: true


### PR DESCRIPTION
GitHub Container Registryで公開しているDockerイメージのタグ付けを修正

- push時: `dev`
- リリース時: `latest` + `[tag]`