### PR TITLE
CLIで扱うIDの型をIaaS独自の型からstringへ変更

### DIFF
--- a/pkg/cflag/id.go
+++ b/pkg/cflag/id.go
@@ -14,25 +14,23 @@
 
 package cflag
 
-import "github.com/sacloud/iaas-api-go/types"
-
 type IDParameterValueHandler interface {
-	IDFlagValue() types.ID
-	SetIDFlagValue(id types.ID)
+	IDFlagValue() string
+	SetIDFlagValue(id string)
 }
 
-func IDFlagValue(p interface{}) types.ID {
+func IDFlagValue(p interface{}) string {
 	if p == nil {
-		return types.ID(0)
+		return ""
 	}
 	v, ok := p.(IDParameterValueHandler)
 	if !ok {
-		return types.ID(0)
+		return ""
 	}
 	return v.IDFlagValue()
 }
 
-func SetIDFlagValue(p interface{}, id types.ID) {
+func SetIDFlagValue(p interface{}, id string) {
 	if p == nil {
 		return
 	}
@@ -45,13 +43,13 @@ func SetIDFlagValue(p interface{}, id types.ID) {
 
 // IDParameter IDを指定して操作する必要があるリソースが実装すべきIDパラメータの定義
 type IDParameter struct {
-	ID types.ID `cli:"-" json:"-"` // IDは実行時にName or Tagsから検索〜設定されるケースがあるためvalidate:"required"にしない
+	ID string `cli:"-" json:"-"` // IDは実行時にName or Tagsから検索〜設定されるケースがあるためvalidate:"required"にしない
 }
 
-func (p *IDParameter) IDFlagValue() types.ID {
+func (p *IDParameter) IDFlagValue() string {
 	return p.ID
 }
 
-func (p *IDParameter) SetIDFlagValue(id types.ID) {
+func (p *IDParameter) SetIDFlagValue(id string) {
 	p.ID = id
 }

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/config"
 	"github.com/sacloud/usacloud/pkg/output"
 	"github.com/sacloud/usacloud/pkg/validate"
@@ -41,8 +40,8 @@ type Context interface {
 	// WithResource 特定のリソース向け作業をする際に呼ばれる。
 	// リソースのIDとゾーンを保持した新しいコンテキストを返す
 	// 新しいコンテキストの親コンテキストには現在のコンテキストが設定される
-	WithResource(id types.ID, zone string, resource interface{}) Context
-	ID() types.ID
+	WithResource(id string, zone string, resource interface{}) Context
+	ID() string
 	Zone() string
 	Resource() interface{}
 }
@@ -129,7 +128,7 @@ func (c *cliContext) CommandName() string {
 	return c.commandName
 }
 
-func (c *cliContext) ID() types.ID {
+func (c *cliContext) ID() string {
 	return c.resource.ID
 }
 
@@ -141,7 +140,7 @@ func (c *cliContext) Resource() interface{} {
 	return c.resource.Resource
 }
 
-func (c *cliContext) WithResource(id types.ID, zone string, resource interface{}) Context {
+func (c *cliContext) WithResource(id string, zone string, resource interface{}) Context {
 	return &cliContext{
 		parentCtx:    c,
 		option:       c.option,

--- a/pkg/cli/resource_context.go
+++ b/pkg/cli/resource_context.go
@@ -16,25 +16,23 @@ package cli
 
 import (
 	"fmt"
-
-	"github.com/sacloud/iaas-api-go/types"
 )
 
 // ResourceContext 現在処理中のリソースの情報
 type ResourceContext struct {
-	ID       types.ID
+	ID       string
 	Zone     string
 	Resource interface{} // 対象のリソースそのもの
 }
 
 func (r *ResourceContext) String() string {
-	if r.ID.IsEmpty() {
+	if r.ID == "" {
 		return ""
 	}
 	if r.Zone == "" {
-		return r.ID.String()
+		return r.ID
 	}
-	return fmt.Sprintf("[%s] %s", r.Zone, r.ID.String())
+	return fmt.Sprintf("[%s] %s", r.Zone, r.ID)
 }
 
 type ResourceContexts []ResourceContext
@@ -54,10 +52,10 @@ func (r *ResourceContexts) Append(values ...ResourceContext) {
 	}
 }
 
-func (r *ResourceContexts) IDs() []types.ID {
-	var ids []types.ID
+func (r *ResourceContexts) IDs() []string {
+	var ids []string
 	for _, v := range *r {
-		if !v.ID.IsEmpty() {
+		if v.ID != "" {
 			ids = append(ids, v.ID)
 		}
 	}

--- a/pkg/commands/iaas/disk/update_test.go
+++ b/pkg/commands/iaas/disk/update_test.go
@@ -34,7 +34,7 @@ func TestUpdate_ConvertToServiceRequest(t *testing.T) {
 	t.Run("full", func(t *testing.T) {
 		in := &updateParameter{
 			ZoneParameter:         cflag.ZoneParameter{Zone: "is1a"},
-			IDParameter:           cflag.IDParameter{ID: types.ID(1)},
+			IDParameter:           cflag.IDParameter{ID: "1"},
 			NameUpdateParameter:   cflag.NameUpdateParameter{Name: pointer.NewString("name")},
 			DescUpdateParameter:   cflag.DescUpdateParameter{Description: pointer.NewString("desc")},
 			TagsUpdateParameter:   cflag.TagsUpdateParameter{Tags: pointer.NewStringSlice([]string{"tag1", "tag2"})},
@@ -61,7 +61,7 @@ func TestUpdate_ConvertToServiceRequest(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		in := &updateParameter{
 			ZoneParameter:       cflag.ZoneParameter{Zone: "is1a"},
-			IDParameter:         cflag.IDParameter{ID: types.ID(1)},
+			IDParameter:         cflag.IDParameter{ID: "1"},
 			NameUpdateParameter: cflag.NameUpdateParameter{Name: pointer.NewString("name")},
 		}
 
@@ -83,7 +83,7 @@ func TestUpdate_ConvertToServiceRequest(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		in := &updateParameter{
 			ZoneParameter:         cflag.ZoneParameter{Zone: "is1a"},
-			IDParameter:           cflag.IDParameter{ID: types.ID(1)},
+			IDParameter:           cflag.IDParameter{ID: "1"},
 			NameUpdateParameter:   cflag.NameUpdateParameter{Name: pointer.NewString("name")},
 			DescUpdateParameter:   cflag.DescUpdateParameter{Description: pointer.NewString("")},
 			TagsUpdateParameter:   cflag.TagsUpdateParameter{Tags: pointer.NewStringSlice([]string{})},
@@ -124,7 +124,7 @@ func TestUpdateParameter_Validate(t *testing.T) {
 		{
 			in: &updateParameter{
 				ZoneParameter:       cflag.ZoneParameter{Zone: "is1a"},
-				IDParameter:         cflag.IDParameter{ID: 1},
+				IDParameter:         cflag.IDParameter{ID: "1"},
 				NameUpdateParameter: cflag.NameUpdateParameter{Name: pointer.NewString("1")},
 				DescUpdateParameter: cflag.DescUpdateParameter{Description: pointer.NewString("")},
 				TagsUpdateParameter: cflag.TagsUpdateParameter{Tags: pointer.NewStringSlice([]string{})},
@@ -136,7 +136,7 @@ func TestUpdateParameter_Validate(t *testing.T) {
 		{
 			in: &updateParameter{
 				ZoneParameter:       cflag.ZoneParameter{Zone: "is1a"},
-				IDParameter:         cflag.IDParameter{ID: 1},
+				IDParameter:         cflag.IDParameter{ID: "1"},
 				NameUpdateParameter: cflag.NameUpdateParameter{Name: pointer.NewString("")},
 			},
 			err: errors.New(strings.Join([]string{

--- a/pkg/commands/iaas/server/rdp_command.go
+++ b/pkg/commands/iaas/server/rdp_command.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/helper/wait"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/connect"
 	"github.com/sacloud/usacloud/pkg/core"
@@ -58,7 +59,7 @@ func rdpFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 	}
 
 	if !instance.InstanceStatus.IsUp() && p.WaitUntilReady {
-		lastState, err := wait.UntilServerIsUp(ctx, iaas.NewServerOp(ctx.Client().(iaas.APICaller)), p.Zone, p.ID)
+		lastState, err := wait.UntilServerIsUp(ctx, iaas.NewServerOp(ctx.Client().(iaas.APICaller)), p.Zone, types.StringID(p.ID))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/commands/iaas/server/ssh_command.go
+++ b/pkg/commands/iaas/server/ssh_command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/helper/query"
 	"github.com/sacloud/iaas-api-go/helper/wait"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/core"
 )
@@ -59,7 +60,7 @@ func sshFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 	}
 
 	if !instance.InstanceStatus.IsUp() && p.WaitUntilReady {
-		lastState, err := wait.UntilServerIsUp(ctx, iaas.NewServerOp(ctx.Client().(iaas.APICaller)), p.Zone, p.ID)
+		lastState, err := wait.UntilServerIsUp(ctx, iaas.NewServerOp(ctx.Client().(iaas.APICaller)), p.Zone, types.StringID(p.ID))
 		if err != nil {
 			return nil, err
 		}
@@ -76,7 +77,7 @@ func sshFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 
 	user := p.User
 	if user == "" {
-		u, err := query.ServerDefaultUserName(ctx, p.Zone, query.NewServerSourceReader(ctx.Client().(iaas.APICaller)), p.ID)
+		u, err := query.ServerDefaultUserName(ctx, p.Zone, query.NewServerSourceReader(ctx.Client().(iaas.APICaller)), types.StringID(p.ID))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/commands/iaas/server/vnc_command.go
+++ b/pkg/commands/iaas/server/vnc_command.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/helper/wait"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/connect"
 	"github.com/sacloud/usacloud/pkg/core"
@@ -53,12 +54,12 @@ func vncFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 
 	instance := ctx.Resource().(*iaas.Server)
 	if !instance.InstanceStatus.IsUp() && p.WaitUntilReady {
-		if _, err := wait.UntilServerIsUp(ctx, iaas.NewServerOp(ctx.Client().(iaas.APICaller)), p.Zone, p.ID); err != nil {
+		if _, err := wait.UntilServerIsUp(ctx, iaas.NewServerOp(ctx.Client().(iaas.APICaller)), p.Zone, types.StringID(p.ID)); err != nil {
 			return nil, err
 		}
 	}
 
-	vncInfo, err := iaas.NewServerOp(ctx.Client().(iaas.APICaller)).GetVNCProxy(ctx, p.Zone, p.ID)
+	vncInfo, err := iaas.NewServerOp(ctx.Client().(iaas.APICaller)).GetVNCProxy(ctx, p.Zone, types.StringID(p.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/iaas/webaccelerator/create_certificate.go
+++ b/pkg/commands/iaas/webaccelerator/create_certificate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cflag"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/core"
@@ -75,7 +76,7 @@ func createCertificateFunc(ctx cli.Context, parameter interface{}) ([]interface{
 	}
 
 	webAccelOp := iaas.NewWebAccelOp(ctx.Client().(iaas.APICaller))
-	result, err := webAccelOp.CreateCertificate(ctx, p.ID, &iaas.WebAccelCertRequest{
+	result, err := webAccelOp.CreateCertificate(ctx, types.StringID(p.ID), &iaas.WebAccelCertRequest{
 		CertificateChain: certs,
 		Key:              key,
 	})

--- a/pkg/commands/iaas/webaccelerator/read.go
+++ b/pkg/commands/iaas/webaccelerator/read.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cflag"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/core"
@@ -61,7 +62,7 @@ func readFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 		return nil, fmt.Errorf("got invalid parameter type: %#v", parameter)
 	}
 	webAccelOp := iaas.NewWebAccelOp(ctx.Client().(iaas.APICaller))
-	result, err := webAccelOp.Read(ctx, p.ID)
+	result, err := webAccelOp.Read(ctx, types.StringID(p.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/iaas/webaccelerator/read_certificate.go
+++ b/pkg/commands/iaas/webaccelerator/read_certificate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cflag"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/core"
@@ -61,7 +62,7 @@ func readCertificateFunc(ctx cli.Context, parameter interface{}) ([]interface{},
 		return nil, fmt.Errorf("got invalid parameter type: %#v", parameter)
 	}
 	webAccelOp := iaas.NewWebAccelOp(ctx.Client().(iaas.APICaller))
-	result, err := webAccelOp.ReadCertificate(ctx, p.ID)
+	result, err := webAccelOp.ReadCertificate(ctx, types.StringID(p.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/iaas/webaccelerator/update_certificate.go
+++ b/pkg/commands/iaas/webaccelerator/update_certificate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cflag"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/core"
@@ -78,7 +79,7 @@ func updateCertificateFunc(ctx cli.Context, parameter interface{}) ([]interface{
 	}
 
 	webAccelOp := iaas.NewWebAccelOp(ctx.Client().(iaas.APICaller))
-	result, err := webAccelOp.UpdateCertificate(ctx, p.ID, &iaas.WebAccelCertRequest{
+	result, err := webAccelOp.UpdateCertificate(ctx, types.StringID(p.ID), &iaas.WebAccelCertRequest{
 		CertificateChain: certs,
 		Key:              key,
 	})

--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -432,7 +432,7 @@ func (c *Command) expandResourceContextsFromArgs(ctx cli.Context, args []string)
 
 		for _, r := range resources {
 			if id, ok := c.extractMatchedResourceID(ctx, r, args); ok {
-				results.Append(cli.ResourceContext{ID: id, Zone: zone, Resource: r})
+				results.Append(cli.ResourceContext{ID: id.String(), Zone: zone, Resource: r})
 			}
 		}
 	}

--- a/pkg/core/progress.go
+++ b/pkg/core/progress.go
@@ -66,8 +66,8 @@ func (p *Progress) msgPrefix() string {
 	if p.ctx.Zone() != "" {
 		prefix = fmt.Sprintf("[%s] %s", p.ctx.Zone(), prefix)
 	}
-	if !p.ctx.ID().IsEmpty() {
-		prefix = fmt.Sprintf("%s (ID:%s)", prefix, p.ctx.ID().String())
+	if p.ctx.ID() != "" {
+		prefix = fmt.Sprintf("%s (ID:%s)", prefix, p.ctx.ID())
 	}
 	return prefix
 }

--- a/pkg/output/contents.go
+++ b/pkg/output/contents.go
@@ -18,12 +18,11 @@ import (
 	"sort"
 
 	"github.com/sacloud/iaas-api-go/accessor"
-	"github.com/sacloud/iaas-api-go/types"
 )
 
 type Content struct {
 	Zone  string
-	ID    types.ID
+	ID    string
 	Value interface{}
 }
 
@@ -66,7 +65,7 @@ func (c *Contents) Sort(zones []string) {
 }
 
 func (c *Contents) forceID(v interface{}) int64 {
-	id, ok := v.(accessor.ID)
+	id, ok := v.(accessor.ID) // TODO IaaS以外にはどう対応すべきか?
 	if !ok {
 		return -1
 	}

--- a/pkg/output/free_output.go
+++ b/pkg/output/free_output.go
@@ -78,7 +78,7 @@ func (o *freeOutput) Print(contents Contents) error {
 				mapValue["Zone"] = contents[i].Zone
 			}
 		}
-		if !contents[i].ID.IsEmpty() {
+		if contents[i].ID != "" {
 			if _, ok := mapValue["ID"]; !ok {
 				mapValue["ID"] = contents[i].ID
 			}

--- a/pkg/output/json_output.go
+++ b/pkg/output/json_output.go
@@ -81,7 +81,7 @@ func (o *jsonOutput) printWithMetaData(contents Contents) error {
 			}
 		}
 		// ID
-		if !contents[i].ID.IsEmpty() {
+		if contents[i].ID != "" {
 			if _, ok := mapValue["ID"]; !ok {
 				mapValue["ID"] = contents[i].ID
 			}

--- a/pkg/output/table_output.go
+++ b/pkg/output/table_output.go
@@ -73,7 +73,7 @@ func (o *tableOutput) Print(contents Contents) error {
 		}
 
 		// ID
-		if !contents[i].ID.IsEmpty() {
+		if contents[i].ID != "" {
 			if _, ok := mapValue["ID"]; !ok {
 				mapValue["ID"] = contents[i].ID
 			}

--- a/pkg/output/yaml_output.go
+++ b/pkg/output/yaml_output.go
@@ -64,7 +64,7 @@ func (o *yamlOutput) Print(contents Contents) error {
 		}
 
 		// ID
-		if !contents[i].ID.IsEmpty() {
+		if contents[i].ID != "" {
 			if _, ok := mapValue["ID"]; !ok {
 				mapValue["ID"] = contents[i].ID
 			}

--- a/pkg/test/cli_context.go
+++ b/pkg/test/cli_context.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/usacloud/pkg/cli"
 	"github.com/sacloud/usacloud/pkg/config"
 	"github.com/sacloud/usacloud/pkg/output"
@@ -32,7 +31,7 @@ type DummyCLIContextValue struct {
 	PlatformName string
 	ResourceName string
 	CommandName  string
-	ID           types.ID
+	ID           string
 	Zone         string
 	Resource     interface{}
 	Args         []string
@@ -66,7 +65,7 @@ func (c *DummyCLIContext) CommandName() string {
 	return c.DummyValue.CommandName
 }
 
-func (c *DummyCLIContext) ID() types.ID {
+func (c *DummyCLIContext) ID() string {
 	return c.DummyValue.ID
 }
 
@@ -78,7 +77,7 @@ func (c *DummyCLIContext) Resource() interface{} {
 	return c.DummyValue.Resource
 }
 
-func (c *DummyCLIContext) WithResource(id types.ID, zone string, resource interface{}) cli.Context {
+func (c *DummyCLIContext) WithResource(id string, zone string, resource interface{}) cli.Context {
 	return &DummyCLIContext{
 		DummyValue: &DummyCLIContextValue{
 			Context:      c.DummyValue.Context,


### PR DESCRIPTION
IaaS以外でもCLIのID周りの処理(補完や名前/タグによるマッチ)を利用したいためその準備としてstringを利用するように修正