### PR TITLE
config: remove zone validation from config commands

### DIFF
--- a/pkg/commands/config/edit.go
+++ b/pkg/commands/config/edit.go
@@ -67,7 +67,7 @@ type EditParameter struct {
 	Name              string `validate:"omitempty,profile_name"`
 	AccessToken       string `cli:"access-token,aliases=token"`
 	AccessTokenSecret string `cli:"access-token-secret,aliases=secret"`
-	Zone              string `validate:"omitempty,zone"`
+	Zone              string
 	DefaultOutputType string `validate:"omitempty,output_type"`
 	NoColor           bool
 	Use               bool


### PR DESCRIPTION
### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

`usacloud config edit`や`usacloud config create`実行時には、利用可能なゾーンはプロファイルや環境変数に依存するため確定できない。
configサブコマンド自体がプロファイルを操作するものであり、ここでゾーンを検証すると依存関係が循環してしまう。
そのため、configサブコマンドではzoneのバリデーションを行わないように修正した。

### ドキュメントの変更は必要ですか？

no