### PR TITLE
Enable usacloud config to run in non-TTY environments

### DIFF
--- a/e2e/config/e2e_test.go
+++ b/e2e/config/e2e_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017-2025 The sacloud/usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package minimum
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sacloud/saclient-go"
+	usacloudE2E "github.com/sacloud/usacloud/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2E_CreateConfigWithoutTTY(t *testing.T) {
+	// setup
+	profileDir := t.TempDir()
+	os.Setenv("SAKURACLOUD_PROFILE_DIR", profileDir)
+
+	profileName := "foobar"
+
+	err := usacloudE2E.UsacloudRun(t, "config", "create", profileName, "--token", "aaa", "--secret", "bbb", "--default-output-type", "table", "--zone", "is1b", "--use")
+	require.NoError(t, err)
+
+	profileOp := saclient.NewProfileOp(os.Environ())
+	profile, err := profileOp.Read(profileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, "aaa", profile.Attributes["AccessToken"])
+	require.Equal(t, "bbb", profile.Attributes["AccessTokenSecret"])
+	require.Equal(t, "table", profile.Attributes["DefaultOutputType"])
+	require.Equal(t, "is1b", profile.Attributes["Zone"])
+}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sacloud/iaas-api-go v1.22.0
 	github.com/sacloud/iaas-service-go v1.19.0
 	github.com/sacloud/packages-go v0.0.12
-	github.com/sacloud/saclient-go v0.2.1
+	github.com/sacloud/saclient-go v0.2.2
 	github.com/sacloud/webaccel-api-go v1.3.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -81,12 +81,12 @@ github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVW
 github.com/hashicorp/terraform-exec v0.21.0/go.mod h1:1PPeMYou+KDUSSeRE9szMZ/oHf4fYUmB923Wzbq1ICg=
 github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7orfb5Ltvec=
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
-github.com/hashicorp/terraform-plugin-framework v1.16.1 h1:1+zwFm3MEqd/0K3YBB2v9u9DtyYHyEuhVOfeIXbteWA=
-github.com/hashicorp/terraform-plugin-framework v1.16.1/go.mod h1:0xFOxLy5lRzDTayc4dzK/FakIgBhNf/lC4499R9cV4Y=
+github.com/hashicorp/terraform-plugin-framework v1.17.0 h1:JdX50CFrYcYFY31gkmitAEAzLKoBgsK+iaJjDC8OexY=
+github.com/hashicorp/terraform-plugin-framework v1.17.0/go.mod h1:4OUXKdHNosX+ys6rLgVlgklfxN3WHR5VHSOABeS/BM0=
 github.com/hashicorp/terraform-plugin-go v0.29.0 h1:1nXKl/nSpaYIUBU1IG/EsDOX0vv+9JxAltQyDMpq5mU=
 github.com/hashicorp/terraform-plugin-go v0.29.0/go.mod h1:vYZbIyvxyy0FWSmDHChCqKvI40cFTDGSb3D8D70i9GM=
-github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
-github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
+github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
+github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
 github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 h1:nqAlWFEdqI0ClbTDrhDvE/8LeQ4pftrqKUX9w5k0j3s=
 github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -157,8 +157,8 @@ github.com/sacloud/iaas-service-go v1.19.0 h1:5YRdezCu2FhU1mhRNk9j8Pa0qnJz2e1muN
 github.com/sacloud/iaas-service-go v1.19.0/go.mod h1:yplnBDrMI1/fMTXhaLlZsBrvAZXuG72y6nk/KjdwkPs=
 github.com/sacloud/packages-go v0.0.12 h1:MKeZNN3FQn1heqUSRBrbZw89YusZA1n4kammjMFZYvQ=
 github.com/sacloud/packages-go v0.0.12/go.mod h1:XNF5MCTWcHo9NiqWnYctVbASSSZR3ZOmmQORIzcurJ8=
-github.com/sacloud/saclient-go v0.2.1 h1:Xt5h2NfzI3ZIyDX/R9HAAfkPNd2SH9FFxPd4HQmsCtg=
-github.com/sacloud/saclient-go v0.2.1/go.mod h1:1uyhSsW2OukufdpHT6rbDiqPpNONexu1G9f5oXIoIFE=
+github.com/sacloud/saclient-go v0.2.2 h1:7dtfq8pL72ygEKkV0tTRap+c1KrUfBhw4g6yhsZAR00=
+github.com/sacloud/saclient-go v0.2.2/go.mod h1:OtOU2yvXynl5c8Pj4ZLXx5/xFcp0xqkpmTy8UfN+xWA=
 github.com/sacloud/webaccel-api-go v1.3.0 h1:qu8QycooO64dkHdWPRdUn3eUf9BWpLASoh9uUo7oWZs=
 github.com/sacloud/webaccel-api-go v1.3.0/go.mod h1:5R914VqVeXIR320MwZYlSouFXgm/mvtY3YQ3SYSPWcU=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=

--- a/pkg/commands/config/edit_test.go
+++ b/pkg/commands/config/edit_test.go
@@ -1,0 +1,15 @@
+// Copyright 2017-2025 The sacloud/usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

`usacloud config`でcreateやeditを非対話形式でも利用可能にしたい。
このために以下の修正を行う。

- プロンプトを出す際にterm.IsTerminal()を用いた判定を行う
- editのバリデーションを見直し、一部のパラメータのみがコマンドライン引数で渡された場合でも非対話形式で実行可能に
- E2Eテストに非対話形式でのプロファイル作成シナリオを追加

> [!WARN]
> 現状だとサービスプリンシパルキー周りのパラメータをコマンドライン引数で指定できない。この対応は別PRで行う。


### ドキュメントの変更は必要ですか？
