### PR TITLE
chore: update saclient-go to v0.4.0

### DIFF
--- a/e2e/config/e2e_test.go
+++ b/e2e/config/e2e_test.go
@@ -36,7 +36,8 @@ func TestE2E_CreateConfigWithoutTTY(t *testing.T) {
 	err := usacloudE2E.UsacloudRun(t, "config", "create", profileName, "--token", "aaa", "--secret", "bbb", "--default-output-type", "table", "--zone", "is1b", "--use")
 	require.NoError(t, err)
 
-	profileOp := saclient.NewProfileOp(os.Environ())
+	profileOp, err := saclient.NewProfileOp(os.Environ())
+	require.NoError(t, err)
 	profile, err := profileOp.Read(profileName)
 	if err != nil {
 		t.Fatal(err)
@@ -55,8 +56,10 @@ func TestE2E_ConfigWithoutSubcommand(t *testing.T) {
 	err := usacloudE2E.UsacloudRun(t, "config")
 	require.NoError(t, err)
 
-	profileOp := saclient.NewProfileOp(os.Environ())
+	profileOp, err := saclient.NewProfileOp(os.Environ())
+	require.NoError(t, err)
 	_, err = profileOp.List()
+	require.NoError(t, err)
 	profile, err := profileOp.Read("default")
 	require.NoError(t, err)
 	require.NotNil(t, profile)

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sacloud/iaas-service-go v1.25.0
 	github.com/sacloud/packages-go v0.1.0
 	github.com/sacloud/packages-go/e2e v0.0.0-20260423012125-3b04540c85d0
-	github.com/sacloud/saclient-go v0.3.7
+	github.com/sacloud/saclient-go v0.4.0
 	github.com/sacloud/webaccel-api-go v1.5.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/sacloud/packages-go v0.1.0 h1:rixWcvkVUI4kX6UYTFJbQgZIoBoNhN48MivHIu3
 github.com/sacloud/packages-go v0.1.0/go.mod h1:ntmPnjF8+mGWNtxgBmO0CrLphUlmRkpy+DztjlECp8M=
 github.com/sacloud/packages-go/e2e v0.0.0-20260423012125-3b04540c85d0 h1:Rvih7Rvk+YzOOA40AKer/qGSdIRG/9rdmbe15jm7dbo=
 github.com/sacloud/packages-go/e2e v0.0.0-20260423012125-3b04540c85d0/go.mod h1:j1e31tY4XNhx8e5LA0RRPaEUQf0Ai7Sa9BS2haVVXzQ=
-github.com/sacloud/saclient-go v0.3.7 h1:LAkOHStYxIKoypiaarhNOwm/JPuubgoKuOSXZWEerbc=
-github.com/sacloud/saclient-go v0.3.7/go.mod h1:h8ATHi9AnQhOxYNm8mbVWyM9/2569PPESIGwAc2SNg4=
+github.com/sacloud/saclient-go v0.4.0 h1:d4CqjKDU0muPVukZ2qGB9Me6ANEcMg73z5tIqXIyGWA=
+github.com/sacloud/saclient-go v0.4.0/go.mod h1:5CqxypkPgUW6qZxBGRdKX3I+mVx/OWbbFrrRm6LBNeE=
 github.com/sacloud/webaccel-api-go v1.5.0 h1:tWNlUwPphMTUGnM6tpH+Z2fEsh9IpEnv+pDMrdOrkwM=
 github.com/sacloud/webaccel-api-go v1.5.0/go.mod h1:osKWoZQV32D+c7DGPv+/o7PYgRut0Ob0LTDN019Oazs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -97,6 +97,10 @@ func NewCLIContext(param *ContextParameter) (Context, func(), error) {
 		cancel()
 		return nil, nil, err
 	}
+	if err := sa.Populate(); err != nil {
+		cancel()
+		return nil, nil, err
+	}
 
 	cliCtx := &cliContext{
 		parentCtx:    ctx,

--- a/pkg/commands/config/config_test.go
+++ b/pkg/commands/config/config_test.go
@@ -46,10 +46,10 @@ func newTestIO(t *testing.T) *testIO {
 	return &testIO{in: f}
 }
 
-func (io *testIO) In() *os.File       { return io.in }
-func (io *testIO) Out() io.Writer     { return &io.out }
+func (io *testIO) In() *os.File        { return io.in }
+func (io *testIO) Out() io.Writer      { return &io.out }
 func (io *testIO) Progress() io.Writer { return &io.progress }
-func (io *testIO) Err() io.Writer     { return &io.err }
+func (io *testIO) Err() io.Writer      { return &io.err }
 
 type testContext struct {
 	option   *config.Config
@@ -69,24 +69,24 @@ func newTestContext(t *testing.T, client saclient.ClientAPI, args ...string) *te
 	}
 }
 
-func (c *testContext) Option() *config.Config      { return c.option }
-func (c *testContext) Output() output.Output       { return output.NewDiscardOutput() }
-func (c *testContext) Client() interface{}         { return nil }
-func (c *testContext) IO() cli.IO                  { return c.io }
-func (c *testContext) Args() []string              { return c.args }
+func (c *testContext) Option() *config.Config       { return c.option }
+func (c *testContext) Output() output.Output        { return output.NewDiscardOutput() }
+func (c *testContext) Client() interface{}          { return nil }
+func (c *testContext) IO() cli.IO                   { return c.io }
+func (c *testContext) Args() []string               { return c.args }
 func (c *testContext) Saclient() saclient.ClientAPI { return c.client }
-func (c *testContext) PlatformName() string        { return "test" }
-func (c *testContext) ResourceName() string        { return "config" }
-func (c *testContext) CommandName() string         { return "test" }
+func (c *testContext) PlatformName() string         { return "test" }
+func (c *testContext) ResourceName() string         { return "config" }
+func (c *testContext) CommandName() string          { return "test" }
 func (c *testContext) WithResource(id, zone string, resource interface{}) cli.Context {
 	return c
 }
-func (c *testContext) ID() string                { return c.resource.ID }
-func (c *testContext) Zone() string              { return c.resource.Zone }
-func (c *testContext) Resource() interface{}     { return c.resource.Resource }
-func (c *testContext) Deadline() (time.Time, bool) { return time.Time{}, false }
-func (c *testContext) Done() <-chan struct{}     { return nil }
-func (c *testContext) Err() error                { return nil }
+func (c *testContext) ID() string                        { return c.resource.ID }
+func (c *testContext) Zone() string                      { return c.resource.Zone }
+func (c *testContext) Resource() interface{}             { return c.resource.Resource }
+func (c *testContext) Deadline() (time.Time, bool)       { return time.Time{}, false }
+func (c *testContext) Done() <-chan struct{}             { return nil }
+func (c *testContext) Err() error                        { return nil }
 func (c *testContext) Value(key interface{}) interface{} { return nil }
 
 func TestMain(m *testing.M) {
@@ -99,6 +99,7 @@ func setupTestClient(t *testing.T) (string, saclient.ClientAPI) {
 	dir := t.TempDir()
 	var client saclient.Client
 	require.NoError(t, client.SetEnviron([]string{"SAKURACLOUD_PROFILE_DIR=" + dir}))
+	require.NoError(t, client.Populate())
 	op, err := client.ProfileOp()
 	require.NoError(t, err)
 	require.NoError(t, op.Create(&saclient.Profile{Name: "default"}))
@@ -201,8 +202,8 @@ func TestDeleteProfile(t *testing.T) {
 
 		ctx := newTestContext(t, client)
 		p := &deleteParameter{
-			ProfileParameter:       ProfileParameter{Name: "bar"},
-			ConfirmParameter:       cflag.ConfirmParameter{AssumeYes: true},
+			ProfileParameter: ProfileParameter{Name: "bar"},
+			ConfirmParameter: cflag.ConfirmParameter{AssumeYes: true},
 		}
 
 		require.NoError(t, deleteCommand.ValidateFunc(ctx, p))
@@ -226,8 +227,8 @@ func TestDeleteProfile(t *testing.T) {
 
 		ctx := newTestContext(t, client)
 		p := &deleteParameter{
-			ProfileParameter:       ProfileParameter{Name: "foo"},
-			ConfirmParameter:       cflag.ConfirmParameter{AssumeYes: true},
+			ProfileParameter: ProfileParameter{Name: "foo"},
+			ConfirmParameter: cflag.ConfirmParameter{AssumeYes: true},
 		}
 
 		_, err = deleteFunc(ctx, p)
@@ -246,8 +247,8 @@ func TestDeleteProfile(t *testing.T) {
 
 		ctx := newTestContext(t, client)
 		p := &deleteParameter{
-			ProfileParameter:       ProfileParameter{Name: "missing"},
-			ConfirmParameter:       cflag.ConfirmParameter{AssumeYes: true},
+			ProfileParameter: ProfileParameter{Name: "missing"},
+			ConfirmParameter: cflag.ConfirmParameter{AssumeYes: true},
 		}
 		err := deleteCommand.ValidateFunc(ctx, p)
 		require.Error(t, err)

--- a/pkg/commands/config/functons.go
+++ b/pkg/commands/config/functons.go
@@ -23,7 +23,10 @@ import (
 )
 
 func profileCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	op := saclient.NewProfileOp(os.Environ()) // no context, create a new op
+	op, err := saclient.NewProfileOp(os.Environ()) // no context, create a new op
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
 
 	names, err := op.List()
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

- `saclient-go` を v0.4.0 に更新した。
- v0.4.0 で `NewProfileOp` が error を返すようになったため、呼び出し側を対応した。
- v0.4.0 で `SetEnviron` 時に `profileOp` が初期化されなくなったため、
  `NewCLIContext` 内で `sa.Populate()` を呼ぶようにした。

### ドキュメントの変更は必要ですか？

不要
