### PR TITLE
Update os-type item in the help

### DIFF
--- a/pkg/cmd/commands/archive/zz_list_gen.go
+++ b/pkg/cmd/commands/archive/zz_list_gen.go
@@ -43,7 +43,7 @@ func (p *listParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVarP(&p.Names, "names", "", p.Names, "")
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.StringVarP(&p.Scope, "scope", "", p.Scope, "options: [user/shared]")
-	fs.StringVarP(&p.OSType, "os-type", "", p.OSType, "options: [centos/centos8stream/centos8/ubuntu/ubuntu2004/debian/debian11/rancheros/k3os/...]")
+	fs.StringVarP(&p.OSType, "os-type", "", p.OSType, "options: [almalinux/rockylinux/miraclelinux/centos8stream/ubuntu/debian/rancheros/k3os/...]")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
 

--- a/pkg/cmd/commands/cdrom/zz_list_gen.go
+++ b/pkg/cmd/commands/cdrom/zz_list_gen.go
@@ -42,7 +42,7 @@ func (p *listParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.QueryDriver, "query-driver", "", p.QueryDriver, "Name of the driver that handles queries to JSON output options: [jmespath/jq]")
 	fs.StringSliceVarP(&p.Names, "names", "", p.Names, "")
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
-	fs.StringVarP(&p.OSType, "os-type", "", p.OSType, "options: [centos/centos8stream/centos8/ubuntu/ubuntu2004/debian/debian11/rancheros/k3os/...]")
+	fs.StringVarP(&p.OSType, "os-type", "", p.OSType, "options: [almalinux/rockylinux/miraclelinux/centos8stream/ubuntu/debian/rancheros/k3os/...]")
 	fs.StringVarP(&p.Scope, "scope", "", p.Scope, "options: [user/shared]")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }

--- a/pkg/cmd/commands/disk/zz_create_gen.go
+++ b/pkg/cmd/commands/disk/zz_create_gen.go
@@ -46,7 +46,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.DiskPlan, "disk-plan", "", p.DiskPlan, "(*required) options: [ssd/hdd]")
 	fs.IntVarP(&p.SizeGB, "size", "", p.SizeGB, "")
 	fs.StringVarP(&p.Connection, "connector", "", p.Connection, "(*required) options: [virtio/ide] (aliases: --connection)")
-	fs.StringVarP(&p.OSType, "os-type", "", p.OSType, "options: [centos/centos8stream/centos8/ubuntu/ubuntu2004/debian/debian11/rancheros/k3os/...]")
+	fs.StringVarP(&p.OSType, "os-type", "", p.OSType, "options: [almalinux/rockylinux/miraclelinux/centos8stream/ubuntu/debian/rancheros/k3os/...]")
 	fs.VarP(core.NewIDFlag(&p.SourceDiskID, &p.SourceDiskID), "source-disk-id", "", "")
 	fs.VarP(core.NewIDFlag(&p.SourceArchiveID, &p.SourceArchiveID), "source-archive-id", "", "")
 	fs.VarP(core.NewIDFlag(&p.ServerID, &p.ServerID), "server-id", "", "")

--- a/pkg/cmd/commands/server/zz_create_gen.go
+++ b/pkg/cmd/commands/server/zz_create_gen.go
@@ -67,7 +67,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.VarP(core.NewIDFlag(&p.Disk.SourceArchiveID, &p.Disk.SourceArchiveID), "disk-source-archive-id", "", "")
 	fs.IntVarP(&p.Disk.SizeGB, "disk-size", "", p.Disk.SizeGB, "(aliases: --size-gb)")
 	fs.VarP(core.NewIDSliceFlag(&p.Disk.DistantFrom, &p.Disk.DistantFrom), "disk-distant-from", "", "")
-	fs.StringVarP(&p.Disk.OSType, "disk-os-type", "", p.Disk.OSType, "options: [centos/centos8stream/centos8/ubuntu/ubuntu2004/debian/debian11/rancheros/k3os/...]")
+	fs.StringVarP(&p.Disk.OSType, "disk-os-type", "", p.Disk.OSType, "options: [almalinux/rockylinux/miraclelinux/centos8stream/ubuntu/debian/rancheros/k3os/...]")
 	fs.StringVarP(&p.Disk.EditDisk.HostName, "disk-edit-host-name", "", p.Disk.EditDisk.HostName, "")
 	fs.StringVarP(&p.Disk.EditDisk.Password, "disk-edit-password", "", p.Disk.EditDisk.Password, "")
 	fs.StringVarP(&p.Disk.EditDisk.IPAddress, "disk-edit-ip-address", "", p.Disk.EditDisk.IPAddress, "")

--- a/pkg/vdef/options.go
+++ b/pkg/vdef/options.go
@@ -19,13 +19,12 @@ package vdef
 // Note: コード生成で利用されるため実行時に動的に変化する項目には利用できない
 var FlagOptionsMap = map[string][]string{
 	"os_type_simple": {
-		"centos",
+		"almalinux",
+		"rockylinux",
+		"miraclelinux",
 		"centos8stream",
-		"centos8",
 		"ubuntu",
-		"ubuntu2004",
 		"debian",
-		"debian11",
 		"rancheros",
 		"k3os",
 		"...",


### PR DESCRIPTION
`os-type`を指定可能な各コマンドでヘルプ表示時の`os-type`の説明に記載されているアイテムを更新する。

更新前:
```console
--os-type string   options: [centos/centos8stream/centos8/ubuntu/ubuntu2004/debian/debian11/coreos/rancheros/k3os/freebsd/...]
```

更新後:
```console
--os-type string   options: [almalinux/rockylinux/miraclelinux/centos8stream/ubuntu/debian/rancheros/k3os/...]
```