### PR TITLE
SimpleMonitor: Timeout

### DIFF
--- a/pkg/cmd/commands/simplemonitor/columns.go
+++ b/pkg/cmd/commands/simplemonitor/columns.go
@@ -26,5 +26,6 @@ var defaultColumnDefs = []output.ColumnDef{
 	ccol.Description,
 	{Name: "HealthCheck", Template: `{{ .HealthCheck.Protocol }}`},
 	{Name: "DelayLoop"},
+	{Name: "Timeout"},
 	{Name: "Enabled"},
 }

--- a/pkg/cmd/commands/simplemonitor/create.go
+++ b/pkg/cmd/commands/simplemonitor/create.go
@@ -46,6 +46,7 @@ type createParameter struct {
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
 
 	DelayLoop   int `validate:"min=60,max=3600"`
+	Timeout     int `validate:"omitempty,min=1,max=30"`
 	Enabled     bool
 	HealthCheck createParameterHealthCheck
 
@@ -94,6 +95,7 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 		TagsParameter:   examples.Tags,
 		IconIDParameter: examples.IconID,
 		DelayLoop:       60,
+		Timeout:         10,
 		Enabled:         true,
 		HealthCheck: createParameterHealthCheck{
 			Protocol:          examples.OptionsString("simple_monitor_protocol"),

--- a/pkg/cmd/commands/simplemonitor/update.go
+++ b/pkg/cmd/commands/simplemonitor/update.go
@@ -48,6 +48,7 @@ type updateParameter struct {
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
 	DelayLoop   *int `validate:"omitempty,min=60,max=3600"`
+	Timeout     *int `validate:"omitempty,min=1,max=30"`
 	Enabled     *bool
 	HealthCheck updateParameterHealthCheck `mapconv:",omitempty"`
 
@@ -91,6 +92,7 @@ func (p *updateParameter) ExampleParameters(ctx cli.Context) interface{} {
 		TagsUpdateParameter:   examples.TagsUpdate,
 		IconIDUpdateParameter: examples.IconIDUpdate,
 		DelayLoop:             pointer.NewInt(60),
+		Timeout:               pointer.NewInt(10),
 		Enabled:               pointer.NewBool(true),
 		HealthCheck: updateParameterHealthCheck{
 			Protocol:          pointer.NewString(examples.OptionsString("simple_monitor_protocol")),

--- a/pkg/cmd/commands/simplemonitor/zz_create_gen.go
+++ b/pkg/cmd/commands/simplemonitor/zz_create_gen.go
@@ -43,6 +43,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
 	fs.IntVarP(&p.DelayLoop, "delay-loop", "", p.DelayLoop, "")
+	fs.IntVarP(&p.Timeout, "timeout", "", p.Timeout, "")
 	fs.BoolVarP(&p.Enabled, "enabled", "", p.Enabled, "")
 	fs.StringVarP(&p.HealthCheck.Protocol, "health-check-protocol", "", p.HealthCheck.Protocol, "(*required) options: [http/https/ping/tcp/dns/ssh/smtp/pop3/snmp/sslcertificate]")
 	fs.IntVarP(&p.HealthCheck.Port, "health-check-port", "", p.HealthCheck.Port, "")
@@ -122,6 +123,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("notify-slack-enabled"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("slack-webhooks-url"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("target"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("timeout"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Simple-Monitor-specific options",
 			Flags: fs,

--- a/pkg/cmd/commands/simplemonitor/zz_update_gen.go
+++ b/pkg/cmd/commands/simplemonitor/zz_update_gen.go
@@ -38,6 +38,9 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("delay-loop") {
 		p.DelayLoop = nil
 	}
+	if !fs.Changed("timeout") {
+		p.Timeout = nil
+	}
 	if !fs.Changed("enabled") {
 		p.Enabled = nil
 	}
@@ -119,6 +122,9 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	if p.DelayLoop == nil {
 		p.DelayLoop = pointer.NewInt(0)
 	}
+	if p.Timeout == nil {
+		p.Timeout = pointer.NewInt(0)
+	}
 	if p.Enabled == nil {
 		p.Enabled = pointer.NewBool(false)
 	}
@@ -198,6 +204,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(p.Tags, "tags", "", nil, "")
 	fs.VarP(core.NewIDFlag(p.IconID, p.IconID), "icon-id", "", "")
 	fs.IntVarP(p.DelayLoop, "delay-loop", "", 0, "")
+	fs.IntVarP(p.Timeout, "timeout", "", 0, "")
 	fs.BoolVarP(p.Enabled, "enabled", "", false, "")
 	fs.StringVarP(p.HealthCheck.Protocol, "health-check-protocol", "", "", "options: [http/https/ping/tcp/dns/ssh/smtp/pop3/snmp/sslcertificate]")
 	fs.IntVarP(p.HealthCheck.Port, "health-check-port", "", 0, "")
@@ -276,6 +283,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("notify-interval"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("notify-slack-enabled"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("slack-webhooks-url"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("timeout"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Simple-Monitor-specific options",
 			Flags: fs,


### PR DESCRIPTION
from #835 

シンプル監視に監視タイムアウト設定用のパラメータ`--timeout`を追加

Note: 既存のシンプル監視を`usacloud simple-monitor ls`などで表示した際に`0`と表示されてしまうが、これはAPIレベルで`Timeout`項目が存在しないため。コントロールパネルとは異なる表示となるが挙動には問題なさそうなためこのままとする。