### PR TITLE
Added LatestLogs field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/rhysd/go-github-selfupdate v1.2.3
-	github.com/sacloud/libsacloud/v2 v2.20.2
+	github.com/sacloud/libsacloud/v2 v2.21.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
-github.com/sacloud/libsacloud/v2 v2.20.2 h1:sYnPSN64ZLSTOWswX+6SyQPIDoaO9Yzx4IHuDuetyQE=
-github.com/sacloud/libsacloud/v2 v2.20.2/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
+github.com/sacloud/libsacloud/v2 v2.21.0 h1:558p5qLiAMF7La965aWmnb2RfXZR3lLE7YxB/21DjHY=
+github.com/sacloud/libsacloud/v2 v2.21.0/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cmd/commands/simplemonitor/health.go
+++ b/pkg/cmd/commands/simplemonitor/health.go
@@ -32,6 +32,7 @@ var healthCommand = &core.Command{
 		{Name: "LastCheckedAt"},
 		{Name: "LastHealthChangedAt"},
 		{Name: "Health"},
+		{Name: "LatestLogs", Template: `{{ .LatestLogs | first_line | ellipsis 100 }}`},
 	},
 
 	SelectorType: core.SelectorTypeRequireMulti,

--- a/pkg/vdef/template_funcs.go
+++ b/pkg/vdef/template_funcs.go
@@ -68,6 +68,17 @@ var TemplateFuncMap = template.FuncMap{
 		v := fmt.Sprintf("%v", value)
 		return strings.ReplaceAll(v, "\n", "\\n")
 	},
+	"first_line": func(value interface{}) interface{} {
+		if value == nil {
+			return nil
+		}
+		if v, ok := value.([]string); ok {
+			if len(v) > 0 {
+				return v[0]
+			}
+		}
+		return ""
+	},
 	"weekdays": func(value interface{}) interface{} {
 		if value == nil {
 			return nil


### PR DESCRIPTION
シンプル監視で`LatestLogs`を参照可能にする。
table形式の場合は`LatestLogs`の先頭要素の先頭100文字までを表示する

```bash
$ usacloud simple-monitor health example.com
+--------------+-------------------------------+-------------------------------+--------+---------------------------------------------------------------------------------------------------------+
|      ID      |         LastCheckedAt         |      LastHealthChangedAt      | Health |                                               LatestLogs                                                |
+--------------+-------------------------------+-------------------------------+--------+---------------------------------------------------------------------------------------------------------+
| 123456789012 | 2021-07-19 15:11:26 +0900 JST | 2020-08-03 15:20:02 +0900 JST | UP     | [Mon Jul 19 00:00:00 2021] CURRENT SERVICE STATE: 123456789012; 123456789012;OK;HARD;1;HTTP OK: Statu... |
+--------------+-------------------------------+-------------------------------+--------+---------------------------------------------------------------------------------------------------------+

```