### PR TITLE
iaasサブコマンド省略時の警告表示を抑制

### DIFF
--- a/pkg/commands/iaas/command.go
+++ b/pkg/commands/iaas/command.go
@@ -15,9 +15,6 @@
 package iaas
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/sacloud/usacloud/pkg/commands/iaas/category"
 	"github.com/sacloud/usacloud/pkg/commands/root"
 	"github.com/sacloud/usacloud/pkg/core"
@@ -54,20 +51,22 @@ func addHiddenSubCommandToRoot(cmd *cobra.Command) {
 			cmd.AddCommand(&c)
 		}
 
+		// Note:当面は警告を表示しないようにする。https://github.com/sacloud/usacloud/issues/911
+		//
 		// コマンドの中にはデフォルトコマンドとして自身のサブコマンドを呼ぶ場合(auth-statusなど)があるため、
 		// 末端(childrenがない)コマンドにだけ設定する。(この条件がないと表示が重複する)
-		if len(children) == 0 {
-			cmd.PersistentPreRun = func(own *cobra.Command, args []string) {
-				// この段階ではctx.IO()が参照できないため標準エラーに出力する
-				fmt.Fprintln(os.Stderr, "[WARN] This command is deprecated. Please use the command under the `usacloud iaas` subcommand instead.") // nolint
-				if cmd.HasParent() {
-					parent := cmd.Parent()
-					if parent.PersistentPreRun != nil {
-						parent.PersistentPreRun(own, args)
-					}
-				}
-			}
-		}
+		//if len(children) == 0 {
+		//	cmd.PersistentPreRun = func(own *cobra.Command, args []string) {
+		//		// この段階ではctx.IO()が参照できないため標準エラーに出力する
+		//		fmt.Fprintln(os.Stderr, "[WARN] This command is deprecated. Please use the command under the `usacloud iaas` subcommand instead.") // nolint
+		//		if cmd.HasParent() {
+		//			parent := cmd.Parent()
+		//			if parent.PersistentPreRun != nil {
+		//				parent.PersistentPreRun(own, args)
+		//			}
+		//		}
+		//	}
+		//}
 	}
 	setChildFn(&c)
 


### PR DESCRIPTION
iaasコマンド導入を緩やかに進めるためにまずは警告表示なしとする。

今後のバージョンアップに伴い段階的に警告表示 -> エラー扱いとしていく。