### PR TITLE
proxy-lb: gzip-enabled

### DIFF
--- a/pkg/cmd/commands/proxylb/create.go
+++ b/pkg/cmd/commands/proxylb/create.go
@@ -53,6 +53,7 @@ type createParameter struct {
 	SorryServer    createParameterSorryServer `mapconv:",omitempty"`
 	LetsEncrypt    createParameterLetsEncrypt
 	StickySession  createParameterStickySession `mapconv:",omitempty"`
+	Gzip           createParameterGzip          `mapconv:",omitempty"`
 	Timeout        createParameterTimeout       `cli:",squash"`
 	UseVIPFailover bool                         `cli:"vip-fail-over"`
 	Region         string                       `cli:",options=proxylb_region" validate:"required,proxylb_region"`
@@ -87,6 +88,10 @@ type createParameterLetsEncrypt struct {
 
 type createParameterStickySession struct {
 	Method  string
+	Enabled bool
+}
+
+type createParameterGzip struct {
 	Enabled bool
 }
 
@@ -163,6 +168,9 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 		},
 		StickySession: createParameterStickySession{
 			Method:  "cookie",
+			Enabled: true,
+		},
+		Gzip: createParameterGzip{
 			Enabled: true,
 		},
 		Timeout: createParameterTimeout{

--- a/pkg/cmd/commands/proxylb/update.go
+++ b/pkg/cmd/commands/proxylb/update.go
@@ -57,6 +57,7 @@ type updateParameter struct {
 	SorryServer   updateParameterSorryServer   `mapconv:",omitempty"`
 	LetsEncrypt   updateParameterLetsEncrypt   `mapconv:",omitempty"`
 	StickySession updateParameterStickySession `mapconv:",omitempty"`
+	Gzip          updateParameterGzip          `mapconv:",omitempty"`
 	Timeout       updateParameterTimeout       `cli:",squash"`
 
 	BindPortsData *string                     `cli:"bind-ports" mapconv:"-"`
@@ -93,6 +94,10 @@ type updateParameterLetsEncrypt struct {
 
 type updateParameterStickySession struct {
 	Method  *string
+	Enabled *bool
+}
+
+type updateParameterGzip struct {
 	Enabled *bool
 }
 
@@ -162,6 +167,9 @@ func (p *updateParameter) ExampleParameters(ctx cli.Context) interface{} {
 		},
 		StickySession: updateParameterStickySession{
 			Method:  pointer.NewString("cookie"),
+			Enabled: pointer.NewBool(true),
+		},
+		Gzip: updateParameterGzip{
 			Enabled: pointer.NewBool(true),
 		},
 		Timeout: updateParameterTimeout{

--- a/pkg/cmd/commands/proxylb/zz_create_gen.go
+++ b/pkg/cmd/commands/proxylb/zz_create_gen.go
@@ -54,6 +54,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&p.LetsEncrypt.AcceptTOS, "lets-encrypt-accept-tos", "", p.LetsEncrypt.AcceptTOS, "The flag to accept the current Let's Encrypt terms of service(see: https://letsencrypt.org/repository/)")
 	fs.StringVarP(&p.StickySession.Method, "sticky-session-method", "", p.StickySession.Method, "")
 	fs.BoolVarP(&p.StickySession.Enabled, "sticky-session-enabled", "", p.StickySession.Enabled, "")
+	fs.BoolVarP(&p.Gzip.Enabled, "gzip-enabled", "", p.Gzip.Enabled, "")
 	fs.IntVarP(&p.Timeout.InactiveSec, "inactive-sec", "", p.Timeout.InactiveSec, "")
 	fs.BoolVarP(&p.UseVIPFailover, "vip-fail-over", "", p.UseVIPFailover, "")
 	fs.StringVarP(&p.Region, "region", "", p.Region, "(*required) options: [tk1/is1/anycast]")
@@ -97,6 +98,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("proxy-lb", pflag.ContinueOnError)
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("bind-ports"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("gzip-enabled"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-delay-loop"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-host"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-path"))

--- a/pkg/cmd/commands/proxylb/zz_update_gen.go
+++ b/pkg/cmd/commands/proxylb/zz_update_gen.go
@@ -71,6 +71,9 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("sticky-session-enabled") {
 		p.StickySession.Enabled = nil
 	}
+	if !fs.Changed("gzip-enabled") {
+		p.Gzip.Enabled = nil
+	}
 	if !fs.Changed("inactive-sec") {
 		p.Timeout.InactiveSec = nil
 	}
@@ -131,6 +134,9 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	if p.StickySession.Enabled == nil {
 		p.StickySession.Enabled = pointer.NewBool(false)
 	}
+	if p.Gzip.Enabled == nil {
+		p.Gzip.Enabled = pointer.NewBool(false)
+	}
 	if p.Timeout.InactiveSec == nil {
 		p.Timeout.InactiveSec = pointer.NewInt(0)
 	}
@@ -168,6 +174,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&p.LetsEncrypt.AcceptTOS, "lets-encrypt-accept-tos", "", p.LetsEncrypt.AcceptTOS, "The flag to accept the current Let's Encrypt terms of service(see: https://letsencrypt.org/repository/)")
 	fs.StringVarP(p.StickySession.Method, "sticky-session-method", "", "", "")
 	fs.BoolVarP(p.StickySession.Enabled, "sticky-session-enabled", "", false, "")
+	fs.BoolVarP(p.Gzip.Enabled, "gzip-enabled", "", false, "")
 	fs.IntVarP(p.Timeout.InactiveSec, "inactive-sec", "", 0, "")
 	fs.StringVarP(p.BindPortsData, "bind-ports", "", "", "")
 	fs.StringVarP(p.ServersData, "servers", "", "", "")
@@ -209,6 +216,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs = pflag.NewFlagSet("proxy-lb", pflag.ContinueOnError)
 		fs.SortFlags = false
 		fs.AddFlag(cmd.LocalFlags().Lookup("bind-ports"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("gzip-enabled"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-delay-loop"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-host"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-path"))


### PR DESCRIPTION
エンハンスドロードバランサでコンテンツのgzip圧縮を有効にするためのフラグ`--gzip-enabled`を追加
作成/更新時に指定可能