### PR TITLE
デフォルトの全リソース取得funcで入力中のパラメータを反映しないように修正

### DIFF
--- a/pkg/services/iaas/archive_services_gen.go
+++ b/pkg/services/iaas/archive_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -439,9 +415,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -487,9 +460,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/auto_backup_services_gen.go
+++ b/pkg/services/iaas/auto_backup_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/auto_scale_services_gen.go
+++ b/pkg/services/iaas/auto_scale_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/bridge_services_gen.go
+++ b/pkg/services/iaas/bridge_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/cdrom_services_gen.go
+++ b/pkg/services/iaas/cdrom_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -439,9 +415,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/certificate_authority_services_gen.go
+++ b/pkg/services/iaas/certificate_authority_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/container_registry_services_gen.go
+++ b/pkg/services/iaas/container_registry_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/database_services_gen.go
+++ b/pkg/services/iaas/database_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -147,9 +141,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -443,9 +419,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -495,9 +468,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -547,9 +517,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -599,9 +566,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -651,9 +615,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -699,9 +660,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -747,9 +705,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/disk_plan_services_gen.go
+++ b/pkg/services/iaas/disk_plan_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/disk_services_gen.go
+++ b/pkg/services/iaas/disk_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -147,9 +141,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -195,9 +186,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -439,9 +415,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -491,9 +464,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -539,9 +509,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/dns_services_gen.go
+++ b/pkg/services/iaas/dns_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/enhanced_db_services_gen.go
+++ b/pkg/services/iaas/enhanced_db_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/esme_services_gen.go
+++ b/pkg/services/iaas/esme_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -298,9 +283,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -346,9 +328,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/gslb_services_gen.go
+++ b/pkg/services/iaas/gslb_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/icon_services_gen.go
+++ b/pkg/services/iaas/icon_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/interface_services_gen.go
+++ b/pkg/services/iaas/interface_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/internet_plan_services_gen.go
+++ b/pkg/services/iaas/internet_plan_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/internet_services_gen.go
+++ b/pkg/services/iaas/internet_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -203,9 +194,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -251,9 +239,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -299,9 +284,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -347,9 +329,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -395,9 +374,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -443,9 +419,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -491,9 +464,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -543,9 +513,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/ipv6addr_services_gen.go
+++ b/pkg/services/iaas/ipv6addr_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/ipv6net_services_gen.go
+++ b/pkg/services/iaas/ipv6net_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/license_info_services_gen.go
+++ b/pkg/services/iaas/license_info_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/license_services_gen.go
+++ b/pkg/services/iaas/license_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/load_balancer_services_gen.go
+++ b/pkg/services/iaas/load_balancer_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -147,9 +141,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -443,9 +419,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -491,9 +464,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -539,9 +509,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/local_router_services_gen.go
+++ b/pkg/services/iaas/local_router_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -294,9 +279,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -346,9 +328,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/mobile_gateway_services_gen.go
+++ b/pkg/services/iaas/mobile_gateway_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -147,9 +141,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -443,9 +419,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -495,9 +468,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -543,9 +513,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -591,9 +558,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/nfs_services_gen.go
+++ b/pkg/services/iaas/nfs_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -147,9 +141,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -443,9 +419,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -495,9 +468,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -543,9 +513,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -591,9 +558,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/note_services_gen.go
+++ b/pkg/services/iaas/note_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/packet_filter_services_gen.go
+++ b/pkg/services/iaas/packet_filter_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/private_host_plan_services_gen.go
+++ b/pkg/services/iaas/private_host_plan_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/private_host_services_gen.go
+++ b/pkg/services/iaas/private_host_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/proxy_lb_services_gen.go
+++ b/pkg/services/iaas/proxy_lb_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -294,9 +279,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -342,9 +324,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -394,9 +373,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/region_services_gen.go
+++ b/pkg/services/iaas/region_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/server_plan_services_gen.go
+++ b/pkg/services/iaas/server_plan_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/server_services_gen.go
+++ b/pkg/services/iaas/server_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -147,9 +141,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -195,9 +186,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -439,9 +415,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -491,9 +464,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -518,9 +488,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -545,9 +512,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -572,9 +536,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -620,9 +581,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -668,9 +626,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/service_class_services_gen.go
+++ b/pkg/services/iaas/service_class_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/sim_services_gen.go
+++ b/pkg/services/iaas/sim_services_gen.go
@@ -50,9 +50,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -98,9 +95,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -294,9 +279,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -342,9 +324,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -394,9 +373,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -446,9 +422,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/simple_monitor_services_gen.go
+++ b/pkg/services/iaas/simple_monitor_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -294,9 +279,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -346,9 +328,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/ssh_key_services_gen.go
+++ b/pkg/services/iaas/ssh_key_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -150,9 +144,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -198,9 +189,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -246,9 +234,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -294,9 +279,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/subnet_services_gen.go
+++ b/pkg/services/iaas/subnet_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/switch_services_gen.go
+++ b/pkg/services/iaas/switch_services_gen.go
@@ -55,9 +55,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -103,9 +100,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -151,9 +145,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/vpc_router_services_gen.go
+++ b/pkg/services/iaas/vpc_router_services_gen.go
@@ -51,9 +51,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -99,9 +96,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -147,9 +141,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -199,9 +190,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -247,9 +235,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -295,9 +280,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -343,9 +325,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -391,9 +370,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -439,9 +415,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -487,9 +460,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -539,9 +509,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -591,9 +558,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -639,9 +603,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -687,9 +648,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue()}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/pkg/services/iaas/zone_services_gen.go
+++ b/pkg/services/iaas/zone_services_gen.go
@@ -54,9 +54,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest
@@ -102,9 +99,6 @@ func init() {
 		func(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 			svc := service.New(ctx.Client().(iaas.APICaller))
 			req := &service.FindRequest{}
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest

--- a/tools/gen-commands/services_template.go
+++ b/tools/gen-commands/services_template.go
@@ -69,9 +69,6 @@ func init() { {{ range .Commands }}{{ if .ParameterInitializer }}{{ if not .Func
 		func (ctx cli.Context, parameter interface{}) ([]interface{}, error) { 
 			svc := service.New(ctx.Client().({{ .ServiceFuncClientTypeName }}))
 			req := &service.FindRequest{ {{ if not .Resource.IsGlobalResource}} Zone: (parameter.(cflag.ZoneParameterValueHandler)).ZoneFlagValue(){{ end }} }
-			if err := conv.ConvertTo(parameter, req); err != nil {
-				return nil, err
-			}
 
 			type requester interface {
 				FindRequest() *service.FindRequest


### PR DESCRIPTION
fixes #925

usacloudではID/名前/タグから処理対象リソースを取得するために以下の流れで処理している。

- 各コマンドごとに全リソース取得funcを定義(基本はコード生成、コマンドごとに検索条件をカスタマイズ可能)
- 全リソース取得funcでAPIを用いて処理対象の候補となる全リソースを取得
- 全リソースから指定されたID/名前/タグに合致するものだけにフィルタリング(フィルタリング処理はAPIではなくコード上で実装)

この時、現在の実装だと全リソース取得funcに入力中のパラメータが渡される。
入力中のパラメータに各サービスのFindParameterとマッチするものがあると検索条件に反映されてしまっていた。
例: tagsやnamesなど

このPRでは全リソース取得funcへの入力中パラメータの反映処理を除去(コード生成テンプレートの修正)することでこの問題を修正する。

Note: 現在は各コマンドごとに検索条件をカスタマイズしている部分はないため、コード生成テンプレートの修正で全修正箇所を網羅可能なはず。