### PR TITLE
WebAccel配下のリソースでシェル補完用のLabel抽出処理を実装

### DIFF
--- a/pkg/commands/webaccel/labels.go
+++ b/pkg/commands/webaccel/labels.go
@@ -1,0 +1,34 @@
+// Copyright 2017-2023 The sacloud/usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webaccel
+
+import (
+	"github.com/sacloud/usacloud/pkg/core"
+	"github.com/sacloud/webaccel-api-go"
+)
+
+func init() {
+	core.LabelsExtractors = append(core.LabelsExtractors, extractLabels)
+}
+
+func extractLabels(v interface{}) *core.Labels {
+	if v, ok := v.(*webaccel.Site); ok {
+		return &core.Labels{
+			Id:   v.ID,
+			Name: v.Name,
+		}
+	}
+	return nil
+}

--- a/pkg/resources.go
+++ b/pkg/resources.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sacloud/usacloud/pkg/commands/root"
 	updateSelf "github.com/sacloud/usacloud/pkg/commands/update-self"
 	"github.com/sacloud/usacloud/pkg/commands/version"
+	_ "github.com/sacloud/usacloud/pkg/commands/webaccel" // webaccel向けのcore.LabelsExtractorsの設定用
 	"github.com/sacloud/usacloud/pkg/commands/webaccel/webaccelerator"
 	"github.com/sacloud/usacloud/pkg/core"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
fixes #1126 

現在のLabel抽出処理はsacloud/iaas-api-goを用いる前提になっておりWebAccel配下に対しては対応していなかった。
このためWebAccel配下のリソースに対するLabel抽出処理をUsacloud内で個別実装する。
今回は*webaccel.Siteのみ対応とした。