### PR TITLE
CLIでのID/Name/Tags処理をIaaSに依存しないように修正

### DIFF
--- a/pkg/commands/iaas/init.go
+++ b/pkg/commands/iaas/init.go
@@ -15,11 +15,29 @@
 package iaas
 
 import (
-	"github.com/spf13/cobra"
+	"github.com/sacloud/iaas-api-go/accessor"
+	"github.com/sacloud/usacloud/pkg/core"
+	_ "github.com/sacloud/usacloud/pkg/services/iaas"
 )
 
-var Command = &cobra.Command{
-	Use:   "iaas",
-	Short: "SubCommands for IaaS",
-	Long:  "SubCommands for IaaS",
+func init() {
+	core.LabelsExtractors = append(core.LabelsExtractors, labelsExtractorForIaaS)
+}
+
+func labelsExtractorForIaaS(v interface{}) *core.Labels {
+	if v, ok := v.(accessor.ID); ok {
+		labels := &core.Labels{Id: v.GetID().String()}
+
+		// Name(部分一致)
+		if name, ok := v.(accessor.Name); ok {
+			labels.Name = name.GetName()
+		}
+
+		// Tags
+		if tags, ok := v.(accessor.Tags); ok {
+			labels.Tags = tags.GetTags()
+		}
+		return labels
+	}
+	return nil
 }

--- a/pkg/core/labels.go
+++ b/pkg/core/labels.go
@@ -12,14 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package iaas
+package core
 
-import (
-	"github.com/spf13/cobra"
-)
+// Labels Usacloudで扱うリソースを識別するためのラベル情報
+//
+// シェル補完や引数をID or Name or Tagsにマッチさせるために利用される
+type Labels struct {
+	Id   string
+	Name string
+	Tags []string
+}
 
-var Command = &cobra.Command{
-	Use:   "iaas",
-	Short: "SubCommands for IaaS",
-	Long:  "SubCommands for IaaS",
+var LabelsExtractors []func(v interface{}) *Labels
+
+func extractLabels(v interface{}) *Labels {
+	for _, extractor := range LabelsExtractors {
+		if l := extractor(v); l != nil {
+			return l
+		}
+	}
+	return nil
 }

--- a/pkg/core/usage.go
+++ b/pkg/core/usage.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sacloud/usacloud/pkg/commands/iaas"
 	"github.com/sacloud/usacloud/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -67,7 +66,7 @@ func SetSubCommandsUsage(cmd *cobra.Command, commands []*CategorizedResources) {
 	cmd.SetUsageTemplate("")
 	var usages []string
 	for _, c := range commands {
-		usages = append(usages, fmt.Sprintf(commandUsageTemplate, c.Category.DisplayName, buildSubCommandsUsage(cmd, c.Resources, c.Category == iaas.ResourceCategoryOther)))
+		usages = append(usages, fmt.Sprintf(commandUsageTemplate, c.Category.DisplayName, buildSubCommandsUsage(cmd, c.Resources, c.Category.Key == "other")))
 	}
 	usage := fmt.Sprintf(commandUsageWrapperTemplate, strings.TrimRight(strings.Join(usages, "\n"), "\n"))
 

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -15,7 +15,6 @@
 package services
 
 import (
-	_ "github.com/sacloud/usacloud/pkg/services/iaas"
 	"github.com/sacloud/usacloud/pkg/services/registry"
 )
 


### PR DESCRIPTION
シェル補完や引数からの処理対象決定処理をIaaSの型(types.IDなど)に依存させないようにするために
core.Labelsという型を新設し、IaaS依存な箇所はiaasパッケージ配下でcore.Labelsを返すような実装とする。