### PR TITLE
iaasサブコマンド省略時でもシェル補完を機能させる

### DIFF
--- a/e2e/completion/e2e_test.go
+++ b/e2e/completion/e2e_test.go
@@ -1,0 +1,37 @@
+// Copyright 2017-2022 The Usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package minimum
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sacloud/usacloud/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2E_complete_old_iaas_command(t *testing.T) {
+	output, err := e2e.UsacloudRunWithOutput(t, "completion", "bash")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+
+	// iaasコマンドの例としてauto-backupを利用する。
+	// commands+=("auto-backup")という文字列がルートコマンドとiaasサブコマンドの2箇所にあるはず
+	require.Equal(t, 2, strings.Count(string(output), `commands+=("auto-backup")`))
+}

--- a/pkg/commands/completion/command.go
+++ b/pkg/commands/completion/command.go
@@ -58,6 +58,15 @@ $ usacloud completion fish > ~/.config/fish/completions/usacloud.fish
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.ExactValidArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// iaasサブコマンド配下のコマンドは互換性維持のためHidden=trueでRoot直下にも配置されている。
+		// これらのコマンドも補完するためにこのタイミングでRoot直下のコマンドのHiddenをfalseにする。
+		// Note: もしRoot直下にHidden=trueなコマンドが欲しくなった場合は修正が必要
+		for _, c := range cmd.Root().Commands() {
+			c.Hidden = false
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		switch args[0] {


### PR DESCRIPTION
closes #917 

iaasサブコマンド省略時でもシェル補完させる。

#### iaasサブコマンド省略

```bash
$ usacloud disk <TAB><TAB>

connect-to-server       delete                  edit                    monitor-disk            resize-partition        wait-until-ready        
create                  disconnect-from-server  list                    read                    update
```

#### iaasサブコマンド入力時

```bash
$ usacloud iaas disk  <TAB><TAB>

connect-to-server       delete                  edit                    monitor-disk            resize-partition        wait-until-ready        
create                  disconnect-from-server  list                    read                    update
```

#### ルートのヘルプには表示させないまま

```bash
$ usacloud -h
CLI to manage to resources on the SAKURA Cloud

Usage:
  usacloud [global options] <command> <sub-command> [options] [arguments] [flags]
  usacloud [command]

Available Commands:
  completion            Generate completion script
  config                Management commands for Configuration file/Profile
  help                  Help about any command
  iaas                  SubCommands for IaaS
  rest                  Invoke SAKURA cloud API directly
  update-self           Update Usacloud to latest-stable version
  version               Show version info
  web-accelerator       SubCommands for WebAccelerator

# ...以下略
```