### PR TITLE
ELB: Syslog

### DIFF
--- a/pkg/cmd/commands/proxylb/create.go
+++ b/pkg/cmd/commands/proxylb/create.go
@@ -56,6 +56,7 @@ type createParameter struct {
 	LetsEncrypt    createParameterLetsEncrypt
 	StickySession  createParameterStickySession `mapconv:",omitempty"`
 	Gzip           createParameterGzip          `mapconv:",omitempty"`
+	Syslog         createParameterSyslog        `mapconv:",omitempty"`
 	Timeout        createParameterTimeout       `cli:",squash"`
 	UseVIPFailover bool                         `cli:"vip-fail-over"`
 	Region         string                       `cli:",options=proxylb_region" validate:"required,proxylb_region"`
@@ -80,6 +81,11 @@ type createParameterHealthCheck struct {
 type createParameterSorryServer struct {
 	IPAddress string `cli:",aliases=ipaddress" validate:"omitempty,ipv4"`
 	Port      int    `validate:"omitempty,min=0,max=65535"`
+}
+
+type createParameterSyslog struct {
+	Server string `validate:"omitempty,ipv4"`
+	Port   int    `validate:"omitempty,min=0,max=65535"`
 }
 
 type createParameterLetsEncrypt struct {
@@ -176,6 +182,10 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 		},
 		Gzip: createParameterGzip{
 			Enabled: true,
+		},
+		Syslog: createParameterSyslog{
+			Server: examples.IPAddress,
+			Port:   514,
 		},
 		Timeout: createParameterTimeout{
 			InactiveSec: 10,

--- a/pkg/cmd/commands/proxylb/update.go
+++ b/pkg/cmd/commands/proxylb/update.go
@@ -60,6 +60,7 @@ type updateParameter struct {
 	LetsEncrypt   updateParameterLetsEncrypt   `mapconv:",omitempty"`
 	StickySession updateParameterStickySession `mapconv:",omitempty"`
 	Gzip          updateParameterGzip          `mapconv:",omitempty"`
+	Syslog        updateParameterSyslog        `mapconv:",omitempty"`
 	Timeout       updateParameterTimeout       `cli:",squash"`
 
 	BindPortsData *string                     `cli:"bind-ports" mapconv:"-"`
@@ -102,6 +103,11 @@ type updateParameterStickySession struct {
 
 type updateParameterGzip struct {
 	Enabled *bool
+}
+
+type updateParameterSyslog struct {
+	Server *string `validate:"omitempty,ipv4"`
+	Port   *int    `validate:"omitempty,min=0,max=65535"`
 }
 
 type updateParameterTimeout struct {
@@ -174,6 +180,10 @@ func (p *updateParameter) ExampleParameters(ctx cli.Context) interface{} {
 		},
 		Gzip: updateParameterGzip{
 			Enabled: pointer.NewBool(true),
+		},
+		Syslog: updateParameterSyslog{
+			Server: &examples.IPAddress,
+			Port:   pointer.NewInt(514),
 		},
 		Timeout: updateParameterTimeout{
 			InactiveSec: pointer.NewInt(10),

--- a/pkg/cmd/commands/proxylb/zz_create_gen.go
+++ b/pkg/cmd/commands/proxylb/zz_create_gen.go
@@ -56,6 +56,8 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.StickySession.Method, "sticky-session-method", "", p.StickySession.Method, "")
 	fs.BoolVarP(&p.StickySession.Enabled, "sticky-session-enabled", "", p.StickySession.Enabled, "")
 	fs.BoolVarP(&p.Gzip.Enabled, "gzip-enabled", "", p.Gzip.Enabled, "")
+	fs.StringVarP(&p.Syslog.Server, "syslog-server", "", p.Syslog.Server, "")
+	fs.IntVarP(&p.Syslog.Port, "syslog-port", "", p.Syslog.Port, "")
 	fs.IntVarP(&p.Timeout.InactiveSec, "inactive-sec", "", p.Timeout.InactiveSec, "")
 	fs.BoolVarP(&p.UseVIPFailover, "vip-fail-over", "", p.UseVIPFailover, "")
 	fs.StringVarP(&p.Region, "region", "", p.Region, "(*required) options: [tk1/is1/anycast]")
@@ -117,6 +119,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("sorry-server-port"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("sticky-session-enabled"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("sticky-session-method"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("syslog-port"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("syslog-server"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("vip-fail-over"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Proxy-Lb-specific options",

--- a/pkg/cmd/commands/proxylb/zz_update_gen.go
+++ b/pkg/cmd/commands/proxylb/zz_update_gen.go
@@ -77,6 +77,12 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("gzip-enabled") {
 		p.Gzip.Enabled = nil
 	}
+	if !fs.Changed("syslog-server") {
+		p.Syslog.Server = nil
+	}
+	if !fs.Changed("syslog-port") {
+		p.Syslog.Port = nil
+	}
 	if !fs.Changed("inactive-sec") {
 		p.Timeout.InactiveSec = nil
 	}
@@ -143,6 +149,12 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	if p.Gzip.Enabled == nil {
 		p.Gzip.Enabled = pointer.NewBool(false)
 	}
+	if p.Syslog.Server == nil {
+		p.Syslog.Server = pointer.NewString("")
+	}
+	if p.Syslog.Port == nil {
+		p.Syslog.Port = pointer.NewInt(0)
+	}
 	if p.Timeout.InactiveSec == nil {
 		p.Timeout.InactiveSec = pointer.NewInt(0)
 	}
@@ -182,6 +194,8 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.StickySession.Method, "sticky-session-method", "", "", "")
 	fs.BoolVarP(p.StickySession.Enabled, "sticky-session-enabled", "", false, "")
 	fs.BoolVarP(p.Gzip.Enabled, "gzip-enabled", "", false, "")
+	fs.StringVarP(p.Syslog.Server, "syslog-server", "", "", "")
+	fs.IntVarP(p.Syslog.Port, "syslog-port", "", 0, "")
 	fs.IntVarP(p.Timeout.InactiveSec, "inactive-sec", "", 0, "")
 	fs.StringVarP(p.BindPortsData, "bind-ports", "", "", "")
 	fs.StringVarP(p.ServersData, "servers", "", "", "")
@@ -240,6 +254,8 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("sorry-server-port"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("sticky-session-enabled"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("sticky-session-method"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("syslog-port"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("syslog-server"))
 		sets = append(sets, &core.FlagSet{
 			Title: "Proxy-Lb-specific options",
 			Flags: fs,


### PR DESCRIPTION
from #835 

ELBでsyslog設定を行えるようにする。

```bash
$ usacloud proxy-lb create -h
Usage:
  usacloud proxy-lb create [flags]

Flags:

  === Proxy-Lb-specific options ===

      # 中略

      --syslog-port int                          
      --syslog-server string                     
```