### PR TITLE
既存コマンドをiaasサブコマンド配下に移動&エイリアス設定

### DIFF
--- a/e2e/commands.go
+++ b/e2e/commands.go
@@ -14,20 +14,29 @@
 
 package e2e
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
 
-func UsacloudRun(args ...string) error {
-	return usacloudCmd(args...).Run()
+func UsacloudRun(t *testing.T, args ...string) error {
+	return usacloudCmd(t, args...).Run()
 }
 
-func UsacloudRunWithOutput(args ...string) ([]byte, error) {
-	return usacloudCmd(args...).Output()
+func UsacloudRunWithOutput(t *testing.T, args ...string) ([]byte, error) {
+	return usacloudCmd(t, args...).Output()
 }
 
-func UsacloudRunWithCombinedOutput(args ...string) ([]byte, error) {
-	return usacloudCmd(args...).CombinedOutput()
+func UsacloudRunWithCombinedOutput(t *testing.T, args ...string) ([]byte, error) {
+	return usacloudCmd(t, args...).CombinedOutput()
 }
 
-func usacloudCmd(args ...string) *exec.Cmd {
-	return exec.Command("usacloud", args...)
+func usacloudCmd(t *testing.T, args ...string) *exec.Cmd {
+	cmd := "usacloud"
+	if overwrite := os.Getenv("USACLOUD_COMMAND"); overwrite != "" {
+		cmd = overwrite
+		t.Logf("using `usacloud` from custom path: %s", cmd)
+	}
+	return exec.Command(cmd, args...)
 }

--- a/e2e/minimum/e2e_test.go
+++ b/e2e/minimum/e2e_test.go
@@ -18,23 +18,22 @@
 package minimum
 
 import (
-	"os/exec"
 	"testing"
+
+	"github.com/sacloud/usacloud/e2e"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestE2E_minimum(t *testing.T) {
-	cmd := exec.Command("usacloud", "-h")
-	output, err := cmd.Output()
+	output, err := e2e.UsacloudRunWithOutput(t, "-h")
 
 	require.NoError(t, err)
 	require.NotEmpty(t, output)
 }
 
 func TestE2E_invalidSubCommand(t *testing.T) {
-	cmd := exec.Command("usacloud", "invalid subcommand")
-	err := cmd.Run()
+	err := e2e.UsacloudRun(t, "invalid subcommand")
 
 	require.Error(t, err)
 }

--- a/e2e/old-iaas-command/e2e.tf
+++ b/e2e/old-iaas-command/e2e.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    sakuracloud = {
+      source  = "sacloud/sakuracloud"
+      version = "2.16.2"
+    }
+  }
+}
+
+locals {
+  zones = ["is1a", "is1b", "tk1a", "tk1b"]
+}
+
+resource "sakuracloud_server" "server" {
+  count = length(local.zones)
+
+  zone = local.zones[count.index]
+  name = format("usacloud-e2e-old-iaas-command%02d", count.index)
+
+  force_shutdown = true
+}

--- a/e2e/old-iaas-command/e2e_test.go
+++ b/e2e/old-iaas-command/e2e_test.go
@@ -1,0 +1,72 @@
+// Copyright 2017-2022 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package old_iaas_command
+
+import (
+	"testing"
+
+	"github.com/sacloud/usacloud/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2E_oldIaaSCommand(t *testing.T) {
+	// **************************************************************
+	// step1: iaasサブコマンドを実行できるか?
+	// **************************************************************
+	err := e2e.UsacloudRun(t,
+		"server", "iaas", "list", "-h")
+	require.NoError(t, err, "unexpected error: %s", err)
+
+	// **************************************************************
+	// step2: root直下のサブコマンド(Hidden=trueなコマンド)を実行できるか?
+	// **************************************************************
+	err = e2e.UsacloudRun(t,
+		"server", "list", "-h")
+	require.NoError(t, err, "unexpected error: %s", err)
+}
+
+func TestE2E_oldIaaSCommandOutputs(t *testing.T) {
+	defer e2e.InitializeWithTerraform(t)()
+
+	// **************************************************************
+	// step1: iaasサブコマンドでサーバの情報を取得
+	// **************************************************************
+	outputs1, err := e2e.UsacloudRunWithOutput(t,
+		"iaas", "server", "list",
+		"--names", "usacloud-e2e-old-iaas-command",
+		"--format", "{{.Name}}",
+		"--zone", "all",
+	)
+	require.NoError(t, err, "unexpected error: %s", err)
+
+	// **************************************************************
+	// step2: root直下のサブコマンド(Hidden=trueなコマンド)でサーバの情報を取得
+	// **************************************************************
+	outputs2, err := e2e.UsacloudRunWithOutput(t,
+		"server", "list",
+		"--names", "usacloud-e2e-old-iaas-command",
+		"--format", "{{.Name}}",
+		"--zone", "all",
+	)
+	require.NoError(t, err, "unexpected error: %s", err)
+
+	// **************************************************************
+	// step3: 新旧コマンドの結果を比較
+	// **************************************************************
+	require.Equal(t, string(outputs1), string(outputs2))
+}

--- a/e2e/zones/e2e_test.go
+++ b/e2e/zones/e2e_test.go
@@ -31,7 +31,7 @@ func TestE2E_multiZoneAction(t *testing.T) {
 	// **************************************************************
 	// step1: テスト対象の全サーバの電源状態を取得
 	// **************************************************************
-	outputs, err := e2e.UsacloudRunWithOutput(
+	outputs, err := e2e.UsacloudRunWithOutput(t,
 		"server", "list",
 		"--names", "usacloud-e2e-zones-server",
 		"--format", "{{.InstanceStatus}}",
@@ -51,7 +51,7 @@ func TestE2E_multiZoneAction(t *testing.T) {
 	// **************************************************************
 	// step2: 全サーバの電源OFF
 	// **************************************************************
-	_, err = e2e.UsacloudRunWithOutput(
+	_, err = e2e.UsacloudRunWithOutput(t,
 		"server", "shutdown",
 		"-f", "-y",
 		"--zone", "all",
@@ -62,7 +62,7 @@ func TestE2E_multiZoneAction(t *testing.T) {
 	// **************************************************************
 	// step2: テスト対象の全サーバの電源状態を取得
 	// **************************************************************
-	outputs, err = e2e.UsacloudRunWithOutput(
+	outputs, err = e2e.UsacloudRunWithOutput(t,
 		"server", "list",
 		"--names", "usacloud-e2e-zones-server",
 		"--format", "{{.InstanceStatus}}",

--- a/pkg/cmd/commands/config/resource.go
+++ b/pkg/cmd/commands/config/resource.go
@@ -20,6 +20,7 @@ import (
 
 var Resource = &core.Resource{
 	Name:               "config",
+	Usage:              "Management commands for Configuration file/Profile",
 	Aliases:            []string{"profile"},
 	DefaultCommandName: "edit",
 	Category:           core.ResourceCategoryConfig,

--- a/pkg/cmd/commands/rest/resource.go
+++ b/pkg/cmd/commands/rest/resource.go
@@ -20,6 +20,7 @@ import (
 
 var Resource = &core.Resource{
 	Name:               "rest",
+	Usage:              "Invoke SAKURA cloud API directly",
 	Category:           core.ResourceCategoryOther,
 	IsGlobalResource:   true,
 	DefaultCommandName: "request",

--- a/pkg/cmd/commands/self/resource.go
+++ b/pkg/cmd/commands/self/resource.go
@@ -20,6 +20,7 @@ import (
 
 var Resource = &core.Resource{
 	Name:               "self",
+	Usage:              "Print resource ID",
 	DefaultCommandName: "id",
 	Category:           core.ResourceCategoryOther,
 }

--- a/pkg/cmd/commands/webaccelerator/resource.go
+++ b/pkg/cmd/commands/webaccelerator/resource.go
@@ -22,6 +22,7 @@ import (
 
 var Resource = &core.Resource{
 	Name:             "web-accelerator",
+	Usage:            "SubCommands for WebAccelerator",
 	Aliases:          []string{"web-accel", "webaccel"},
 	IsGlobalResource: true,
 	Category:         core.ResourceCategoryWebAccel,

--- a/pkg/cmd/core/usage.go
+++ b/pkg/cmd/core/usage.go
@@ -32,7 +32,7 @@ const commandUsageTemplate = ` === %s ===
 const commandUsageWrapperTemplate = `Available Commands:
 %s`
 
-func buildRootCommandUsages(rootCmd *cobra.Command, resources []*Resource, appendManualImplCommands bool) string {
+func buildSubCommandsUsage(rootCmd *cobra.Command, resources []*Resource, appendManualImplCommands bool) string {
 	line := "    %s %s"
 	var usages []string
 	for _, r := range resources {
@@ -62,15 +62,18 @@ func buildRootCommandUsages(rootCmd *cobra.Command, resources []*Resource, appen
 	return strings.TrimRight(strings.Join(usages, "\n"), "\n")
 }
 
-func BuildRootCommandsUsage(cmd *cobra.Command, commands []*CategorizedResources) {
+func SetSubCommandsUsage(cmd *cobra.Command, commands []*CategorizedResources) {
 	cmd.SetUsageTemplate("")
 	var usages []string
 	for _, c := range commands {
-		usages = append(usages, fmt.Sprintf(commandUsageTemplate, c.Category.DisplayName, buildRootCommandUsages(cmd, c.Resources, c.Category == ResourceCategoryOther)))
+		usages = append(usages, fmt.Sprintf(commandUsageTemplate, c.Category.DisplayName, buildSubCommandsUsage(cmd, c.Resources, c.Category == ResourceCategoryOther)))
 	}
 	usage := fmt.Sprintf(commandUsageWrapperTemplate, strings.TrimRight(strings.Join(usages, "\n"), "\n"))
-	cmd.SetUsageTemplate(strings.Replace(cmd.UsageTemplate(), originalCommandsUsage, usage, 1))
-	cmd.SetUsageTemplate(cmd.UsageTemplate() + fmt.Sprintf("\nCopyright %s The Usacloud Authors\n", version.CopyrightYear))
+
+	usageTemplate := strings.Replace(cmd.UsageTemplate(), originalCommandsUsage, usage, 1) +
+		fmt.Sprintf("\nCopyright %s The Usacloud Authors\n", version.CopyrightYear)
+
+	cmd.SetUsageTemplate(usageTemplate)
 }
 
 func buildCommandUsages(rootCmd *cobra.Command, commands []*Command) string {

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -16,6 +16,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/sacloud/usacloud/pkg/cmd/commands/archive"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/authstatus"
 	"github.com/sacloud/usacloud/pkg/cmd/commands/autobackup"
@@ -66,66 +69,135 @@ import (
 	"github.com/sacloud/usacloud/pkg/cmd/core"
 	"github.com/sacloud/usacloud/pkg/cmd/root"
 	_ "github.com/sacloud/usacloud/pkg/cmd/version"
+	"github.com/spf13/cobra"
 )
 
-var Resources = core.Resources{
-	// libsacloud services
-	archive.Resource,
-	authstatus.Resource,
-	autobackup.Resource,
-	bill.Resource,
-	bridge.Resource,
-	cdrom.Resource,
-	certificateauthority.Resource,
-	containerregistry.Resource,
-	coupon.Resource,
-	database.Resource,
-	disk.Resource,
-	diskplan.Resource,
-	dns.Resource,
-	enhanceddb.Resource,
-	esme.Resource,
-	gslb.Resource,
-	icon.Resource,
-	iface.Resource,
-	internet.Resource,
-	internetplan.Resource,
-	ipaddress.Resource,
-	ipv6addr.Resource,
-	ipv6net.Resource,
-	license.Resource,
-	licenseinfo.Resource,
-	loadbalancer.Resource,
-	localrouter.Resource,
-	mobilegateway.Resource,
-	nfs.Resource,
-	note.Resource,
-	packetfilter.Resource,
-	privatehost.Resource,
-	privatehostplan.Resource,
-	proxylb.Resource,
-	region.Resource,
-	server.Resource,
-	serverplan.Resource,
-	serviceclass.Resource,
-	sim.Resource,
-	simplemonitor.Resource,
-	sshkey.Resource,
-	subnet.Resource,
-	swytch.Resource,
-	vpcrouter.Resource,
-	zone.Resource,
-	// libsacloud service以外のマニュアル実装分
-	rest.Resource,
-	webaccelerator.Resource,
+var (
+	IaaSResources = core.Resources{
+		// libsacloud services
+		archive.Resource,
+		authstatus.Resource,
+		autobackup.Resource,
+		bill.Resource,
+		bridge.Resource,
+		cdrom.Resource,
+		certificateauthority.Resource,
+		containerregistry.Resource,
+		coupon.Resource,
+		database.Resource,
+		disk.Resource,
+		diskplan.Resource,
+		dns.Resource,
+		enhanceddb.Resource,
+		esme.Resource,
+		gslb.Resource,
+		icon.Resource,
+		iface.Resource,
+		internet.Resource,
+		internetplan.Resource,
+		ipaddress.Resource,
+		ipv6addr.Resource,
+		ipv6net.Resource,
+		license.Resource,
+		licenseinfo.Resource,
+		loadbalancer.Resource,
+		localrouter.Resource,
+		mobilegateway.Resource,
+		nfs.Resource,
+		note.Resource,
+		packetfilter.Resource,
+		privatehost.Resource,
+		privatehostplan.Resource,
+		proxylb.Resource,
+		region.Resource,
+		server.Resource,
+		serverplan.Resource,
+		serviceclass.Resource,
+		sim.Resource,
+		simplemonitor.Resource,
+		sshkey.Resource,
+		subnet.Resource,
+		swytch.Resource,
+		vpcrouter.Resource,
+		zone.Resource,
+		// libsacloud service以外のマニュアル実装分
+	}
+
+	MiscResources = core.Resources{
+		rest.Resource,
+		webaccelerator.Resource,
+	}
+)
+
+func Resources() core.Resources {
+	rs := core.Resources{}
+	rs = append(rs, IaaSResources...)
+	rs = append(rs, MiscResources...)
+	return rs
 }
 
 func initCommands() {
-	for _, r := range Resources {
+	initIaasCommands()
+	initMiscCommands()
+}
+
+func initIaasCommands() {
+	iaasCmd := &cobra.Command{
+		Use:   "iaas",
+		Short: "SubCommands for IaaS",
+		Long:  "SubCommands for IaaS",
+	}
+
+	for _, r := range IaaSResources {
+		cmd := r.CLICommand()
+		if len(cmd.Commands()) > 0 {
+			iaasCmd.AddCommand(cmd)
+			addHiddenSubCommandToRoot(cmd)
+		}
+	}
+	core.SetSubCommandsUsage(iaasCmd, IaaSResources.CategorizedResources())
+	root.Command.AddCommand(iaasCmd)
+}
+
+// addHiddenSubCommandToRoot 互換性維持のためにroot直下にHidden=trueの状態でコマンドを追加する
+func addHiddenSubCommandToRoot(cmd *cobra.Command) {
+	c := *cmd
+	var setChildFn func(cmd *cobra.Command)
+	setChildFn = func(cmd *cobra.Command) {
+		children := cmd.Commands()
+		cmd.ResetCommands()
+		for _, child := range children {
+			c := *child
+			setChildFn(&c)
+			cmd.AddCommand(&c)
+		}
+
+		// コマンドの中にはデフォルトコマンドとして自身のサブコマンドを呼ぶ場合(auth-statusなど)があるため、
+		// 末端(childrenがない)コマンドにだけ設定する。(この条件がないと表示が重複する)
+		if len(children) == 0 {
+			cmd.PersistentPreRun = func(own *cobra.Command, args []string) {
+				// この段階ではctx.IO()が参照できないため標準エラーに出力する
+				fmt.Fprintln(os.Stderr, "[WARN] This command is deprecated. Please use the command under the `usacloud iaas` subcommand instead.") // nolint
+				if cmd.HasParent() {
+					parent := cmd.Parent()
+					if parent.PersistentPreRun != nil {
+						parent.PersistentPreRun(own, args)
+					}
+				}
+			}
+		}
+	}
+	setChildFn(&c)
+
+	c.Hidden = true
+	root.Command.AddCommand(&c)
+}
+
+func initMiscCommands() {
+	for _, r := range MiscResources {
 		cmd := r.CLICommand()
 		if len(cmd.Commands()) > 0 {
 			root.Command.AddCommand(cmd)
 		}
 	}
-	core.BuildRootCommandsUsage(root.Command, Resources.CategorizedResources())
 }

--- a/pkg/cmd/resources_other.go
+++ b/pkg/cmd/resources_other.go
@@ -23,8 +23,10 @@ import (
 )
 
 func init() {
-	Resources = append(Resources,
-		config.Resource,
+	IaaSResources = append(IaaSResources,
 		self.Resource,
+	)
+	MiscResources = append(MiscResources,
+		config.Resource,
 	)
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -26,8 +26,8 @@ import (
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "show version info",
-	Long:  `show version info`,
+	Short: "Show version info",
+	Long:  `Show version info`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		_, err := fmt.Fprintln(os.Stdout, version.FullVersion())
 		return err

--- a/tools/generate_context.go
+++ b/tools/generate_context.go
@@ -30,7 +30,7 @@ type GenerateContext struct {
 
 func NewGenerateContext() *GenerateContext {
 	// command schema validation
-	for _, r := range cmd.Resources {
+	for _, r := range cmd.Resources() {
 		for _, c := range r.Commands() {
 			if err := c.ValidateSchema(); err != nil {
 				log.Fatal(err)
@@ -38,7 +38,7 @@ func NewGenerateContext() *GenerateContext {
 		}
 	}
 	return &GenerateContext{
-		Resources: NewResources(cmd.Resources),
+		Resources: NewResources(cmd.Resources()),
 	}
 }
 


### PR DESCRIPTION
PHYやオブジェクトストレージへの対応の準備として既存のサブコマンドをiaasサブコマンド配下に移動する。
互換性のために移動前のサブコマンドに対しては移動後のサブコマンドへのエイリアスを設定する。

Note: 以下コマンドは対象外とする。

- config
- rest
- completion
- update-self

restについてはHTTPのリトライハンドリングなどの一部の処理がIaaSにしか対応していないが、
本来はPHYやオブジェクトストレージでも利用可能であるべきなため、後続PRでIaaS以外にも対応させる。

#### ヘルプ表示の変更点

トップレベルでのヘルプ表示は`iaas`サブコマンドを表示するだけとし、`usacloud iaas`のヘルプ表示で従来のカテゴリ分けされたヘルプを表示する。

```bash
$ bin/usacloud -h
CLI to manage to resources on the SAKURA Cloud

Usage:
  usacloud [global options] <command> <sub-command> [options] [arguments] [flags]
  usacloud [command]

Available Commands:
  completion      Generate completion script
  config          Management commands for Configuration file/Profile
  help            Help about any command
  iaas            SubCommands for IaaS
  rest            Invoke SAKURA cloud API directly
  update-self     Update Usacloud to latest-stable version
  version         Show version info
  web-accelerator SubCommands for WebAccelerator

# ...省略
```

#### 既存のコマンドを実行した際に警告を表示

以下のような警告を標準エラーに出力する。
```bash
# iaasサブコマンドを省略した場合に警告表示
$ usacloud auth-status
[WARN] This command is deprecated. Please use the command under the `usacloud iaas` subcommand instead.

...

```
