### PR TITLE
rest: added PATCH method

### DIFF
--- a/pkg/cmd/commands/rest/zz_request_gen.go
+++ b/pkg/cmd/commands/rest/zz_request_gen.go
@@ -30,7 +30,7 @@ func (p *requestParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 func (p *requestParameter) buildFlags(fs *pflag.FlagSet) {
 
 	fs.StringVarP(&p.Zone, "zone", "", p.Zone, "")
-	fs.StringVarP(&p.Method, "method", "X", p.Method, "(*required) options: [get/post/put/delete/GET/POST/PUT/DELETE]")
+	fs.StringVarP(&p.Method, "method", "X", p.Method, "(*required) options: [get/post/patch/put/delete/GET/POST/PATCH/PUT/DELETE]")
 	fs.StringVarP(&p.Data, "data", "d", p.Data, "")
 	fs.StringVarP(&p.Query, "query", "", p.Query, "Query for JSON output")
 	fs.StringVarP(&p.QueryDriver, "query-driver", "", p.QueryDriver, "Name of the driver that handles queries to JSON output options: [jmespath/jq]")
@@ -71,7 +71,7 @@ func (p *requestParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *requestParameter) setCompletionFunc(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc("method", util.FlagCompletionFunc("get", "post", "put", "delete", "GET", "POST", "PUT", "DELETE"))
+	cmd.RegisterFlagCompletionFunc("method", util.FlagCompletionFunc("get", "post", "patch", "put", "delete", "GET", "POST", "PATCH", "PUT", "DELETE"))
 
 }
 

--- a/pkg/vdef/definitions.go
+++ b/pkg/vdef/definitions.go
@@ -207,10 +207,12 @@ var definitions = map[string][]*definition{
 	"rest_method": {
 		{key: "get", value: "get"},
 		{key: "post", value: "post"},
+		{key: "patch", value: "patch"},
 		{key: "put", value: "put"},
 		{key: "delete", value: "delete"},
 		{key: "GET", value: "get"},
 		{key: "POST", value: "post"},
+		{key: "PATCH", value: "patch"},
 		{key: "PUT", value: "put"},
 		{key: "DELETE", value: "delete"},
 	},


### PR DESCRIPTION
closes #869 

restコマンドでPATCHメソッドを利用可能にする。

```bash
usacloud rest --help

...略...

  -X, --method string         (*required) options: [get/post/patch/put/delete/GET/POST/PATCH/PUT/DELETE] (default "get")

...略...

```