### PR TITLE
Linuxにinstall.shを実行してインストールする時に適切なアーキテクチャを選択する

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,13 +50,31 @@ SCRIPT
 }
 
 install_with_curl() {
+  detect_arch
   echo "===== install usacloud by curl ====="
-  sudo sh <<'SCRIPT'
-    curl -LO https://github.com/sacloud/usacloud/releases/latest/download/usacloud_linux-amd64.zip
-    unzip -j usacloud_linux-amd64.zip usacloud && rm usacloud_linux-amd64.zip
+  sudo sh <<SCRIPT
+    curl -LO https://github.com/sacloud/usacloud/releases/latest/download/usacloud_linux-${ARCH}.zip
+    unzip -j usacloud_linux-${ARCH}.zip usacloud && rm usacloud_linux-${ARCH}.zip
     chmod +x usacloud
     mv usacloud /usr/local/bin/
 SCRIPT
+}
+
+detect_arch() {
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    "i386" | "i686")
+      ARCH="386" ;;
+    "amd64"| "x86_64")
+      ARCH="amd64" ;;
+    "arm" | "aarch32")
+      ARCH="arm" ;;
+    "arm64" | "aarch64")
+      ARCH="arm64" ;;
+    *)
+      echo "Your platform ($(uname -a)) is not supported."
+      exit 1 ;;
+  esac
 }
 
 ### main


### PR DESCRIPTION
aarch64なUbuntu環境でinstall.shを実行した時に適切なアーキテクチャ(arm64)のリリースを取得するようにしました。

usacloudがLinuxで対応しているアーキテクチャ 386, amd64, arm, arm64に対応するように実装しましたが、検証環境の都合で`uname -m`が `x86_64` `aarch64`の場合のみ検証しています。

## aarch64

limaでaarch64のUbuntuを用意して検証しました。

```bash
t-inagaki@lima-aarch64:~$ uname -m
aarch64
t-inagaki@lima-aarch64:~$ curl -fsSL https://raw.githubusercontent.com/ophum/usacloud/main/scripts/install.sh | bash
===== install dependencies by apt =====
+ apt-get update -qq
+ apt-get install -y curl apt-transport-https zip
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
curl is already the newest version (8.2.1-1ubuntu3.3).
apt-transport-https is already the newest version (2.7.3ubuntu0.1).
zip is already the newest version (3.0-13).
0 upgraded, 0 newly installed, 0 to remove and 27 not upgraded.
===== install usacloud by curl =====
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100 6305k  100 6305k    0     0  1852k      0  0:00:03  0:00:03 --:--:-- 4167k
Archive:  usacloud_linux-arm64.zip
  inflating: usacloud                
t-inagaki@lima-aarch64:~$ usacloud version
1.13.3 linux/arm64, build a9f307b6
```

## x86_64

limaでx86_64のUbuntuを用意して検証しました。

```bash
t-inagaki@ubuntu:~$ uname -m
x86_64
t-inagaki@ubuntu:~$ curl -fsSL https://raw.githubusercontent.com/ophum/usacloud/main/scripts/install.sh | bash
===== install dependencies by apt =====
+ apt-get update -qq
+ apt-get install -y curl apt-transport-https zip
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
curl is already the newest version (8.2.1-1ubuntu3.3).
apt-transport-https is already the newest version (2.7.3ubuntu0.1).
zip is already the newest version (3.0-13).
0 upgraded, 0 newly installed, 0 to remove and 27 not upgraded.
===== install usacloud by curl =====
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100 6923k  100 6923k    0     0  2040k      0  0:00:03  0:00:03 --:--:-- 6958k
Archive:  usacloud_linux-amd64.zip
  inflating: usacloud                
t-inagaki@ubuntu:~$ usacloud version
1.13.3 linux/amd64, build a9f307b6
```