### PR TITLE
fix(profile): reset current to default when deleting current profile

### DIFF
--- a/pkg/commands/config/config_test.go
+++ b/pkg/commands/config/config_test.go
@@ -1,0 +1,419 @@
+// Copyright 2017-2025 The sacloud/usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/saclient-go"
+	"github.com/sacloud/usacloud/pkg/cflag"
+	"github.com/sacloud/usacloud/pkg/cli"
+	"github.com/sacloud/usacloud/pkg/config"
+	"github.com/sacloud/usacloud/pkg/output"
+	"github.com/sacloud/usacloud/pkg/validate"
+	"github.com/stretchr/testify/require"
+)
+
+type testIO struct {
+	in       *os.File
+	out      bytes.Buffer
+	progress bytes.Buffer
+	err      bytes.Buffer
+}
+
+func newTestIO(t *testing.T) *testIO {
+	t.Helper()
+	f, err := os.Open("/dev/null")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	return &testIO{in: f}
+}
+
+func (io *testIO) In() *os.File       { return io.in }
+func (io *testIO) Out() io.Writer     { return &io.out }
+func (io *testIO) Progress() io.Writer { return &io.progress }
+func (io *testIO) Err() io.Writer     { return &io.err }
+
+type testContext struct {
+	option   *config.Config
+	io       cli.IO
+	client   saclient.ClientAPI
+	args     []string
+	resource cli.ResourceContext
+}
+
+func newTestContext(t *testing.T, client saclient.ClientAPI, args ...string) *testContext {
+	t.Helper()
+	return &testContext{
+		option: &config.Config{},
+		io:     newTestIO(t),
+		client: client,
+		args:   args,
+	}
+}
+
+func (c *testContext) Option() *config.Config      { return c.option }
+func (c *testContext) Output() output.Output       { return output.NewDiscardOutput() }
+func (c *testContext) Client() interface{}         { return nil }
+func (c *testContext) IO() cli.IO                  { return c.io }
+func (c *testContext) Args() []string              { return c.args }
+func (c *testContext) Saclient() saclient.ClientAPI { return c.client }
+func (c *testContext) PlatformName() string        { return "test" }
+func (c *testContext) ResourceName() string        { return "config" }
+func (c *testContext) CommandName() string         { return "test" }
+func (c *testContext) WithResource(id, zone string, resource interface{}) cli.Context {
+	return c
+}
+func (c *testContext) ID() string                { return c.resource.ID }
+func (c *testContext) Zone() string              { return c.resource.Zone }
+func (c *testContext) Resource() interface{}     { return c.resource.Resource }
+func (c *testContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *testContext) Done() <-chan struct{}     { return nil }
+func (c *testContext) Err() error                { return nil }
+func (c *testContext) Value(key interface{}) interface{} { return nil }
+
+func TestMain(m *testing.M) {
+	validate.InitializeValidator(iaas.SakuraCloudZones)
+	os.Exit(m.Run())
+}
+
+func setupTestClient(t *testing.T) (string, saclient.ClientAPI) {
+	t.Helper()
+	dir := t.TempDir()
+	var client saclient.Client
+	require.NoError(t, client.SetEnviron([]string{"SAKURACLOUD_PROFILE_DIR=" + dir}))
+	op, err := client.ProfileOp()
+	require.NoError(t, err)
+	require.NoError(t, op.Create(&saclient.Profile{Name: "default"}))
+	require.NoError(t, op.SetCurrentName("default"))
+	return dir, &client
+}
+
+func createTestProfile(t *testing.T, op saclient.ProfileAPI, name, token, secret string) {
+	t.Helper()
+	p := &saclient.Profile{
+		Name: name,
+		Attributes: map[string]any{
+			"AccessToken":       token,
+			"AccessTokenSecret": secret,
+			"Zone":              "is1b",
+		},
+	}
+	require.NoError(t, op.Create(p))
+}
+
+func TestCreateProfile(t *testing.T) {
+	t.Run("new profile", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+
+		ctx := newTestContext(t, client)
+		p := &createParameter{
+			EditParameter: EditParameter{
+				Name:              "foo",
+				AccessToken:       "token-foo",
+				AccessTokenSecret: "secret-foo",
+				Zone:              "is1b",
+			},
+		}
+
+		require.NoError(t, createCommand.ValidateFunc(ctx, p))
+		_, err = createProfile(ctx, p)
+		require.NoError(t, err)
+
+		read, err := op.Read("foo")
+		require.NoError(t, err)
+		require.Equal(t, "token-foo", read.Attributes["AccessToken"])
+		require.Equal(t, "is1b", read.Attributes["Zone"])
+
+		// current should remain default
+		current, err := op.GetCurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "default", current)
+	})
+
+	t.Run("with --use", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+
+		ctx := newTestContext(t, client)
+		p := &createParameter{
+			EditParameter: EditParameter{
+				Name:              "bar",
+				AccessToken:       "token-bar",
+				AccessTokenSecret: "secret-bar",
+				Zone:              "tk1a",
+				Use:               true,
+			},
+		}
+
+		_, err = createProfile(ctx, p)
+		require.NoError(t, err)
+
+		current, err := op.GetCurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "bar", current)
+	})
+
+	t.Run("already exists", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+		createTestProfile(t, op, "dupe", "token", "secret")
+
+		ctx := newTestContext(t, client)
+		p := &createParameter{
+			EditParameter: EditParameter{Name: "dupe"},
+		}
+		err = createCommand.ValidateFunc(ctx, p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestDeleteProfile(t *testing.T) {
+	t.Run("delete non-current", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+		createTestProfile(t, op, "foo", "token", "secret")
+		createTestProfile(t, op, "bar", "token", "secret")
+		require.NoError(t, op.SetCurrentName("foo"))
+
+		ctx := newTestContext(t, client)
+		p := &deleteParameter{
+			ProfileParameter:       ProfileParameter{Name: "bar"},
+			ConfirmParameter:       cflag.ConfirmParameter{AssumeYes: true},
+		}
+
+		require.NoError(t, deleteCommand.ValidateFunc(ctx, p))
+		_, err = deleteFunc(ctx, p)
+		require.NoError(t, err)
+
+		_, err = op.Read("bar")
+		require.Error(t, err)
+
+		current, err := op.GetCurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "foo", current)
+	})
+
+	t.Run("delete current resets to default", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+		createTestProfile(t, op, "foo", "token", "secret")
+		require.NoError(t, op.SetCurrentName("foo"))
+
+		ctx := newTestContext(t, client)
+		p := &deleteParameter{
+			ProfileParameter:       ProfileParameter{Name: "foo"},
+			ConfirmParameter:       cflag.ConfirmParameter{AssumeYes: true},
+		}
+
+		_, err = deleteFunc(ctx, p)
+		require.NoError(t, err)
+
+		_, err = op.Read("foo")
+		require.Error(t, err)
+
+		current, err := op.GetCurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "default", current)
+	})
+
+	t.Run("delete non-existent", func(t *testing.T) {
+		_, client := setupTestClient(t)
+
+		ctx := newTestContext(t, client)
+		p := &deleteParameter{
+			ProfileParameter:       ProfileParameter{Name: "missing"},
+			ConfirmParameter:       cflag.ConfirmParameter{AssumeYes: true},
+		}
+		err := deleteCommand.ValidateFunc(ctx, p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not exists")
+	})
+}
+
+func TestUseProfile(t *testing.T) {
+	_, client := setupTestClient(t)
+	op, err := client.ProfileOp()
+	require.NoError(t, err)
+
+	createTestProfile(t, op, "foo", "token", "secret")
+	createTestProfile(t, op, "bar", "token", "secret")
+	require.NoError(t, op.SetCurrentName("foo"))
+
+	ctx := newTestContext(t, client)
+	p := &useParameter{ProfileParameter: ProfileParameter{Name: "bar"}}
+	require.NoError(t, useCommand.ValidateFunc(ctx, p))
+	_, err = useFunc(ctx, p)
+	require.NoError(t, err)
+
+	current, err := op.GetCurrentName()
+	require.NoError(t, err)
+	require.Equal(t, "bar", current)
+}
+
+func TestListProfiles(t *testing.T) {
+	_, client := setupTestClient(t)
+	op, err := client.ProfileOp()
+	require.NoError(t, err)
+
+	createTestProfile(t, op, "foo", "token", "secret")
+	createTestProfile(t, op, "bar", "token", "secret")
+	require.NoError(t, op.SetCurrentName("bar"))
+
+	ctx := newTestContext(t, client)
+	_, err = listFunc(ctx, nil)
+	require.NoError(t, err)
+
+	out := ctx.io.(*testIO).out.String()
+	require.Contains(t, out, "bar")
+	require.Contains(t, out, "foo")
+}
+
+func TestShowProfile(t *testing.T) {
+	_, client := setupTestClient(t)
+	op, err := client.ProfileOp()
+	require.NoError(t, err)
+
+	createTestProfile(t, op, "foo", "token", "secret")
+
+	ctx := newTestContext(t, client)
+	p := &showParameter{ProfileParameter: ProfileParameter{Name: "foo"}}
+	require.NoError(t, showCommand.ValidateFunc(ctx, p))
+	_, err = showFunc(ctx, p)
+	require.NoError(t, err)
+
+	out := ctx.io.(*testIO).out.String()
+	require.Contains(t, out, "token")
+}
+
+func TestPathProfile(t *testing.T) {
+	dir, client := setupTestClient(t)
+	op, err := client.ProfileOp()
+	require.NoError(t, err)
+
+	createTestProfile(t, op, "foo", "token", "secret")
+
+	ctx := newTestContext(t, client)
+	p := &pathParameter{ProfileParameter: ProfileParameter{Name: "foo"}}
+	require.NoError(t, pathCommand.ValidateFunc(ctx, p))
+	_, err = pathFunc(ctx, p)
+	require.NoError(t, err)
+
+	out := ctx.io.(*testIO).out.String()
+	require.Contains(t, out, dir)
+	require.Contains(t, out, "foo")
+	require.Contains(t, out, "config.json")
+}
+
+func TestCurrentProfile(t *testing.T) {
+	_, client := setupTestClient(t)
+	op, err := client.ProfileOp()
+	require.NoError(t, err)
+
+	createTestProfile(t, op, "foo", "token", "secret")
+	require.NoError(t, op.SetCurrentName("foo"))
+
+	ctx := newTestContext(t, client)
+	_, err = currentFunc(ctx, nil)
+	require.NoError(t, err)
+
+	out := ctx.io.(*testIO).out.String()
+	require.Equal(t, "foo\n", out)
+}
+
+func TestEditProfile(t *testing.T) {
+	t.Run("edit existing profile", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+		createTestProfile(t, op, "foo", "old-token", "old-secret")
+
+		ctx := newTestContext(t, client)
+		p := &EditParameter{
+			Name:              "foo",
+			AccessToken:       "new-token",
+			AccessTokenSecret: "new-secret",
+			Zone:              "tk1a",
+		}
+		_, err = editProfile(ctx, p)
+		require.NoError(t, err)
+
+		read, err := op.Read("foo")
+		require.NoError(t, err)
+		require.Equal(t, "new-token", read.Attributes["AccessToken"])
+		require.Equal(t, "tk1a", read.Attributes["Zone"])
+	})
+
+	t.Run("create new profile", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+
+		ctx := newTestContext(t, client)
+		p := &EditParameter{
+			Name:              "new-profile",
+			AccessToken:       "token",
+			AccessTokenSecret: "secret",
+			Zone:              "is1b",
+		}
+		_, err = editProfile(ctx, p)
+		require.NoError(t, err)
+
+		read, err := op.Read("new-profile")
+		require.NoError(t, err)
+		require.Equal(t, "token", read.Attributes["AccessToken"])
+		require.Equal(t, "is1b", read.Attributes["Zone"])
+
+		current, err := op.GetCurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "default", current)
+	})
+
+	t.Run("with --use", func(t *testing.T) {
+		_, client := setupTestClient(t)
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+		createTestProfile(t, op, "bar", "token", "secret")
+		createTestProfile(t, op, "baz", "token", "secret")
+		require.NoError(t, op.SetCurrentName("bar"))
+
+		ctx := newTestContext(t, client)
+		p := &EditParameter{
+			Name:              "baz",
+			AccessToken:       "token",
+			AccessTokenSecret: "secret",
+			Zone:              "is1b",
+			Use:               true,
+		}
+		_, err = editProfile(ctx, p)
+		require.NoError(t, err)
+
+		current, err := op.GetCurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "baz", current)
+	})
+}

--- a/pkg/commands/config/delete.go
+++ b/pkg/commands/config/delete.go
@@ -56,5 +56,18 @@ func deleteFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {
 		return nil, err
 	}
 
-	return nil, op.Delete(p.Name)
+	current, err := op.GetCurrentName()
+	if err != nil {
+		return nil, err
+	}
+	if err := op.Delete(p.Name); err != nil {
+		return nil, err
+	}
+	if current == p.Name {
+		if err := op.SetCurrentName("default"); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,12 +15,16 @@
 package config
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/sacloud/api-client-go/profile"
 	"github.com/sacloud/iaas-api-go"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFillDefaults_ZonesEmpty(t *testing.T) {
@@ -385,5 +389,172 @@ func clearTestEnv() {
 func setEnv(m map[string]string) {
 	for k, v := range m {
 		_ = os.Setenv(k, v)
+	}
+}
+
+func defaultZonesWithAll() []string {
+	zones := append([]string{}, iaas.SakuraCloudZones...)
+	return append(zones, "all")
+}
+
+func TestLoadConfigValue(t *testing.T) {
+	defaultZones := defaultZonesWithAll()
+
+	tests := []struct {
+		name     string
+		env      map[string]string
+		args     []string
+		setup    func(t *testing.T, dir string)
+		want     Config
+		wantWarn string
+	}{
+		{
+			name: "no profiles",
+			env:  map[string]string{},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					Zones: defaultZones,
+				},
+				Profile: "default",
+			},
+		},
+		{
+			name: "default profile exists",
+			env:  map[string]string{},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("default", &profile.ConfigValue{
+					AccessToken: "default-token",
+				}))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					AccessToken: "default-token",
+					Zones:       defaultZones,
+				},
+				Profile: "default",
+			},
+		},
+		{
+			name: "--profile flag",
+			env:  map[string]string{},
+			args: []string{"--profile", "foo"},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("foo", &profile.ConfigValue{
+					AccessToken: "foo-token",
+				}))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					AccessToken: "foo-token",
+					Zones:       defaultZones,
+				},
+				Profile: "foo",
+			},
+		},
+		{
+			name: "SAKURA_PROFILE env",
+			env:  map[string]string{"SAKURA_PROFILE": "foo"},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("foo", &profile.ConfigValue{
+					AccessToken: "foo-token",
+				}))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					AccessToken: "foo-token",
+					Zones:       defaultZones,
+				},
+				Profile: "foo",
+			},
+		},
+		{
+			name: "current points to existing profile",
+			env:  map[string]string{},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("foo", &profile.ConfigValue{
+					AccessToken: "foo-token",
+				}))
+				require.NoError(t, profile.SetCurrentName("foo"))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					AccessToken: "foo-token",
+					Zones:       defaultZones,
+				},
+				Profile: "foo",
+			},
+		},
+		{
+			name: "current points to deleted profile",
+			env:  map[string]string{},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("foo", &profile.ConfigValue{
+					AccessToken: "foo-token",
+				}))
+				require.NoError(t, profile.SetCurrentName("foo"))
+				// emulate deletion: remove foo profile files but leave current file
+				path, err := profile.ConfigFilePath("foo")
+				require.NoError(t, err)
+				require.NoError(t, os.Remove(path))
+				require.NoError(t, os.Remove(filepath.Dir(path)))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					Zones: defaultZones,
+				},
+				Profile: "foo",
+			},
+			wantWarn: `[WARN] loading profile "foo" is failed:`,
+		},
+		{
+			name: "flag wins over env",
+			env:  map[string]string{"SAKURA_PROFILE": "bar"},
+			args: []string{"--profile", "foo"},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("foo", &profile.ConfigValue{
+					AccessToken: "foo-token",
+				}))
+				require.NoError(t, profile.Save("bar", &profile.ConfigValue{
+					AccessToken: "bar-token",
+				}))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					AccessToken: "foo-token",
+					Zones:       defaultZones,
+				},
+				Profile: "foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearTestEnv()
+			setEnv(tt.env)
+
+			profileDir := t.TempDir()
+			t.Setenv("SAKURACLOUD_PROFILE_DIR", profileDir)
+
+			if tt.setup != nil {
+				tt.setup(t, profileDir)
+			}
+
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			InitConfig(flags)
+			if len(tt.args) > 0 {
+				require.NoError(t, flags.Parse(tt.args))
+			}
+
+			var errW bytes.Buffer
+			cfg, err := LoadConfigValue(flags, &errW, false)
+			require.NoError(t, err)
+
+			assertConfigEqual(t, *cfg, tt.want)
+			require.Equal(t, tt.want.Profile, cfg.Profile)
+			if tt.wantWarn != "" {
+				require.Contains(t, errW.String(), tt.wantWarn)
+			}
+		})
 	}
 }

--- a/pkg/config/profile.go
+++ b/pkg/config/profile.go
@@ -45,4 +45,5 @@ func (o *Config) loadFromProfile(flags *pflag.FlagSet, errW io.Writer) {
 		fmt.Fprintf(errW, "[WARN] loading profile %q is failed: %s", profileName, err)
 		return
 	}
+	o.Profile = profileName
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

- `config delete` 実行時に、削除対象が現在の `current` プロファイルだった場合、
  削除後に `current` を `default` に戻すようにした。
  - saclient-go 導入前は `api-client-go/profile.Remove()` がこの処理を行っていた -> https://github.com/sacloud/api-client-go/blob/644bdc4284a82b309dec83b0952a5b74b605a718/profile/profile.go#L337-L346
- `LoadConfigValue` と `config` サブコマンドの単体テストを追加した。

### ドキュメントの変更は必要ですか？

不要
