### PR TITLE
libsacloud v2.22.0 - includes @previous-id support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/rhysd/go-github-selfupdate v1.2.3
-	github.com/sacloud/libsacloud/v2 v2.21.1
+	github.com/sacloud/libsacloud/v2 v2.22.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
-github.com/sacloud/libsacloud/v2 v2.21.1 h1:mDsEIrvOcm0l/pjZk0DnfKLOyHtTeIFpZ/ZbvTWOwQE=
-github.com/sacloud/libsacloud/v2 v2.21.1/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
+github.com/sacloud/libsacloud/v2 v2.22.0 h1:kYHezSFHN9giqEw10aU2OJg3Bqt8Mtq9VGNaGDdLxOs=
+github.com/sacloud/libsacloud/v2 v2.22.0/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
https://github.com/sacloud/libsacloud/pull/780 の対応を含むlibsacloud v2.22.0へ更新

Note: Usacloudは基本的にlibsacloudのhelper/serviceを呼び出すのみで、例外として一部の特殊なコマンドのみusacloud側で処理を実装している。プラン変更コマンドの実装はhelper/serviceの呼び出しのみで上記の特殊なコマンドには該当しないため、libsacloud v2.22へ更新するだけで@previous-idタグ対応版に切り替わる。