### PR TITLE
ELB: SSLPolicy

### DIFF
--- a/pkg/cmd/commands/proxylb/create.go
+++ b/pkg/cmd/commands/proxylb/create.go
@@ -194,6 +194,7 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 						Value:  "public, max-age=900",
 					},
 				},
+				SSLPolicy: examples.OptionsString("proxylb_ssl_policy"),
 			},
 		},
 		Servers: []*sacloud.ProxyLBServer{

--- a/pkg/cmd/commands/proxylb/update.go
+++ b/pkg/cmd/commands/proxylb/update.go
@@ -190,6 +190,7 @@ func (p *updateParameter) ExampleParameters(ctx cli.Context) interface{} {
 						Value:  "public, max-age=900",
 					},
 				},
+				SSLPolicy: examples.OptionsString("proxylb_ssl_policy"),
 			},
 		},
 		Servers: &[]*sacloud.ProxyLBServer{

--- a/pkg/vdef/definitions.go
+++ b/pkg/vdef/definitions.go
@@ -193,6 +193,11 @@ var definitions = map[string][]*definition{
 		{key: types.ProxyLBRegions.IS1.String(), value: types.ProxyLBRegions.IS1},
 		{key: types.ProxyLBRegions.Anycast.String(), value: types.ProxyLBRegions.Anycast},
 	},
+	"proxylb_ssl_policy": {
+		{key: "TLS-1-2-2019-04", value: "TLS-1-2-2019-04"},
+		{key: "TLS-1-2-2021-06", value: "TLS-1-2-2021-06"},
+		{key: "TLS-1-3-2021-06", value: "TLS-1-3-2021-06"},
+	},
 	"rest_method": {
 		{key: "get", value: "get"},
 		{key: "post", value: "post"},


### PR DESCRIPTION
from #835 

ELBにSSLPolicyを設定可能にする。
実行自体は #836 で対応済みなためこのPRではexampleの追加のみ。

```bash
usacloud proxy-lb create --example
{
    // 中略
    "BindPorts": [
        {
            "ProxyMode": "http | https | tcp",
            "Port": 80,
            "RedirectToHTTPS": true,
            "SupportHTTP2": true,
            "AddResponseHeader": [
                {
                    "Header": "Cache-Control",
                    "Value": "public, max-age=900"
                }
            ],
            "SSLPolicy": "TLS-1-2-2019-04 | TLS-1-2-2021-06 | TLS-1-3-2021-06"
        }
    ],
}

```
