### PR TITLE
core.Resourceとcli.Contextにプラットフォーム名を保持する

### DIFF
--- a/pkg/cli/api_client.go
+++ b/pkg/cli/api_client.go
@@ -1,0 +1,79 @@
+// Copyright 2017-2022 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	client "github.com/sacloud/api-client-go"
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/helper/api"
+	"github.com/sacloud/usacloud/pkg/config"
+)
+
+type apiClient struct {
+	option *config.Config
+
+	iaasClient iaas.APICaller
+}
+
+func newAPIClient(o *config.Config) *apiClient {
+	c := &apiClient{
+		option: o,
+	}
+
+	if o.FakeMode {
+		// libsacloud fakeドライバはlogパッケージにシステムログを出すがusacloudからは利用しないため出力を抑制する
+		log.SetOutput(io.Discard)
+	}
+
+	c.iaasClient = api.NewCallerWithOptions(&api.CallerOptions{
+		Options: &client.Options{
+			AccessToken:          o.AccessToken,
+			AccessTokenSecret:    o.AccessTokenSecret,
+			AcceptLanguage:       o.AcceptLanguage,
+			HttpClient:           http.DefaultClient,
+			HttpRequestTimeout:   o.HTTPRequestTimeout,
+			HttpRequestRateLimit: o.HTTPRequestRateLimit,
+			RetryMax:             o.RetryMax,
+			RetryWaitMax:         o.RetryWaitMax,
+			RetryWaitMin:         o.RetryWaitMin,
+			UserAgent:            UserAgent,
+			Trace:                o.EnableHTTPTrace(),
+		},
+		APIRootURL:    o.APIRootURL,
+		DefaultZone:   o.DefaultZone,
+		TraceAPI:      o.EnableAPITrace(),
+		FakeMode:      o.FakeMode,
+		FakeStorePath: o.FakeStorePath,
+	})
+	return c
+}
+
+func (c *apiClient) client(platformName string) interface{} {
+	switch platformName {
+	case "phy":
+		panic("not yet implemented")
+	case "objectstorage":
+		panic("not yet implemented")
+	case "iaas", "": // Note: プラットフォーム未指定の場合はIaaSとみなす
+		return c.iaasClient
+	}
+
+	panic(fmt.Sprintf("unsupported platform: %s", platformName))
+}

--- a/pkg/cmd/core/command.go
+++ b/pkg/cmd/core/command.go
@@ -301,7 +301,16 @@ func (c *Command) collectCompletionValuesFromResource(resource interface{}, pref
 }
 
 func (c *Command) initCommandContext(cmd *cobra.Command, args []string) (cli.Context, func(), bool, error) {
-	ctx, cancel, err := cli.NewCLIContext(c.resource.Name, c.Name, root.Command.PersistentFlags(), args, c.ColumnDefs, c.currentParameter, c.resource.SkipLoadingProfile)
+	ctx, cancel, err := cli.NewCLIContext(&cli.ContextParameter{
+		PlatformName:       c.resource.PlatformName,
+		ResourceName:       c.resource.Name,
+		CommandName:        c.Name,
+		GlobalFlags:        root.Command.PersistentFlags(),
+		Args:               args,
+		ColumnDefs:         c.ColumnDefs,
+		Parameter:          c.currentParameter,
+		SkipLoadingProfile: c.resource.SkipLoadingProfile,
+	})
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/cmd/core/resource.go
+++ b/pkg/cmd/core/resource.go
@@ -32,6 +32,7 @@ type Resource struct {
 	Category           Category
 	Warning            string
 	IsGlobalResource   bool
+	PlatformName       string       // "iaas" or "phy" or "objectstorage", 空の場合はIaaSとして扱われる
 	ServiceType        reflect.Type // リソースに対応するlibsacloud serviceの型情報、コード生成用
 	SkipLoadingProfile bool
 

--- a/pkg/test/cli_context.go
+++ b/pkg/test/cli_context.go
@@ -29,6 +29,7 @@ type DummyCLIContextValue struct {
 	IO           cli.IO
 	Option       *config.Config
 	Output       output.Output
+	PlatformName string
 	ResourceName string
 	CommandName  string
 	ID           types.ID
@@ -51,6 +52,10 @@ func (c *DummyCLIContext) Option() *config.Config {
 
 func (c *DummyCLIContext) Output() output.Output {
 	return c.DummyValue.Output
+}
+
+func (c *DummyCLIContext) PlatformName() string {
+	return c.DummyValue.PlatformName
 }
 
 func (c *DummyCLIContext) ResourceName() string {
@@ -80,6 +85,7 @@ func (c *DummyCLIContext) WithResource(id types.ID, zone string, resource interf
 			IO:           c.DummyValue.IO,
 			Option:       c.DummyValue.Option,
 			Output:       c.DummyValue.Output,
+			PlatformName: c.DummyValue.PlatformName,
 			ResourceName: c.DummyValue.ResourceName,
 			CommandName:  c.DummyValue.CommandName,
 			Args:         c.DummyValue.Args,


### PR DESCRIPTION
IaaS以外に対応するためにcore.Resourceでプラットフォーム名を定義しcli.Contextへ引き継ぐ
cli.Contextではプラットフォーム名に応じて適切なAPIクライアントを返す

---

Note: この修正方針はコマンド階層が`platform resource command`の3階層までと想定しており、
将来コマンド階層が増える時に対応できない。
しかし根本対応するとなると、core.Resourceやcore.Commandの概念レベルから手を加える必要があり、実装ボリュームが大きめとなる。

これを踏まえた上で、
- 現状の機能だけであれば3階層で事足りる
- まずはPHY/オブジェクトストレージ対応を優先したい
ということから、このPRでの実装を採用した。