### PR TITLE
cloud-init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/rhysd/go-github-selfupdate v1.2.3
-	github.com/sacloud/libsacloud/v2 v2.22.0
+	github.com/sacloud/libsacloud/v2 v2.23.1-0.20210818024308-5d354df5bc17
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
-github.com/sacloud/libsacloud/v2 v2.22.0 h1:kYHezSFHN9giqEw10aU2OJg3Bqt8Mtq9VGNaGDdLxOs=
-github.com/sacloud/libsacloud/v2 v2.22.0/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
+github.com/sacloud/libsacloud/v2 v2.23.1-0.20210818024308-5d354df5bc17 h1:AV8/RsIFpxkaAa1rNh6yHd4CCKA+470nwlYFJhxPKKg=
+github.com/sacloud/libsacloud/v2 v2.23.1-0.20210818024308-5d354df5bc17/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cmd/commands/server/zz_boot_gen.go
+++ b/pkg/cmd/commands/server/zz_boot_gen.go
@@ -33,6 +33,7 @@ func (p *bootParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Parameters, "parameters", "", p.Parameters, "Input parameters in JSON format")
 	fs.BoolVarP(&p.GenerateSkeleton, "generate-skeleton", "", p.GenerateSkeleton, "Output skeleton of parameters with JSON format (aliases: --skeleton)")
 	fs.BoolVarP(&p.Example, "example", "", p.Example, "Output example parameters with JSON format")
+	fs.StringVarP(&p.UserData, "user-data", "", p.UserData, "")
 	fs.BoolVarP(&p.NoWait, "no-wait", "", p.NoWait, "")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
@@ -47,6 +48,16 @@ func (p *bootParameter) normalizeFlagName(_ *pflag.FlagSet, name string) pflag.N
 
 func (p *bootParameter) buildFlagsUsage(cmd *cobra.Command) {
 	var sets []*core.FlagSet
+	{
+		var fs *pflag.FlagSet
+		fs = pflag.NewFlagSet("server", pflag.ContinueOnError)
+		fs.SortFlags = false
+		fs.AddFlag(cmd.LocalFlags().Lookup("user-data"))
+		sets = append(sets, &core.FlagSet{
+			Title: "Server-specific options",
+			Flags: fs,
+		})
+	}
 	{
 		var fs *pflag.FlagSet
 		fs = pflag.NewFlagSet("zone", pflag.ContinueOnError)

--- a/pkg/vdef/template_funcs.go
+++ b/pkg/vdef/template_funcs.go
@@ -17,15 +17,15 @@ package vdef
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"text/template"
 	"time"
 
-	"github.com/sacloud/libsacloud/v2/sacloud"
-
-	"github.com/sacloud/libsacloud/v2/sacloud/types"
-
+	"github.com/mitchellh/go-homedir"
 	"github.com/sacloud/libsacloud/v2/pkg/size"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/usacloud/pkg/util"
 )
 
@@ -128,6 +128,25 @@ var TemplateFuncMap = template.FuncMap{
 		}
 		v := time.Unix(value/1000, 0)
 		return &v
+	},
+	"file": func(path string) string {
+		if path == "" {
+			return ""
+		}
+
+		poc, err := homedir.Expand(path)
+		if err != nil {
+			return ""
+		}
+
+		data, err := os.ReadFile(poc)
+		if err != nil {
+			return ""
+		}
+		return string(data)
+	},
+	"trim_space": func(s string) string {
+		return strings.TrimSpace(s)
 	},
 }
 


### PR DESCRIPTION
サーバ起動時にUserDataを指定可能にする。

```bash
usacloud server boot --user-data="path or string" <サーバのID or Name>
```

`--user-data`にはファイルパス or 文字列を指定する。  
内容は [cloud-config](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)形式で指定する。

cloud-configの組み立てを簡易化するために`--format`で指定可能なGoテンプレートに以下のfuncを追加している。

- `file`: 引数にファイルパスを受け取り、読み込んで文字列として返す
- `trim_space`: 引数に文字列を受け取り、[strings.TrimSpace](https://pkg.go.dev/strings#TrimSpace)を呼び出した結果を返す

### 利用例

`--format`を使いcloud-configを組み立てる。`runcmd`でnetplanを実行しNICの設定を行う。

```bash
$ cat cloud-config.tmpl

#cloud-config
hostname: {{.Name}}
password: {{ file ".passwd" | trim_space }}
chpasswd: {expire: False}
ssh_pwauth: False
ssh_authorized_keys:
 - {{ file "~/.ssh/id_rsa.pub" | trim_space }}

write_files:
- path: /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
  permissions: '0644'
  content: |
    network: {config: disabled}

{{ $nameservers := .Zone.Region.NameServers }}
{{ range $i, $v := .Interfaces }}
- path: /etc/netplan/90-eth{{$i}}.yaml
  permissions: '0644'
  content: |
    network:
      version: 2
      ethernets:
        eth{{$i}}:
          match:
            macaddress: {{ $v.MACAddress }}
          dhcp4: false
          addresses: [{{ $v.IPAddress }}/{{ $v.SubnetNetworkMaskLen }}]
          gateway4: {{ $v.SubnetDefaultRoute }}
          set-name: eth{{$i}}
{{ if eq $i 0 }}
          nameservers:
           addresses:
{{ range $nameservers }}
             - {{ . }}
{{ end }}

{{ end }}
{{ end }}

runcmd:
 - "rm -f /etc/netplan/50-cloud-init.yaml"
 - netplan generate
 - netplan apply

# テンプレートからcloud-configを作成
$ usacloud server read --format cloud-config.tmpl example > cloud-config.yaml

# 作成したファイルを用いて起動
$ usacloud server boot --user-data cloud-config.yaml example
```

