### PR TITLE
fix(config): ensure SAKURACLOUD_ZONES env var is respected

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -66,9 +67,7 @@ var DefaultQueryDriver = query.DriverJMESPath
 // LoadConfigValue 指定のフラグセットからフラグを読み取り*Flagsを組み立てて返す
 func LoadConfigValue(flags *pflag.FlagSet, errW io.Writer, skipLoadingProfile bool) (*Config, error) {
 	o := &Config{
-		ConfigValue: profile.ConfigValue{
-			Zones: append(iaas.SakuraCloudZones, "all"),
-		},
+		ConfigValue: profile.ConfigValue{},
 	}
 	if skipLoadingProfile {
 		return o, nil
@@ -100,6 +99,9 @@ func (o *Config) fillDefaults() {
 	if len(o.Zones) == 0 {
 		o.Zones = iaas.SakuraCloudZones
 	}
+	if !slices.Contains(o.Zones, "all") {
+		o.Zones = append(o.Zones, "all")
+	}
 }
 
 func (o *Config) loadFromEnv() {
@@ -113,7 +115,7 @@ func (o *Config) loadFromEnv() {
 		o.Zone = stringFromEnv("SAKURACLOUD_ZONE", "")
 	}
 	if len(o.Zones) == 0 {
-		o.Zones = stringSliceFromEnv("SAKURACLOUD_ZONES", append(iaas.SakuraCloudZones, "all"))
+		o.Zones = stringSliceFromEnv("SAKURACLOUD_ZONES", []string{})
 	}
 	if o.AcceptLanguage == "" {
 		o.AcceptLanguage = stringFromEnv("SAKURACLOUD_ACCEPT_LANGUAGE", "")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,72 @@
+// Copyright 2017-2025 The sacloud/usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/sacloud/api-client-go/profile"
+	"github.com/sacloud/iaas-api-go"
+)
+
+func TestFillDefaults_ZonesEmpty(t *testing.T) {
+	c := &Config{}
+	c.fillDefaults()
+	want := iaas.SakuraCloudZones
+	want = append(want, "all")
+	if !reflect.DeepEqual(c.Zones, want) {
+		t.Errorf("Zones: got %v, want %v", c.Zones, want)
+	}
+}
+
+func TestFillDefaults_ZonesWithAll(t *testing.T) {
+	c := &Config{
+		ConfigValue: profile.ConfigValue{
+			Zones: []string{"is1a", "all"},
+		},
+	}
+	c.fillDefaults()
+	want := []string{"is1a", "all"}
+	if !reflect.DeepEqual(c.Zones, want) {
+		t.Errorf("Zones: got %v, want %v", c.Zones, want)
+	}
+}
+
+func TestFillDefaults_ZonesWithoutAll(t *testing.T) {
+	c := &Config{
+		ConfigValue: profile.ConfigValue{
+			Zones: []string{"is1a", "tk1a"},
+		},
+	}
+	c.fillDefaults()
+	want := []string{"is1a", "tk1a", "all"}
+	if !reflect.DeepEqual(c.Zones, want) {
+		t.Errorf("Zones: got %v, want %v", c.Zones, want)
+	}
+}
+
+func TestFillDefaults_EnvVar(t *testing.T) {
+	os.Setenv("SAKURACLOUD_ZONES", "is1a,tk1a") //nolint:errcheck,gosec
+	defer os.Unsetenv("SAKURACLOUD_ZONES")      //nolint:errcheck
+	c := &Config{}
+	c.loadFromEnv()
+	c.fillDefaults()
+	want := []string{"is1a", "tk1a", "all"}
+	if !reflect.DeepEqual(c.Zones, want) {
+		t.Errorf("Zones: got %v, want %v", c.Zones, want)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

社内からの問い合わせにより発覚
プロファイル/環境変数の組み合わせによっては環境変数からSAKURACLOUD_ZONESの設定が行えない。

### このPRはどういう変更を行いますか？

config周りの初期化処理を整理し、SAKURACLOUD_ZONESの設定を尊重するようにする。

### ドキュメントの変更は必要ですか？

no