### PR TITLE
20GBのISOイメージ作成機能

### DIFF
--- a/pkg/commands/iaas/cdrom/create.go
+++ b/pkg/commands/iaas/cdrom/create.go
@@ -43,7 +43,7 @@ type createParameter struct {
 	cflag.DescParameter   `cli:",squash" mapconv:",squash"`
 	cflag.TagsParameter   `cli:",squash" mapconv:",squash"`
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
-	SizeGB                int `cli:"size,desc=(*required when --source-file is specified)" validate:"required_with=SourceFile,cdrom_sizes"`
+	SizeGB                int `cli:"size,desc=(*required when --source-file is specified),options=cdrom_sizes" validate:"required_with=SourceFile,cdrom_sizes"`
 
 	SourceFile string `mapconv:"SourceReader,filters=path_to_reader" validate:"required,file"`
 }

--- a/pkg/commands/iaas/cdrom/zz_create_gen.go
+++ b/pkg/commands/iaas/cdrom/zz_create_gen.go
@@ -18,6 +18,7 @@ package cdrom
 
 import (
 	"github.com/sacloud/usacloud/pkg/core"
+	"github.com/sacloud/usacloud/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -42,7 +43,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Description, "description", "", p.Description, "")
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
-	fs.IntVarP(&p.SizeGB, "size", "", p.SizeGB, "(*required when --source-file is specified)")
+	fs.IntVarP(&p.SizeGB, "size", "", p.SizeGB, "(*required when --source-file is specified) options: [5/10/20]")
 	fs.StringVarP(&p.SourceFile, "source-file", "", p.SourceFile, "(*required) ")
 	fs.SetNormalizeFunc(p.normalizeFlagName)
 }
@@ -136,6 +137,7 @@ func (p *createParameter) buildFlagsUsage(cmd *cobra.Command) {
 }
 
 func (p *createParameter) setCompletionFunc(cmd *cobra.Command) {
+	cmd.RegisterFlagCompletionFunc("size", util.FlagCompletionFunc("5", "10", "20"))
 
 }
 

--- a/pkg/vdef/definitions.go
+++ b/pkg/vdef/definitions.go
@@ -50,6 +50,7 @@ var definitions = map[string][]*definition{
 	"cdrom_sizes": {
 		{key: 5, value: 5},
 		{key: 10, value: 10},
+		{key: 20, value: 20},
 	},
 	"certificate_authority_issuance_method": {
 		{key: types.CertificateAuthorityIssuanceMethods.URL.String(), value: types.CertificateAuthorityIssuanceMethods.URL},


### PR DESCRIPTION
closes #1099

ISOイメージ作成時に`--size`に20を指定可能にする。

```
./usacloud cdrom create --name example --size 20 --source-file example.iso
```

また、--sizeに対しシェル補完やヘルプで候補値ga表示されていなかったため合わせて対応