### PR TITLE
Fix nil client when httpClient is provided on initialization

### DIFF
--- a/e2e/sacloud.go
+++ b/e2e/sacloud.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"fmt"
-	"net/http"
 	"runtime"
 
 	client "github.com/sacloud/api-client-go"
@@ -37,7 +36,6 @@ var SacloudAPICaller = api.NewCallerWithOptions(&api.CallerOptions{
 			runtime.GOARCH,
 			iaas.DefaultUserAgent,
 		),
-		HttpClient:           &http.Client{},
 		HttpRequestTimeout:   300,
 		HttpRequestRateLimit: 10,
 		RetryMax:             10,

--- a/pkg/cli/api_client.go
+++ b/pkg/cli/api_client.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 
 	client "github.com/sacloud/api-client-go"
 	"github.com/sacloud/iaas-api-go"
@@ -49,7 +48,6 @@ func newAPIClient(o *config.Config) *apiClient {
 		AccessToken:          o.AccessToken,
 		AccessTokenSecret:    o.AccessTokenSecret,
 		AcceptLanguage:       o.AcceptLanguage,
-		HttpClient:           http.DefaultClient,
 		HttpRequestTimeout:   o.HTTPRequestTimeout,
 		HttpRequestRateLimit: o.HTTPRequestRateLimit,
 		RetryMax:             o.RetryMax,


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

iaas-api-goやsaclient-goの更新に伴い、クライアント初期化時にhttp.Clientを渡すとnilが返るようになったため渡さないように修正

### ドキュメントの変更は必要ですか？

no