### PR TITLE
Fix: mapconvでポインタを受け取る箇所でのdereferenceフィルタ指定誤りを修正

### DIFF
--- a/pkg/commands/iaas/autobackup/update.go
+++ b/pkg/commands/iaas/autobackup/update.go
@@ -47,7 +47,7 @@ type updateParameter struct {
 	cflag.TagsUpdateParameter   `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
-	Weekdays         *[]string `cli:",options=weekdays" mapconv:"BackupSpanWeekdays,omitempty,filters=weekdays" validate:"omitempty,weekdays"`
+	Weekdays         *[]string `cli:",options=weekdays" mapconv:"BackupSpanWeekdays,omitempty,filters=dereference weekdays" validate:"omitempty,weekdays"`
 	MaxNumOfArchives *int      `cli:"max-backup-num" mapconv:"MaximumNumberOfArchives" validate:"omitempty,min=1,max=10"`
 }
 

--- a/pkg/commands/iaas/autoscale/update.go
+++ b/pkg/commands/iaas/autoscale/update.go
@@ -48,7 +48,7 @@ type updateParameter struct {
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
 	Zones  *[]string `validate:"omitempty,required"`
-	Config *string   `validate:"omitempty,required" mapconv:",omitempty,filters=path_or_content"`
+	Config *string   `validate:"omitempty,required" mapconv:",omitempty,filters=dereference path_or_content"`
 
 	Disabled               bool
 	TriggerType            *string                      `cli:"trigger-type,options=cpu router schedule" validate:"omitempty,oneof=cpu router schedule" mapconv:",omitempty"`

--- a/pkg/commands/iaas/database/update.go
+++ b/pkg/commands/iaas/database/update.go
@@ -59,7 +59,7 @@ type updateParameter struct {
 	ReplicaUserPassword   *string   `cli:",category=replication,order=20,desc=(*required when --enable-replication is specified)" validate:"omitempty,required_with=EnableReplication"`
 	EnableWebUI           *bool     `cli:",category=WebUI"`
 	EnableBackup          *bool     `cli:",category=backup,order=10"`
-	BackupWeekdays        *[]string `cli:",options=weekdays,category=backup,order=20" mapconv:",omitempty,filters=weekdays" validate:"omitempty,max=7,weekdays"`
+	BackupWeekdays        *[]string `cli:",options=weekdays,category=backup,order=20" mapconv:",omitempty,filters=dereference weekdays" validate:"omitempty,max=7,weekdays"`
 	BackupStartTimeHour   *int      `cli:",category=backup,order=30" mapconv:",omitempty" validate:"omitempty,min=0,max=23"`
 	BackupStartTimeMinute *int      `cli:",category=backup,order=40" mapconv:",omitempty" validate:"omitempty,oneof=0 15 30 45"`
 

--- a/pkg/commands/iaas/proxylb/update.go
+++ b/pkg/commands/iaas/proxylb/update.go
@@ -53,7 +53,7 @@ type updateParameter struct {
 	cflag.TagsUpdateParameter   `cli:",squash" mapconv:",omitempty,squash"`
 	cflag.IconIDUpdateParameter `cli:",squash" mapconv:",omitempty,squash"`
 
-	Plan *string `cli:",options=proxylb_plan" mapconv:",omitempty,filters=proxylb_plan_to_value" validate:"omitempty,proxylb_plan"`
+	Plan *string `cli:",options=proxylb_plan" mapconv:",omitempty,filters=dereference proxylb_plan_to_value" validate:"omitempty,proxylb_plan"`
 
 	HealthCheck          updateParameterHealthCheck          `mapconv:",omitempty"`
 	SorryServer          updateParameterSorryServer          `mapconv:",omitempty"`

--- a/pkg/commands/iaas/server/update.go
+++ b/pkg/commands/iaas/server/update.go
@@ -56,10 +56,10 @@ type updateParameter struct {
 	Memory     *int    `cli:"memory,category=plan,order=20" mapconv:"MemoryGB"`
 	GPU        *int    `cli:"gpu,category=plan,order=30"`
 	CPUModel   *string `cli:"cpu-model,category=plan,order=40"`
-	Commitment *string `cli:",options=server_plan_commitment,category=plan,order=50" mapconv:",omitempty,filters=server_plan_commitment_to_value" validate:"omitempty,server_plan_commitment"`
-	Generation *string `cli:",options=server_plan_generation,category=plan,order=60" mapconv:",omitempty,filters=server_plan_generation_to_value" validate:"omitempty,server_plan_generation"`
+	Commitment *string `cli:",options=server_plan_commitment,category=plan,order=50" mapconv:",omitempty,filters=dereference server_plan_commitment_to_value" validate:"omitempty,server_plan_commitment"`
+	Generation *string `cli:",options=server_plan_generation,category=plan,order=60" mapconv:",omitempty,filters=dereference server_plan_generation_to_value" validate:"omitempty,server_plan_generation"`
 
-	InterfaceDriver *string `cli:",options=interface_dirver" mapconv:",omitempty,filters=interface_driver_to_value" validate:"omitempty,interface_driver"`
+	InterfaceDriver *string `cli:",options=interface_driver" mapconv:",omitempty,filters=dereference interface_driver_to_value" validate:"omitempty,interface_driver"`
 
 	CDROMID       *types.ID `cli:"cdrom-id,aliases=iso-image-id"`
 	PrivateHostID *types.ID

--- a/pkg/commands/iaas/server/zz_update_gen.go
+++ b/pkg/commands/iaas/server/zz_update_gen.go
@@ -130,7 +130,7 @@ func (p *updateParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(p.CPUModel, "cpu-model", "", "", "")
 	fs.StringVarP(p.Commitment, "commitment", "", "", "options: [standard/dedicatedcpu]")
 	fs.StringVarP(p.Generation, "generation", "", "", "options: [default/g100/g200]")
-	fs.StringVarP(p.InterfaceDriver, "interface-driver", "", "", "options: [interface_dirver]")
+	fs.StringVarP(p.InterfaceDriver, "interface-driver", "", "", "options: [virtio/e1000]")
 	fs.VarP(core.NewIDFlag(p.CDROMID, p.CDROMID), "cdrom-id", "", "(aliases: --iso-image-id)")
 	fs.VarP(core.NewIDFlag(p.PrivateHostID, p.PrivateHostID), "private-host-id", "", "")
 	fs.StringVarP(&p.NetworkInterfaceData, "network-interfaces", "", p.NetworkInterfaceData, "")
@@ -264,7 +264,7 @@ func (p *updateParameter) buildFlagsUsage(cmd *cobra.Command) {
 func (p *updateParameter) setCompletionFunc(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("commitment", util.FlagCompletionFunc("standard", "dedicatedcpu"))
 	cmd.RegisterFlagCompletionFunc("generation", util.FlagCompletionFunc("default", "g100", "g200"))
-	cmd.RegisterFlagCompletionFunc("interface-driver", util.FlagCompletionFunc("interface_dirver"))
+	cmd.RegisterFlagCompletionFunc("interface-driver", util.FlagCompletionFunc("virtio", "e1000"))
 
 }
 

--- a/pkg/commands/iaas/simplemonitor/update.go
+++ b/pkg/commands/iaas/simplemonitor/update.go
@@ -62,7 +62,7 @@ type updateParameter struct {
 }
 
 type updateParameterHealthCheck struct {
-	Protocol          *string `cli:",options=simple_monitor_protocol" mapconv:",omitempty,filters=simple_monitor_protocol_to_value" validate:"omitempty,simple_monitor_protocol" json:",omitempty"`
+	Protocol          *string `cli:",options=simple_monitor_protocol" mapconv:",omitempty,filters=dereference simple_monitor_protocol_to_value" validate:"omitempty,simple_monitor_protocol" json:",omitempty"`
 	Port              *int    `json:",omitempty"`
 	Path              *string `json:",omitempty"`
 	Status            *int    `json:",omitempty"`
@@ -78,7 +78,7 @@ type updateParameterHealthCheck struct {
 	OID               *string `json:",omitempty"`
 	RemainingDays     *int    `json:",omitempty"`
 	HTTP2             *bool   `cli:"http2" json:",omitempty"`
-	FTPS              *string `cli:",options=simple_monitor_ftps" mapconv:",omitempty,filters=simple_monitor_ftps_to_value" validate:"omitempty,simple_monitor_ftps" json:",omitempty"`
+	FTPS              *string `cli:",options=simple_monitor_ftps" mapconv:",omitempty,filters=dereference simple_monitor_ftps_to_value" validate:"omitempty,simple_monitor_ftps" json:",omitempty"`
 	VerifySNI         *bool   `cli:"verify-sni" json:",omitempty"`
 }
 


### PR DESCRIPTION
from: https://github.com/sacloud/usacloud/issues/1067#issuecomment-1699991106

Update時に`failed to apply the filter: key 0x140008c99d0 not found in proxylb_plan`のようなエラーが出る問題の修正

修正内容:
mapconvでCLIパラメータ->Serviceパラメータに変換する際のフィルタのうち、`dereference`指定が漏れている箇所に追記