### PR TITLE
fix: populate saclient after DupWith in NewCLIContext

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -97,6 +97,13 @@ func NewCLIContext(param *ContextParameter) (Context, func(), error) {
 		cancel()
 		return nil, nil, err
 	}
+	// Note: saclient-go v0.4.0+ requires explicit Populate() before using
+	// ProfileOp() and other methods. Ideally this should be handled inside
+	// saclient-go, but for now we call it here to keep the client usable.
+	if err := sa.Populate(); err != nil {
+		cancel()
+		return nil, nil, err
+	}
 
 	cliCtx := &cliContext{
 		parentCtx:    ctx,


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

saclient-go v0.4.0 では `ProfileOp()` を利用する前に `Populate()` を呼び出す必要があるため、`NewCLIContext` 内で `DupWith()` 直後に `Populate()` を追加した。
これにより `config` コマンドが `ProfileOp uninitialized` エラーで終了する問題を修正する。

### ドキュメントの変更は必要ですか？

不要

<!-- for GitHub Copilot: レビューは日本語で実施してください -->