### PR TITLE
コード生成でのプラットフォームごとのAPIクライアント処理対応

### DIFF
--- a/tools/gen-commands/services_template.go
+++ b/tools/gen-commands/services_template.go
@@ -20,6 +20,8 @@ package generated_services
 
 import (
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/object-storage-api-go"
+	"github.com/sacloud/phy-api-go"
 	service "{{ .ServiceRepositoryName }}/{{ .PackageDirName }}"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/cmd/cflag"
@@ -31,7 +33,7 @@ import (
 func init() { {{ range .Commands }}{{ if .ParameterInitializer }}{{ if not .Func }}
 	registry.SetDefaultServiceFunc("{{ .Resource.Platform }}", "{{ .Resource.Name }}", "{{.Name}}", 
 		func (ctx cli.Context, parameter interface{}) ([]interface{}, error) { 
-			svc := service.New(ctx.Client().(iaas.APICaller))
+			svc := service.New(ctx.Client().({{ .ServiceFuncClientTypeName }}))
 			{{ if .ServiceFuncReturnValueType.HasRequestValue }}
 			req := &service.{{.ServiceRequestTypeName}}{}
 			if err := conv.ConvertTo(parameter, req); err != nil {
@@ -64,7 +66,7 @@ func init() { {{ range .Commands }}{{ if .ParameterInitializer }}{{ if not .Func
 	){{ end }}
 	{{ if .Resource.ServiceMeta.HasFindMethod }}registry.SetDefaultListAllFunc("{{ .Resource.Platform }}", "{{ .Resource.Name }}", "{{.Name}}", 
 		func (ctx cli.Context, parameter interface{}) ([]interface{}, error) { 
-			svc := service.New(ctx.Client().(iaas.APICaller))
+			svc := service.New(ctx.Client().({{ .ServiceFuncClientTypeName }}))
 			res, err := svc.FindWithContext(ctx, &service.FindRequest{ {{ if not .Resource.IsGlobalResource}} Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue(){{ end }} })
 			if err != nil {
 				return nil, err

--- a/tools/service_func_meta.go
+++ b/tools/service_func_meta.go
@@ -15,6 +15,7 @@
 package tools
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 )
@@ -50,4 +51,16 @@ func (c *Command) ServiceFuncReturnValueType() *ServiceFuncMeta {
 		return &ServiceFuncMeta{HasRequestValue: hasRequest, HasReturnValue: true, IsReturnValueSlice: true}
 	}
 	return &ServiceFuncMeta{HasRequestValue: hasRequest, HasReturnValue: true, IsReturnValueSlice: false}
+}
+
+func (c *Command) ServiceFuncClientTypeName() string {
+	switch c.Resource.Platform() {
+	case "iaas":
+		return "iaas.APICaller"
+	case "phy":
+		return "*phy.Client"
+	case "objectstorage":
+		return "*objectstorage.Client"
+	}
+	panic(fmt.Sprintf("unsupported platform name: %s", c.Resource.Platform()))
 }


### PR DESCRIPTION
core.Resourceで設定したプラットフォームに応じてAPIクライアントの型を扱えるようにコードテンプレートなどを修正