### PR TITLE
deprecate: mark container registry access-level as deprecated

### DIFF
--- a/pkg/commands/iaas/containerregistry/create.go
+++ b/pkg/commands/iaas/containerregistry/create.go
@@ -15,6 +15,8 @@
 package containerregistry
 
 import (
+	"fmt"
+
 	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/iaas-service-go/containerregistry/builder"
 	"github.com/sacloud/usacloud/pkg/cflag"
@@ -46,7 +48,7 @@ type createParameter struct {
 	cflag.TagsParameter   `cli:",squash" mapconv:",squash"`
 	cflag.IconIDParameter `cli:",squash" mapconv:",squash"`
 
-	AccessLevel    string `cli:",options=container_registry_access_level" mapconv:",filters=container_registry_access_level_to_value" validate:"required,container_registry_access_level"`
+	AccessLevel    string `cli:",options=container_registry_access_level" mapconv:",filters=container_registry_access_level_to_value" validate:"omitempty,container_registry_access_level"`
 	SubDomainLabel string `cli:"subdomain-label" validate:"required"`
 	VirtualDomain  string `validate:"omitempty,fqdn"`
 
@@ -63,12 +65,18 @@ func init() {
 }
 
 // Customize パラメータ変換処理
-func (p *createParameter) Customize(_ cli.Context) error {
+func (p *createParameter) Customize(ctx cli.Context) error {
 	var users []*builder.User
 	if p.UsersData != "" {
 		if err := util.MarshalJSONFromPathOrContent(p.UsersData, &users); err != nil {
 			return err
 		}
+	}
+
+	if p.AccessLevel != "" {
+		fmt.Fprintln(ctx.IO().Err(), "[WARN] The --access-level field is deprecated. Future versions will not support public access settings, and this field will be removed.")
+	} else {
+		p.AccessLevel = types.ContainerRegistryAccessLevels.None.String()
 	}
 
 	p.Users = append(p.Users, users...)

--- a/pkg/commands/iaas/containerregistry/create.go
+++ b/pkg/commands/iaas/containerregistry/create.go
@@ -89,6 +89,7 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 		DescParameter:   examples.Description,
 		TagsParameter:   examples.Tags,
 		IconIDParameter: examples.IconID,
+		AccessLevel:     "none",
 		SubDomainLabel:  "your-sub-domain",
 		VirtualDomain:   "your-domain.example.com",
 		Users: []*builder.User{

--- a/pkg/commands/iaas/containerregistry/create.go
+++ b/pkg/commands/iaas/containerregistry/create.go
@@ -74,7 +74,7 @@ func (p *createParameter) Customize(ctx cli.Context) error {
 	}
 
 	if p.AccessLevel != "" {
-		fmt.Fprintln(ctx.IO().Err(), "[WARN] The --access-level field is deprecated. Future versions will not support public access settings, and this field will be removed.")
+		fmt.Fprintln(ctx.IO().Err(), "[WARN] The --access-level flag is deprecated. Future versions will not support public access settings, and this flag will be removed.")
 	} else {
 		p.AccessLevel = types.ContainerRegistryAccessLevels.None.String()
 	}
@@ -89,7 +89,6 @@ func (p *createParameter) ExampleParameters(ctx cli.Context) interface{} {
 		DescParameter:   examples.Description,
 		TagsParameter:   examples.Tags,
 		IconIDParameter: examples.IconID,
-		AccessLevel:     examples.OptionsString("container_registry_access_level"),
 		SubDomainLabel:  "your-sub-domain",
 		VirtualDomain:   "your-domain.example.com",
 		Users: []*builder.User{

--- a/pkg/commands/iaas/containerregistry/update.go
+++ b/pkg/commands/iaas/containerregistry/update.go
@@ -90,6 +90,7 @@ func (p *updateParameter) ExampleParameters(ctx cli.Context) interface{} {
 		DescUpdateParameter:   examples.DescriptionUpdate,
 		TagsUpdateParameter:   examples.TagsUpdate,
 		IconIDUpdateParameter: examples.IconIDUpdate,
+		AccessLevel:           pointer.NewString("none"),
 		SubDomainLabel:        pointer.NewString("your-sub-domain"),
 		VirtualDomain:         pointer.NewString("your-domain.example.com"),
 		Users: &[]*builder.User{

--- a/pkg/commands/iaas/containerregistry/update.go
+++ b/pkg/commands/iaas/containerregistry/update.go
@@ -15,6 +15,8 @@
 package containerregistry
 
 import (
+	"fmt"
+
 	"github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/iaas-service-go/containerregistry/builder"
 	"github.com/sacloud/packages-go/pointer"
@@ -66,13 +68,17 @@ func init() {
 }
 
 // Customize パラメータ変換処理
-func (p *updateParameter) Customize(_ cli.Context) error {
+func (p *updateParameter) Customize(ctx cli.Context) error {
 	var users []*builder.User
 	if p.UsersData != nil && *p.UsersData != "" {
 		if err := util.MarshalJSONFromPathOrContent(*p.UsersData, &users); err != nil {
 			return err
 		}
 		p.Users = &users
+	}
+
+	if p.AccessLevel != nil {
+		fmt.Fprintln(ctx.IO().Err(), "[WARN] The --access-level field is deprecated. Future versions will not support public access settings, and this field will be removed.")
 	}
 
 	return nil

--- a/pkg/commands/iaas/containerregistry/update.go
+++ b/pkg/commands/iaas/containerregistry/update.go
@@ -78,7 +78,7 @@ func (p *updateParameter) Customize(ctx cli.Context) error {
 	}
 
 	if p.AccessLevel != nil {
-		fmt.Fprintln(ctx.IO().Err(), "[WARN] The --access-level field is deprecated. Future versions will not support public access settings, and this field will be removed.")
+		fmt.Fprintln(ctx.IO().Err(), "[WARN] The --access-level flag is deprecated. Future versions will not support public access settings, and this flag will be removed.")
 	}
 
 	return nil
@@ -90,7 +90,6 @@ func (p *updateParameter) ExampleParameters(ctx cli.Context) interface{} {
 		DescUpdateParameter:   examples.DescriptionUpdate,
 		TagsUpdateParameter:   examples.TagsUpdate,
 		IconIDUpdateParameter: examples.IconIDUpdate,
-		AccessLevel:           pointer.NewString(examples.OptionsString("container_registry_access_level")),
 		SubDomainLabel:        pointer.NewString("your-sub-domain"),
 		VirtualDomain:         pointer.NewString("your-domain.example.com"),
 		Users: &[]*builder.User{

--- a/pkg/commands/iaas/containerregistry/zz_create_gen.go
+++ b/pkg/commands/iaas/containerregistry/zz_create_gen.go
@@ -42,7 +42,7 @@ func (p *createParameter) buildFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&p.Description, "description", "", p.Description, "")
 	fs.StringSliceVarP(&p.Tags, "tags", "", p.Tags, "")
 	fs.VarP(core.NewIDFlag(&p.IconID, &p.IconID), "icon-id", "", "")
-	fs.StringVarP(&p.AccessLevel, "access-level", "", p.AccessLevel, "(*required) options: [readonly/none]")
+	fs.StringVarP(&p.AccessLevel, "access-level", "", p.AccessLevel, "options: [readonly/none]")
 	fs.StringVarP(&p.SubDomainLabel, "subdomain-label", "", p.SubDomainLabel, "(*required) ")
 	fs.StringVarP(&p.VirtualDomain, "virtual-domain", "", p.VirtualDomain, "")
 	fs.StringVarP(&p.UsersData, "users", "", p.UsersData, "")


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

`sacloud/usacloud` の `iaas container-registry create` / `update` コマンドにおいて、`--access-level` フラグを非推奨にします。

- `create` コマンドの `--access-level` をオプション化（`required` → `omitempty`）
  - 未指定時はデフォルト値 `"none"` を自動設定
  - 明示的に指定された場合は標準エラーに非推奨警告を出力
- `update` コマンドでも `--access-level` を指定した際に同様の警告を出力
  - 未指定時は既存の値を維持（変更なし）
- ヘルプテキストから `(*required)` 表記を削除（自動生成ファイル）

背景: コンテナレジストリの公開設定（Pullのみ）が廃止予定となり、今後は一律「非公開（none）」での運用となります。

参考: terraform-provider-sakuracloud の対応PR https://github.com/sacloud/terraform-provider-sakuracloud/pull/1390

### ドキュメントの変更は必要ですか？

不要。ヘルプテキスト（`zz_create_gen.go`）はコードから自動生成されています。

<!-- for GitHub Copilot: レビューは日本語で実施してください -->