### PR TITLE
SimpleMonitor: FTP/FTPS

### DIFF
--- a/pkg/cmd/commands/simplemonitor/create.go
+++ b/pkg/cmd/commands/simplemonitor/create.go
@@ -74,6 +74,7 @@ type createParameterHealthCheck struct {
 	OID               string `json:",omitempty"`
 	RemainingDays     int    `json:",omitempty"`
 	HTTP2             bool   `cli:"http2" json:",omitempty"`
+	FTPS              string `cli:",options=simple_monitor_ftps" mapconv:",filters=simple_monitor_ftps_to_value" validate:"omitempty,simple_monitor_ftps" json:",omitempty"`
 }
 
 func newCreateParameter() *createParameter {
@@ -108,6 +109,7 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 			BasicAuthUsername: "username",
 			BasicAuthPassword: "password",
 			HTTP2:             true,
+			FTPS:              examples.OptionsString("simple_monitor_ftps"),
 		},
 		NotifyEmailEnabled: true,
 		NotifyEmailHTML:    true,

--- a/pkg/cmd/commands/simplemonitor/update.go
+++ b/pkg/cmd/commands/simplemonitor/update.go
@@ -76,6 +76,7 @@ type updateParameterHealthCheck struct {
 	OID               *string `json:",omitempty"`
 	RemainingDays     *int    `json:",omitempty"`
 	HTTP2             *bool   `cli:"http2" json:",omitempty"`
+	FTPS              *string `cli:",options=simple_monitor_ftps" mapconv:",omitempty,filters=simple_monitor_ftps_to_value" validate:"omitempty,simple_monitor_ftps" json:",omitempty"`
 }
 
 func newUpdateParameter() *updateParameter {
@@ -105,6 +106,7 @@ func (p *updateParameter) ExampleParameters(ctx cli.Context) interface{} {
 			BasicAuthUsername: pointer.NewString("username"),
 			BasicAuthPassword: pointer.NewString("password"),
 			HTTP2:             pointer.NewBool(true),
+			FTPS:              pointer.NewString(examples.OptionsString("simple_monitor_ftps")),
 		},
 		NotifyEmailEnabled: pointer.NewBool(true),
 		NotifyEmailHTML:    pointer.NewBool(true),

--- a/pkg/cmd/commands/simplemonitor/zz_create_gen.go
+++ b/pkg/cmd/commands/simplemonitor/zz_create_gen.go
@@ -45,7 +45,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.IntVarP(&p.DelayLoop, "delay-loop", "", p.DelayLoop, "")
 	fs.IntVarP(&p.Timeout, "timeout", "", p.Timeout, "")
 	fs.BoolVarP(&p.Enabled, "enabled", "", p.Enabled, "")
-	fs.StringVarP(&p.HealthCheck.Protocol, "health-check-protocol", "", p.HealthCheck.Protocol, "(*required) options: [http/https/ping/tcp/dns/ssh/smtp/pop3/snmp/sslcertificate]")
+	fs.StringVarP(&p.HealthCheck.Protocol, "health-check-protocol", "", p.HealthCheck.Protocol, "(*required) options: [http/https/ping/tcp/dns/ssh/smtp/pop3/snmp/sslcertificate/ftp]")
 	fs.IntVarP(&p.HealthCheck.Port, "health-check-port", "", p.HealthCheck.Port, "")
 	fs.StringVarP(&p.HealthCheck.Path, "health-check-path", "", p.HealthCheck.Path, "")
 	fs.IntVarP(&p.HealthCheck.Status, "health-check-status", "", p.HealthCheck.Status, "")
@@ -61,6 +61,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.HealthCheck.OID, "health-check-oid", "", p.HealthCheck.OID, "")
 	fs.IntVarP(&p.HealthCheck.RemainingDays, "health-check-remaining-days", "", p.HealthCheck.RemainingDays, "")
 	fs.BoolVarP(&p.HealthCheck.HTTP2, "health-check-http2", "", p.HealthCheck.HTTP2, "")
+	fs.StringVarP(&p.HealthCheck.FTPS, "health-check-ftps", "", p.HealthCheck.FTPS, "options: [explicit/implicit]")
 	fs.BoolVarP(&p.NotifyEmailEnabled, "notify-email-enabled", "", p.NotifyEmailEnabled, "")
 	fs.BoolVarP(&p.NotifyEmailHTML, "notify-email-html", "", p.NotifyEmailHTML, "")
 	fs.BoolVarP(&p.NotifySlackEnabled, "notify-slack-enabled", "", p.NotifySlackEnabled, "")
@@ -106,6 +107,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-community"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-contains-string"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-expected-data"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-ftps"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-host"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-http2"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-oid"))
@@ -170,7 +172,8 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *createParameter) setCompletionFunc(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc("health-check-protocol", util.FlagCompletionFunc("http", "https", "ping", "tcp", "dns", "ssh", "smtp", "pop3", "snmp", "sslcertificate"))
+	cmd.RegisterFlagCompletionFunc("health-check-protocol", util.FlagCompletionFunc("http", "https", "ping", "tcp", "dns", "ssh", "smtp", "pop3", "snmp", "sslcertificate", "ftp"))
+	cmd.RegisterFlagCompletionFunc("health-check-ftps", util.FlagCompletionFunc("explicit", "implicit"))
 
 }
 

--- a/pkg/cmd/commands/simplemonitor/zz_update_gen.go
+++ b/pkg/cmd/commands/simplemonitor/zz_update_gen.go
@@ -92,6 +92,9 @@ func (p *updateParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 	if !fs.Changed("health-check-http2") {
 		p.HealthCheck.HTTP2 = nil
 	}
+	if !fs.Changed("health-check-ftps") {
+		p.HealthCheck.FTPS = nil
+	}
 	if !fs.Changed("notify-email-enabled") {
 		p.NotifyEmailEnabled = nil
 	}
@@ -176,6 +179,9 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	if p.HealthCheck.HTTP2 == nil {
 		p.HealthCheck.HTTP2 = pointer.NewBool(false)
 	}
+	if p.HealthCheck.FTPS == nil {
+		p.HealthCheck.FTPS = pointer.NewString("")
+	}
 	if p.NotifyEmailEnabled == nil {
 		p.NotifyEmailEnabled = pointer.NewBool(false)
 	}
@@ -206,7 +212,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.IntVarP(p.DelayLoop, "delay-loop", "", 0, "")
 	fs.IntVarP(p.Timeout, "timeout", "", 0, "")
 	fs.BoolVarP(p.Enabled, "enabled", "", false, "")
-	fs.StringVarP(p.HealthCheck.Protocol, "health-check-protocol", "", "", "options: [http/https/ping/tcp/dns/ssh/smtp/pop3/snmp/sslcertificate]")
+	fs.StringVarP(p.HealthCheck.Protocol, "health-check-protocol", "", "", "options: [http/https/ping/tcp/dns/ssh/smtp/pop3/snmp/sslcertificate/ftp]")
 	fs.IntVarP(p.HealthCheck.Port, "health-check-port", "", 0, "")
 	fs.StringVarP(p.HealthCheck.Path, "health-check-path", "", "", "")
 	fs.IntVarP(p.HealthCheck.Status, "health-check-status", "", 0, "")
@@ -222,6 +228,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.HealthCheck.OID, "health-check-oid", "", "", "")
 	fs.IntVarP(p.HealthCheck.RemainingDays, "health-check-remaining-days", "", 0, "")
 	fs.BoolVarP(p.HealthCheck.HTTP2, "health-check-http2", "", false, "")
+	fs.StringVarP(p.HealthCheck.FTPS, "health-check-ftps", "", "", "options: [explicit/implicit]")
 	fs.BoolVarP(p.NotifyEmailEnabled, "notify-email-enabled", "", false, "")
 	fs.BoolVarP(p.NotifyEmailHTML, "notify-email-html", "", false, "")
 	fs.BoolVarP(p.NotifySlackEnabled, "notify-slack-enabled", "", false, "")
@@ -267,6 +274,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-community"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-contains-string"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-expected-data"))
+		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-ftps"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-host"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-http2"))
 		fs.AddFlag(cmd.LocalFlags().Lookup("health-check-oid"))
@@ -330,7 +338,8 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *updateParameter) setCompletionFunc(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc("health-check-protocol", util.FlagCompletionFunc("http", "https", "ping", "tcp", "dns", "ssh", "smtp", "pop3", "snmp", "sslcertificate"))
+	cmd.RegisterFlagCompletionFunc("health-check-protocol", util.FlagCompletionFunc("http", "https", "ping", "tcp", "dns", "ssh", "smtp", "pop3", "snmp", "sslcertificate", "ftp"))
+	cmd.RegisterFlagCompletionFunc("health-check-ftps", util.FlagCompletionFunc("explicit", "implicit"))
 
 }
 

--- a/pkg/vdef/definitions.go
+++ b/pkg/vdef/definitions.go
@@ -232,6 +232,11 @@ var definitions = map[string][]*definition{
 		{key: types.SimpleMonitorProtocols.POP3.String(), value: types.SimpleMonitorProtocols.POP3},
 		{key: types.SimpleMonitorProtocols.SNMP.String(), value: types.SimpleMonitorProtocols.SNMP},
 		{key: types.SimpleMonitorProtocols.SSLCertificate.String(), value: types.SimpleMonitorProtocols.SSLCertificate},
+		{key: types.SimpleMonitorProtocols.FTP.String(), value: types.SimpleMonitorProtocols.FTP},
+	},
+	"simple_monitor_ftps": {
+		{key: types.SimpleMonitorFTPSValues.Explicit.String(), value: types.SimpleMonitorFTPSValues.Explicit},
+		{key: types.SimpleMonitorFTPSValues.Implicit.String(), value: types.SimpleMonitorFTPSValues.Implicit},
 	},
 	"vpc_router_plan": {
 		{key: "standard", value: types.VPCRouterPlans.Standard},


### PR DESCRIPTION
シンプル監視でのFTP/FTPS監視に対応する。

 - create/updateでヘルスチェックプロトコルとして`ftp`を指定可能に
 - ヘルスチェックのパラメータとして`--health-check-ftps`を指定可能に

```bash
usacloud simple-monitor create --example
{
    "Target": "www.example.com",
    "Description": "example",
    "Tags": [
        "tag1=example1",
        "tag2=example2"
    ],
    "IconID": 123456789012,
    "DelayLoop": 60,
    "Timeout": 10,
    "Enabled": true,
    "HealthCheck": {
        "Protocol": "http | https | ping | tcp | dns | ssh | smtp | pop3 | snmp | sslcertificate | ftp",
        "Port": 80,
        "Path": "/healthz",
        "Status": 200,
        "ContainsString": "ok",
        "SNI": true,
        "Host": "www2.example.com",
        "BasicAuthUsername": "username",
        "BasicAuthPassword": "password",
        "HTTP2": true,
        "FTPS": "explicit | implicit"
    },
    "NotifyEmailEnabled": true,
    "NotifyEmailHTML": true,
    "NotifySlackEnabled": true,
    "SlackWebhooksURL": "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX",
    "NotifyInterval": 7200
}
```