### PR TITLE
IaaSコマンド向けカテゴリーを切り出し

### DIFF
--- a/pkg/category/category.go
+++ b/pkg/category/category.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package category
 
 type Category struct {
 	Key         string

--- a/pkg/category/commands.go
+++ b/pkg/category/commands.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package category
 
 var CommandCategories = []Category{
 	{

--- a/pkg/category/parameters.go
+++ b/pkg/category/parameters.go
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package category
 
-import "math"
+import (
+	"math"
+)
 
 var ParameterCategories = []*Category{
 	{

--- a/pkg/commands/config/resource.go
+++ b/pkg/commands/config/resource.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -23,7 +24,7 @@ var Resource = &core.Resource{
 	Usage:              "Management commands for Configuration file/Profile",
 	Aliases:            []string{"profile"},
 	DefaultCommandName: "edit",
-	Category:           core.ResourceCategoryConfig,
+	Category:           iaas.ResourceCategoryConfig,
 	IsGlobalResource:   true,
 	SkipLoadingProfile: true,
 }

--- a/pkg/commands/iaas/archive/resource.go
+++ b/pkg/commands/iaas/archive/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/archive"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "archive",
 	ServiceType:  reflect.TypeOf(&archive.Service{}),
-	Category:     core.ResourceCategoryStorage,
+	Category:     iaas.ResourceCategoryStorage,
 }

--- a/pkg/commands/iaas/authstatus/resource.go
+++ b/pkg/commands/iaas/authstatus/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/authstatus"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:               "auth-status",
 	ServiceType:        reflect.TypeOf(&authstatus.Service{}),
 	DefaultCommandName: "read",
-	Category:           core.ResourceCategoryAuth,
+	Category:           iaas.ResourceCategoryAuth,
 }

--- a/pkg/commands/iaas/autobackup/resource.go
+++ b/pkg/commands/iaas/autobackup/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/autobackup"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "auto-backup",
 	ServiceType:  reflect.TypeOf(&autobackup.Service{}),
-	Category:     core.ResourceCategoryStorage,
+	Category:     iaas.ResourceCategoryStorage,
 }

--- a/pkg/commands/iaas/bill/resource.go
+++ b/pkg/commands/iaas/bill/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/bill"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "bill",
 	ServiceType:      reflect.TypeOf(&bill.Service{}),
-	Category:         core.ResourceCategoryBilling,
+	Category:         iaas.ResourceCategoryBilling,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/bridge/resource.go
+++ b/pkg/commands/iaas/bridge/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/bridge"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "bridge",
 	ServiceType:  reflect.TypeOf(&bridge.Service{}),
-	Category:     core.ResourceCategoryNetworking,
+	Category:     iaas.ResourceCategoryNetworking,
 }

--- a/pkg/commands/iaas/cdrom/resource.go
+++ b/pkg/commands/iaas/cdrom/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/cdrom"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "cdrom",
 	Aliases:      []string{"iso-image"},
 	ServiceType:  reflect.TypeOf(&cdrom.Service{}),
-	Category:     core.ResourceCategoryStorage,
+	Category:     iaas.ResourceCategoryStorage,
 }

--- a/pkg/commands/iaas/certificateauthority/resource.go
+++ b/pkg/commands/iaas/certificateauthority/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/certificateauthority"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,6 +27,6 @@ var Resource = &core.Resource{
 	Name:             "certificate-authority",
 	Aliases:          []string{"managed-pki"},
 	ServiceType:      reflect.TypeOf(&certificateauthority.Service{}),
-	Category:         core.ResourceCategoryLab,
+	Category:         iaas.ResourceCategoryLab,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/containerregistry/resource.go
+++ b/pkg/commands/iaas/containerregistry/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/containerregistry"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "container-registry",
 	ServiceType:      reflect.TypeOf(&containerregistry.Service{}),
-	Category:         core.ResourceCategoryLab,
+	Category:         iaas.ResourceCategoryLab,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/coupon/resource.go
+++ b/pkg/commands/iaas/coupon/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/coupon"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,7 +26,7 @@ var Resource = &core.Resource{
 	PlatformName:       "iaas",
 	Name:               "coupon",
 	ServiceType:        reflect.TypeOf(&coupon.Service{}),
-	Category:           core.ResourceCategoryBilling,
+	Category:           iaas.ResourceCategoryBilling,
 	IsGlobalResource:   true,
 	DefaultCommandName: "list",
 }

--- a/pkg/commands/iaas/database/resource.go
+++ b/pkg/commands/iaas/database/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/database"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "database",
 	ServiceType:  reflect.TypeOf(&database.Service{}),
-	Category:     core.ResourceCategoryAppliance,
+	Category:     iaas.ResourceCategoryAppliance,
 }

--- a/pkg/commands/iaas/disk/resource.go
+++ b/pkg/commands/iaas/disk/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/disk"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "disk",
 	ServiceType:  reflect.TypeOf(&disk.Service{}),
-	Category:     core.ResourceCategoryStorage,
+	Category:     iaas.ResourceCategoryStorage,
 }

--- a/pkg/commands/iaas/diskplan/resource.go
+++ b/pkg/commands/iaas/diskplan/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/diskplan"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "disk-plan",
 	Aliases:      []string{"diskplan"},
 	ServiceType:  reflect.TypeOf(&diskplan.Service{}),
-	Category:     core.ResourceCategoryInformation,
+	Category:     iaas.ResourceCategoryInformation,
 }

--- a/pkg/commands/iaas/dns/resource.go
+++ b/pkg/commands/iaas/dns/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/dns"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "dns",
 	ServiceType:      reflect.TypeOf(&dns.Service{}),
-	Category:         core.ResourceCategoryCommonServiceItem,
+	Category:         iaas.ResourceCategoryCommonServiceItem,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/enhanceddb/resource.go
+++ b/pkg/commands/iaas/enhanceddb/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/enhanceddb"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,6 +27,6 @@ var Resource = &core.Resource{
 	Name:             "enhanced-db",
 	Aliases:          []string{"enhanced-database", "edb"},
 	ServiceType:      reflect.TypeOf(&enhanceddb.Service{}),
-	Category:         core.ResourceCategoryLab,
+	Category:         iaas.ResourceCategoryLab,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/esme/resource.go
+++ b/pkg/commands/iaas/esme/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/esme"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "esme",
 	ServiceType:      reflect.TypeOf(&esme.Service{}),
-	Category:         core.ResourceCategoryLab,
+	Category:         iaas.ResourceCategoryLab,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/gslb/resource.go
+++ b/pkg/commands/iaas/gslb/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/gslb"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "gslb",
 	ServiceType:      reflect.TypeOf(&gslb.Service{}),
-	Category:         core.ResourceCategoryCommonServiceItem,
+	Category:         iaas.ResourceCategoryCommonServiceItem,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/icon/resource.go
+++ b/pkg/commands/iaas/icon/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/icon"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "icon",
 	ServiceType:      reflect.TypeOf(&icon.Service{}),
-	Category:         core.ResourceCategoryMisc,
+	Category:         iaas.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/iface/resource.go
+++ b/pkg/commands/iaas/iface/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/iface"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "interface",
 	Aliases:      []string{"iface"},
 	ServiceType:  reflect.TypeOf(&iface.Service{}),
-	Category:     core.ResourceCategoryNetworkingSub,
+	Category:     iaas.ResourceCategoryNetworkingSub,
 }

--- a/pkg/commands/iaas/internet/resource.go
+++ b/pkg/commands/iaas/internet/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/internet"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "internet",
 	Aliases:      []string{"router"},
 	ServiceType:  reflect.TypeOf(&internet.Service{}),
-	Category:     core.ResourceCategoryNetworking,
+	Category:     iaas.ResourceCategoryNetworking,
 }

--- a/pkg/commands/iaas/internetplan/resource.go
+++ b/pkg/commands/iaas/internetplan/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/internetplan"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "internet-plan",
 	Aliases:      []string{"internetplan"},
 	ServiceType:  reflect.TypeOf(&internetplan.Service{}),
-	Category:     core.ResourceCategoryInformation,
+	Category:     iaas.ResourceCategoryInformation,
 }

--- a/pkg/commands/iaas/ipaddress/resource.go
+++ b/pkg/commands/iaas/ipaddress/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/ipaddress"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "ipaddress",
 	Aliases:      []string{"ip-address"},
 	ServiceType:  reflect.TypeOf(&ipaddress.Service{}),
-	Category:     core.ResourceCategoryNetworkingSub,
+	Category:     iaas.ResourceCategoryNetworkingSub,
 }

--- a/pkg/commands/iaas/ipv6addr/resource.go
+++ b/pkg/commands/iaas/ipv6addr/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/ipv6addr"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "ipv6addr",
 	ServiceType:  reflect.TypeOf(&ipv6addr.Service{}),
-	Category:     core.ResourceCategoryNetworkingSub,
+	Category:     iaas.ResourceCategoryNetworkingSub,
 }

--- a/pkg/commands/iaas/ipv6net/resource.go
+++ b/pkg/commands/iaas/ipv6net/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/ipv6net"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "ipv6net",
 	ServiceType:  reflect.TypeOf(&ipv6net.Service{}),
-	Category:     core.ResourceCategoryNetworkingSub,
+	Category:     iaas.ResourceCategoryNetworkingSub,
 }

--- a/pkg/commands/iaas/license/resource.go
+++ b/pkg/commands/iaas/license/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/license"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "license",
 	ServiceType:      reflect.TypeOf(&license.Service{}),
-	Category:         core.ResourceCategoryMisc,
+	Category:         iaas.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/licenseinfo/resource.go
+++ b/pkg/commands/iaas/licenseinfo/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/licenseinfo"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -27,5 +28,5 @@ var Resource = &core.Resource{
 	Aliases:          []string{"licenseinfo"},
 	ServiceType:      reflect.TypeOf(&licenseinfo.Service{}),
 	IsGlobalResource: true,
-	Category:         core.ResourceCategoryInformation,
+	Category:         iaas.ResourceCategoryInformation,
 }

--- a/pkg/commands/iaas/loadbalancer/resource.go
+++ b/pkg/commands/iaas/loadbalancer/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/loadbalancer"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "load-balancer",
 	Aliases:      []string{"loadbalancer"},
 	ServiceType:  reflect.TypeOf(&loadbalancer.Service{}),
-	Category:     core.ResourceCategoryAppliance,
+	Category:     iaas.ResourceCategoryAppliance,
 }

--- a/pkg/commands/iaas/localrouter/resource.go
+++ b/pkg/commands/iaas/localrouter/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/localrouter"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "local-router",
 	ServiceType:      reflect.TypeOf(&localrouter.Service{}),
-	Category:         core.ResourceCategoryNetworking,
+	Category:         iaas.ResourceCategoryNetworking,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/mobilegateway/resource.go
+++ b/pkg/commands/iaas/mobilegateway/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/mobilegateway"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "mobile-gateway",
 	Aliases:      []string{"mobilegateway", "mgw"},
 	ServiceType:  reflect.TypeOf(&mobilegateway.Service{}),
-	Category:     core.ResourceCategorySecureMobile,
+	Category:     iaas.ResourceCategorySecureMobile,
 }

--- a/pkg/commands/iaas/nfs/resource.go
+++ b/pkg/commands/iaas/nfs/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/nfs"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "nfs",
 	ServiceType:  reflect.TypeOf(&nfs.Service{}),
-	Category:     core.ResourceCategoryAppliance,
+	Category:     iaas.ResourceCategoryAppliance,
 }

--- a/pkg/commands/iaas/note/resource.go
+++ b/pkg/commands/iaas/note/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/note"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,6 +27,6 @@ var Resource = &core.Resource{
 	Name:             "note",
 	Aliases:          []string{"startup-script"},
 	ServiceType:      reflect.TypeOf(&note.Service{}),
-	Category:         core.ResourceCategoryMisc,
+	Category:         iaas.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/packetfilter/resource.go
+++ b/pkg/commands/iaas/packetfilter/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/packetfilter"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "packet-filter",
 	Aliases:      []string{"packetfilter"},
 	ServiceType:  reflect.TypeOf(&packetfilter.Service{}),
-	Category:     core.ResourceCategoryNetworking,
+	Category:     iaas.ResourceCategoryNetworking,
 }

--- a/pkg/commands/iaas/privatehost/resource.go
+++ b/pkg/commands/iaas/privatehost/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/privatehost"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "private-host",
 	Aliases:      []string{"privatehost"},
 	ServiceType:  reflect.TypeOf(&privatehost.Service{}),
-	Category:     core.ResourceCategoryComputing,
+	Category:     iaas.ResourceCategoryComputing,
 }

--- a/pkg/commands/iaas/privatehostplan/resource.go
+++ b/pkg/commands/iaas/privatehostplan/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/privatehostplan"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "private-host-plan",
 	Aliases:      []string{"privatehostplan"},
 	ServiceType:  reflect.TypeOf(&privatehostplan.Service{}),
-	Category:     core.ResourceCategoryInformation,
+	Category:     iaas.ResourceCategoryInformation,
 }

--- a/pkg/commands/iaas/proxylb/resource.go
+++ b/pkg/commands/iaas/proxylb/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/proxylb"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,6 +27,6 @@ var Resource = &core.Resource{
 	Name:             "proxy-lb",
 	Aliases:          []string{"proxylb", "elb", "enhanced-load-balancer"},
 	ServiceType:      reflect.TypeOf(&proxylb.Service{}),
-	Category:         core.ResourceCategoryCommonServiceItem,
+	Category:         iaas.ResourceCategoryCommonServiceItem,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/region/resource.go
+++ b/pkg/commands/iaas/region/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/region"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -27,5 +28,5 @@ var Resource = &core.Resource{
 	Aliases:          []string{"regions"},
 	ServiceType:      reflect.TypeOf(&region.Service{}),
 	IsGlobalResource: true,
-	Category:         core.ResourceCategoryZone,
+	Category:         iaas.ResourceCategoryZone,
 }

--- a/pkg/commands/iaas/resource_categories.go
+++ b/pkg/commands/iaas/resource_categories.go
@@ -12,111 +12,115 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package iaas
+
+import (
+	"github.com/sacloud/usacloud/pkg/category"
+)
 
 var (
-	ResourceCategoryConfig = Category{
+	ResourceCategoryConfig = category.Category{
 		Key:         "config",
 		DisplayName: "Configuration",
 		Order:       10,
 	}
 
-	ResourceCategoryAuth = Category{
+	ResourceCategoryAuth = category.Category{
 		Key:         "auth",
 		DisplayName: "Authentication",
 		Order:       20,
 	}
 
-	ResourceCategoryComputing = Category{
+	ResourceCategoryComputing = category.Category{
 		Key:         "computing",
 		DisplayName: "Computing",
 		Order:       30,
 	}
 
-	ResourceCategoryStorage = Category{
+	ResourceCategoryStorage = category.Category{
 		Key:         "storage",
 		DisplayName: "Storage",
 		Order:       40,
 	}
 
-	ResourceCategoryNetworking = Category{
+	ResourceCategoryNetworking = category.Category{
 		Key:         "networking",
 		DisplayName: "Networking",
 		Order:       50,
 	}
 
-	ResourceCategoryNetworkingSub = Category{
+	ResourceCategoryNetworkingSub = category.Category{
 		Key:         "networking-sub",
 		DisplayName: "Networking(SubResources)",
 		Order:       55,
 	}
 
-	ResourceCategoryAppliance = Category{
+	ResourceCategoryAppliance = category.Category{
 		Key:         "appliance",
 		DisplayName: "Appliance",
 		Order:       60,
 	}
 
-	ResourceCategorySecureMobile = Category{
+	ResourceCategorySecureMobile = category.Category{
 		Key:         "securemobile",
 		DisplayName: "SecureMobile",
 		Order:       70,
 	}
-	ResourceCategoryCommonServiceItem = Category{
+	ResourceCategoryCommonServiceItem = category.Category{
 		Key:         "commonserviceitem",
 		DisplayName: "Common service items",
 		Order:       80,
 	}
 
-	ResourceCategoryCommonItem = Category{
+	ResourceCategoryCommonItem = category.Category{
 		Key:         "commonitem",
 		DisplayName: "Common items",
 		Order:       90,
 	}
 
-	ResourceCategoryBilling = Category{
+	ResourceCategoryBilling = category.Category{
 		Key:         "billing",
 		DisplayName: "Billing",
 		Order:       100,
 	}
 
-	ResourceCategoryLab = Category{
+	ResourceCategoryLab = category.Category{
 		Key:         "lab",
 		DisplayName: "Lab",
 		Order:       110,
 	}
 
-	ResourceCategoryWebAccel = Category{
+	ResourceCategoryWebAccel = category.Category{
 		Key:         "webaccel",
 		DisplayName: "WebAccelerator",
 		Order:       120,
 	}
 
-	ResourceCategoryMisc = Category{
+	ResourceCategoryMisc = category.Category{
 		Key:         "misc",
 		DisplayName: "Other services",
 		Order:       130,
 	}
 
-	ResourceCategoryZone = Category{
+	ResourceCategoryZone = category.Category{
 		Key:         "zone",
 		DisplayName: "Region/Zone information",
 		Order:       140,
 	}
 
-	ResourceCategoryInformation = Category{
+	ResourceCategoryInformation = category.Category{
 		Key:         "information",
 		DisplayName: "Service/Product information",
 		Order:       150,
 	}
 
-	ResourceCategoryOther = Category{
+	ResourceCategoryOther = category.Category{
 		Key:         "other",
 		DisplayName: "Other commands",
 		Order:       160,
 	}
 
-	ResourceCategories = []Category{
+	ResourceCategories = []category.Category{
 		ResourceCategoryConfig,
 		ResourceCategoryAuth,
 		ResourceCategoryComputing,

--- a/pkg/commands/iaas/self/resource.go
+++ b/pkg/commands/iaas/self/resource.go
@@ -15,6 +15,7 @@
 package self
 
 import (
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -23,5 +24,5 @@ var Resource = &core.Resource{
 	Name:               "self",
 	Usage:              "Print resource ID",
 	DefaultCommandName: "id",
-	Category:           core.ResourceCategoryOther,
+	Category:           iaas.ResourceCategoryOther,
 }

--- a/pkg/commands/iaas/server/resource.go
+++ b/pkg/commands/iaas/server/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/server"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "server",
 	ServiceType:  reflect.TypeOf(&server.Service{}),
-	Category:     core.ResourceCategoryComputing,
+	Category:     iaas.ResourceCategoryComputing,
 }

--- a/pkg/commands/iaas/serverplan/resource.go
+++ b/pkg/commands/iaas/serverplan/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/serverplan"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "server-plan",
 	Aliases:      []string{"serverplan"},
 	ServiceType:  reflect.TypeOf(&serverplan.Service{}),
-	Category:     core.ResourceCategoryInformation,
+	Category:     iaas.ResourceCategoryInformation,
 }

--- a/pkg/commands/iaas/serviceclass/resource.go
+++ b/pkg/commands/iaas/serviceclass/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/serviceclass"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "service-class",
 	Aliases:      []string{"serviceclass", "public-price", "publicprice"},
 	ServiceType:  reflect.TypeOf(&serviceclass.Service{}),
-	Category:     core.ResourceCategoryInformation,
+	Category:     iaas.ResourceCategoryInformation,
 }

--- a/pkg/commands/iaas/sim/resource.go
+++ b/pkg/commands/iaas/sim/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/sim"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,6 +26,6 @@ var Resource = &core.Resource{
 	PlatformName:     "iaas",
 	Name:             "sim",
 	ServiceType:      reflect.TypeOf(&sim.Service{}),
-	Category:         core.ResourceCategorySecureMobile,
+	Category:         iaas.ResourceCategorySecureMobile,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/simplemonitor/resource.go
+++ b/pkg/commands/iaas/simplemonitor/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/simplemonitor"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,6 +27,6 @@ var Resource = &core.Resource{
 	Name:             "simple-monitor",
 	Aliases:          []string{"simplemonitor"},
 	ServiceType:      reflect.TypeOf(&simplemonitor.Service{}),
-	Category:         core.ResourceCategoryCommonServiceItem,
+	Category:         iaas.ResourceCategoryCommonServiceItem,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/sshkey/resource.go
+++ b/pkg/commands/iaas/sshkey/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/sshkey"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,6 +27,6 @@ var Resource = &core.Resource{
 	Name:             "ssh-key",
 	Aliases:          []string{"sshkey"},
 	ServiceType:      reflect.TypeOf(&sshkey.Service{}),
-	Category:         core.ResourceCategoryMisc,
+	Category:         iaas.ResourceCategoryMisc,
 	IsGlobalResource: true,
 }

--- a/pkg/commands/iaas/subnet/resource.go
+++ b/pkg/commands/iaas/subnet/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/subnet"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "subnet",
 	ServiceType:  reflect.TypeOf(&subnet.Service{}),
-	Category:     core.ResourceCategoryNetworkingSub,
+	Category:     iaas.ResourceCategoryNetworkingSub,
 }

--- a/pkg/commands/iaas/swytch/resource.go
+++ b/pkg/commands/iaas/swytch/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/swytch"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -25,5 +26,5 @@ var Resource = &core.Resource{
 	PlatformName: "iaas",
 	Name:         "switch",
 	ServiceType:  reflect.TypeOf(&swytch.Service{}),
-	Category:     core.ResourceCategoryNetworking,
+	Category:     iaas.ResourceCategoryNetworking,
 }

--- a/pkg/commands/iaas/vpcrouter/resource.go
+++ b/pkg/commands/iaas/vpcrouter/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/vpcrouter"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,5 +27,5 @@ var Resource = &core.Resource{
 	Name:         "vpc-router",
 	Aliases:      []string{"vpcrouter"},
 	ServiceType:  reflect.TypeOf(&vpcrouter.Service{}),
-	Category:     core.ResourceCategoryAppliance,
+	Category:     iaas.ResourceCategoryAppliance,
 }

--- a/pkg/commands/iaas/webaccelerator/resource.go
+++ b/pkg/commands/iaas/webaccelerator/resource.go
@@ -17,6 +17,7 @@ package webaccelerator
 import (
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/usacloud/pkg/cli"
+	iaas2 "github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -26,7 +27,7 @@ var Resource = &core.Resource{
 	Usage:            "SubCommands for WebAccelerator",
 	Aliases:          []string{"web-accel", "webaccel"},
 	IsGlobalResource: true,
-	Category:         core.ResourceCategoryWebAccel,
+	Category:         iaas2.ResourceCategoryWebAccel,
 }
 
 func listAllFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {

--- a/pkg/commands/iaas/zone/resource.go
+++ b/pkg/commands/iaas/zone/resource.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/sacloud/iaas-service-go/zone"
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
@@ -27,5 +28,5 @@ var Resource = &core.Resource{
 	Aliases:          []string{"zones"},
 	ServiceType:      reflect.TypeOf(&zone.Service{}),
 	IsGlobalResource: true,
-	Category:         core.ResourceCategoryZone,
+	Category:         iaas.ResourceCategoryZone,
 }

--- a/pkg/commands/rest/resource.go
+++ b/pkg/commands/rest/resource.go
@@ -15,13 +15,14 @@
 package rest
 
 import (
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/core"
 )
 
 var Resource = &core.Resource{
 	Name:               "rest",
 	Usage:              "Invoke SAKURA cloud API directly",
-	Category:           core.ResourceCategoryOther,
+	Category:           iaas.ResourceCategoryOther,
 	IsGlobalResource:   true,
 	DefaultCommandName: "request",
 }

--- a/pkg/core/categorized.go
+++ b/pkg/core/categorized.go
@@ -14,12 +14,14 @@
 
 package core
 
+import "github.com/sacloud/usacloud/pkg/category"
+
 type CategorizedResources struct {
-	Category  Category
+	Category  category.Category
 	Resources []*Resource
 }
 
 type CategorizedCommands struct {
-	Category Category
+	Category category.Category
 	Commands []*Command
 }

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/sacloud/iaas-api-go/accessor"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/usacloud/pkg/category"
 	"github.com/sacloud/usacloud/pkg/cflag"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/commands/root"
@@ -62,7 +63,7 @@ type Command struct {
 	ConfirmMessage string
 
 	// パラメータ関連
-	ParameterCategories  []Category
+	ParameterCategories  []category.Category
 	ParameterInitializer func() interface{}
 	ServiceFuncAltName   string // デフォルトのlibsacloud service呼び出しコード生成用、空の場合はNameをCamelizeしたものが利用される // TODO libsacloud側で対応すべき
 
@@ -604,8 +605,8 @@ func (c *Command) parameterWithZone(zone string) (interface{}, error) {
 	return newParameter, nil
 }
 
-func (c *Command) ParameterCategoryBy(key string) *Category {
-	for _, cat := range ParameterCategories {
+func (c *Command) ParameterCategoryBy(key string) *category.Category {
+	for _, cat := range category.ParameterCategories {
 		if cat.Key == key {
 			return cat
 		}
@@ -613,7 +614,7 @@ func (c *Command) ParameterCategoryBy(key string) *Category {
 
 	if key == "" {
 		key = c.resource.Name
-		return &Category{
+		return &category.Category{
 			Key:         key,
 			DisplayName: fmt.Sprintf("%s-specific options", strings.Title(key)),
 			Order:       100,
@@ -625,7 +626,7 @@ func (c *Command) ParameterCategoryBy(key string) *Category {
 			return &cat
 		}
 	}
-	return &Category{
+	return &category.Category{
 		Key:         key,
 		DisplayName: fmt.Sprintf("%s options", strings.Title(key)),
 		Order:       200,

--- a/pkg/core/resource.go
+++ b/pkg/core/resource.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/sacloud/usacloud/pkg/category"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -29,7 +30,7 @@ type Resource struct {
 	Aliases            []string
 	Usage              string
 	DefaultCommandName string
-	Category           Category
+	Category           category.Category
 	Warning            string
 	IsGlobalResource   bool
 	PlatformName       string       // "iaas" or "phy" or "objectstorage", 空の場合はIaaSとして扱われる
@@ -132,8 +133,8 @@ func (r *Resource) AddCommand(command *Command) {
 	}
 }
 
-func (r *Resource) commandCategory(key string) *Category {
-	for _, c := range CommandCategories {
+func (r *Resource) commandCategory(key string) *category.Category {
+	for _, c := range category.CommandCategories { // Note: コマンドのカテゴリーは現状では全プラットフォーム共通としている
 		if c.Key == key {
 			return &c
 		}

--- a/pkg/core/resources.go
+++ b/pkg/core/resources.go
@@ -14,12 +14,16 @@
 
 package core
 
-import "sort"
+import (
+	"sort"
+
+	"github.com/sacloud/usacloud/pkg/category"
+)
 
 type Resources []*Resource
 
-func (r Resources) CategorizedResources() []*CategorizedResources {
-	categories := ResourceCategories
+// CategorizedResources categoriesと各リソースのカテゴリー名を用いてカテゴリー配下にリソースを紐づけて返す
+func (r Resources) CategorizedResources(categories []category.Category) []*CategorizedResources {
 	sort.Slice(categories, func(i, j int) bool {
 		return categories[i].Order < categories[j].Order
 	})

--- a/pkg/core/usage.go
+++ b/pkg/core/usage.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +67,7 @@ func SetSubCommandsUsage(cmd *cobra.Command, commands []*CategorizedResources) {
 	cmd.SetUsageTemplate("")
 	var usages []string
 	for _, c := range commands {
-		usages = append(usages, fmt.Sprintf(commandUsageTemplate, c.Category.DisplayName, buildSubCommandsUsage(cmd, c.Resources, c.Category == ResourceCategoryOther)))
+		usages = append(usages, fmt.Sprintf(commandUsageTemplate, c.Category.DisplayName, buildSubCommandsUsage(cmd, c.Resources, c.Category == iaas.ResourceCategoryOther)))
 	}
 	usage := fmt.Sprintf(commandUsageWrapperTemplate, strings.TrimRight(strings.Join(usages, "\n"), "\n"))
 

--- a/pkg/resources.go
+++ b/pkg/resources.go
@@ -157,7 +157,7 @@ func initIaasCommands() {
 			addHiddenSubCommandToRoot(cmd)
 		}
 	}
-	core.SetSubCommandsUsage(iaas.Command, IaaSResources.CategorizedResources())
+	core.SetSubCommandsUsage(iaas.Command, IaaSResources.CategorizedResources(iaas.ResourceCategories))
 	root.Command.AddCommand(iaas.Command)
 }
 

--- a/tools/command_category.go
+++ b/tools/command_category.go
@@ -17,11 +17,11 @@ package tools
 import (
 	"sort"
 
-	"github.com/sacloud/usacloud/pkg/core"
+	"github.com/sacloud/usacloud/pkg/category"
 )
 
 type CategorizedParameterFields struct {
-	*core.Category
+	*category.Category
 	Fields []Field
 }
 


### PR DESCRIPTION
from #899 

リソースのカテゴリーは各プラットフォームごとに異なるためそれぞれのパッケージ内で定義するように変更。
コマンドとパラメータについては全プラットフォームで共通のカテゴリーとするためにcategoryパッケージへ移動。

- core.Categoryを別パッケージへ移動
- coreで定義していたIaaS向けリソースカテゴリーをiaasパッケージへ移動
- coreで定義していたコマンド/パラメータカテゴリーをcategoryパッケージへ移動