### PR TITLE
fix(config): skip profile loading and tolerate client populate errors

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/sacloud/saclient-go"
@@ -98,8 +99,11 @@ func NewCLIContext(param *ContextParameter) (Context, func(), error) {
 		return nil, nil, err
 	}
 	if err := sa.Populate(); err != nil {
-		cancel()
-		return nil, nil, err
+		if !param.SkipLoadingProfile {
+			cancel()
+			return nil, nil, err
+		}
+		fmt.Fprintf(io.Err(), "[WARN] API client population failed; ignored for config commands: %s\n", err)
 	}
 
 	cliCtx := &cliContext{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -103,7 +103,7 @@ func NewCLIContext(param *ContextParameter) (Context, func(), error) {
 			cancel()
 			return nil, nil, err
 		}
-		fmt.Fprintf(io.Err(), "[WARN] API client population failed; ignored for config commands: %s\n", err)
+		fmt.Fprintf(io.Err(), "[WARN] API client population failed; ignored for %s/%s because profile loading is skipped: %s\n", param.ResourceName, param.CommandName, err)
 	}
 
 	cliCtx := &cliContext{

--- a/pkg/cli/context_test.go
+++ b/pkg/cli/context_test.go
@@ -15,10 +15,14 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/sacloud/saclient-go"
 	"github.com/sacloud/usacloud/pkg/config"
 	"github.com/sacloud/usacloud/pkg/output"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 )
 
@@ -201,4 +205,41 @@ func Test_getOutputWriter(t *testing.T) {
 			require.EqualValues(t, tt.want, got, tt.name)
 		})
 	}
+}
+
+func TestNewCLIContext_SkipLoadingProfile_WithBrokenCurrent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SAKURACLOUD_PROFILE_DIR", dir)
+
+	op, err := saclient.NewProfileOp([]string{"SAKURACLOUD_PROFILE_DIR=" + dir})
+	require.NoError(t, err)
+	require.NoError(t, op.Create(&saclient.Profile{
+		Name:       "foo",
+		Attributes: map[string]any{"AccessToken": "token"},
+	}))
+	require.NoError(t, op.SetCurrentName("foo"))
+
+	// currentを存在しないプロファイル名で上書き
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "current"), []byte("broken"), 0o600))
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.InitConfig(flags)
+	require.NoError(t, flags.Parse([]string{"--no-color"}))
+
+	ctx, cancel, err := NewCLIContext(&ContextParameter{
+		ResourceName:       "config",
+		CommandName:        "current",
+		GlobalFlags:        flags,
+		SkipLoadingProfile: true,
+	})
+	require.NoError(t, err)
+	defer cancel()
+
+	require.True(t, ctx.Option().NoColor)
+
+	profileOp, err := ctx.Saclient().ProfileOp()
+	require.NoError(t, err)
+	current, err := profileOp.GetCurrentName()
+	require.NoError(t, err)
+	require.Equal(t, "broken", current)
 }

--- a/pkg/commands/config/config_test.go
+++ b/pkg/commands/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -105,6 +106,18 @@ func setupTestClient(t *testing.T) (string, saclient.ClientAPI) {
 	require.NoError(t, op.Create(&saclient.Profile{Name: "default"}))
 	require.NoError(t, op.SetCurrentName("default"))
 	return dir, &client
+}
+
+func setupTestClientWithBrokenCurrent(t *testing.T) (string, saclient.ClientAPI) {
+	dir, client := setupTestClient(t)
+	op, err := client.ProfileOp()
+	require.NoError(t, err)
+	createTestProfile(t, op, "foo", "token", "secret")
+
+	// currentを存在しないプロファイル名で上書き
+	currentPath := filepath.Join(dir, "current")
+	require.NoError(t, os.WriteFile(currentPath, []byte("broken"), 0o600))
+	return dir, client
 }
 
 func createTestProfile(t *testing.T, op saclient.ProfileAPI, name, token, secret string) {
@@ -416,5 +429,43 @@ func TestEditProfile(t *testing.T) {
 		current, err := op.GetCurrentName()
 		require.NoError(t, err)
 		require.Equal(t, "baz", current)
+	})
+}
+
+func TestConfigCommandsWithBrokenCurrent(t *testing.T) {
+	t.Run("current shows raw current value", func(t *testing.T) {
+		_, client := setupTestClientWithBrokenCurrent(t)
+		ctx := newTestContext(t, client)
+		_, err := currentFunc(ctx, nil)
+		require.NoError(t, err)
+
+		out := ctx.io.(*testIO).out.String()
+		require.Equal(t, "broken\n", out)
+	})
+
+	t.Run("list shows existing profiles", func(t *testing.T) {
+		_, client := setupTestClientWithBrokenCurrent(t)
+		ctx := newTestContext(t, client)
+		_, err := listFunc(ctx, nil)
+		require.NoError(t, err)
+
+		out := ctx.io.(*testIO).out.String()
+		require.Contains(t, out, "default")
+		require.Contains(t, out, "foo")
+	})
+
+	t.Run("use fixes current profile", func(t *testing.T) {
+		_, client := setupTestClientWithBrokenCurrent(t)
+		ctx := newTestContext(t, client)
+		p := &useParameter{ProfileParameter: ProfileParameter{Name: "foo"}}
+		require.NoError(t, useCommand.ValidateFunc(ctx, p))
+		_, err := useFunc(ctx, p)
+		require.NoError(t, err)
+
+		op, err := client.ProfileOp()
+		require.NoError(t, err)
+		current, err := op.GetCurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "foo", current)
 	})
 }

--- a/pkg/commands/config/parameter.go
+++ b/pkg/commands/config/parameter.go
@@ -46,17 +46,16 @@ func validateProfileParameter(ctx cli.Context, parameter interface{}) error {
 	if len(ctx.Args()) > 0 && p.GetName() == "" {
 		p.SetName(ctx.Args()[0])
 	}
-	client := ctx.Saclient()
-	op, err := client.ProfileOp()
+	op, err := ctx.Saclient().ProfileOp()
 	if err != nil {
 		return err
 	}
 	if p.GetName() == "" {
-		current, err := client.Profile()
+		current, err := op.GetCurrentName()
 		if err != nil {
 			return err
 		}
-		p.SetName(current.Name)
+		p.SetName(current)
 	}
 	if err := validate.Exec(p); err != nil {
 		return err

--- a/pkg/commands/config/resource.go
+++ b/pkg/commands/config/resource.go
@@ -26,5 +26,5 @@ var Resource = &core.Resource{
 	DefaultCommandName: "edit",
 	Category:           category.ResourceCategoryConfig,
 	IsGlobalResource:   true,
-	SkipLoadingProfile: false,
+	SkipLoadingProfile: true,
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,11 +86,7 @@ func LoadConfigValue(flags *pflag.FlagSet, errW io.Writer, skipLoadingProfile bo
 	o := &Config{
 		ConfigValue: profile.ConfigValue{},
 	}
-	if skipLoadingProfile {
-		return o, nil
-	}
-
-	o.loadConfig(flags, errW)
+	o.loadConfig(flags, errW, skipLoadingProfile)
 	return o, o.Validate(false)
 }
 
@@ -100,16 +96,28 @@ func (o *Config) IsEmpty() bool {
 		o.Zone == "" && o.DefaultOutputType == ""
 }
 
-func (o *Config) loadConfig(flags *pflag.FlagSet, errW io.Writer) {
-	// プロファイルだけ先に環境変数を読んでおく
-	if o.Profile == "" {
-		o.Profile = envvar.StringFromEnvMulti([]string{"SAKURA_PROFILE", "SAKURACLOUD_PROFILE", "USACLOUD_PROFILE"}, "")
+func (o *Config) loadConfig(flags *pflag.FlagSet, errW io.Writer, skipProfile bool) {
+	o.loadProfileName(flags, errW)
+	if !skipProfile {
+		o.loadFromProfile(flags, errW)
 	}
-
-	o.loadFromProfile(flags, errW)
 	o.loadFromEnv()
 	o.loadFromFlags(flags, errW)
 	o.fillDefaults()
+}
+
+func (o *Config) loadProfileName(flags *pflag.FlagSet, errW io.Writer) {
+	if flags.Changed("profile") {
+		v, err := flags.GetString("profile")
+		if err != nil {
+			fmt.Fprintf(errW, "[WARN] reading value of %q flag is failed: %s", "profile", err)
+			return
+		}
+		o.Profile = v
+	}
+	if o.Profile == "" {
+		o.Profile = envvar.StringFromEnvMulti([]string{"SAKURA_PROFILE", "SAKURACLOUD_PROFILE", "USACLOUD_PROFILE"}, "")
+	}
 }
 
 func (o *Config) fillDefaults() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -558,3 +558,87 @@ func TestLoadConfigValue(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfigValue_SkipLoadingProfile(t *testing.T) {
+	defaultZones := defaultZonesWithAll()
+
+	tests := []struct {
+		name     string
+		env      map[string]string
+		args     []string
+		setup    func(t *testing.T, dir string)
+		want     Config
+		wantWarn string
+	}{
+		{
+			name: "skips profile file but still loads env and flags",
+			env:  map[string]string{"SAKURA_PROCESS_TIMEOUT_SEC": "123"},
+			args: []string{"--no-color", "--profile", "foo"},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("foo", &profile.ConfigValue{
+					AccessToken: "foo-token",
+				}))
+				require.NoError(t, profile.SetCurrentName("default"))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					Zones: defaultZones,
+				},
+				ProcessTimeoutSec: 123,
+				Profile:           "foo",
+				NoColor:           true,
+			},
+		},
+		{
+			name: "broken current file does not cause error",
+			args: []string{"--profile", "foo"},
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, profile.Save("foo", &profile.ConfigValue{
+					AccessToken: "foo-token",
+				}))
+				require.NoError(t, profile.SetCurrentName("foo"))
+				// emulate broken current: remove foo profile but leave current file
+				path, err := profile.ConfigFilePath("foo")
+				require.NoError(t, err)
+				require.NoError(t, os.Remove(path))
+				require.NoError(t, os.Remove(filepath.Dir(path)))
+			},
+			want: Config{
+				ConfigValue: profile.ConfigValue{
+					Zones: defaultZones,
+				},
+				Profile: "foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearTestEnv()
+			setEnv(tt.env)
+
+			profileDir := t.TempDir()
+			t.Setenv("SAKURACLOUD_PROFILE_DIR", profileDir)
+
+			if tt.setup != nil {
+				tt.setup(t, profileDir)
+			}
+
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			InitConfig(flags)
+			if len(tt.args) > 0 {
+				require.NoError(t, flags.Parse(tt.args))
+			}
+
+			var errW bytes.Buffer
+			cfg, err := LoadConfigValue(flags, &errW, true)
+			require.NoError(t, err)
+
+			assertConfigEqual(t, *cfg, tt.want)
+			require.Equal(t, tt.want.Profile, cfg.Profile)
+			if tt.wantWarn != "" {
+				require.Contains(t, errW.String(), tt.wantWarn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

`~/.usacloud/current` が壊れている、または存在しないプロファイルを指している場合でも、`usacloud config` サブコマンドが動作するようにします。

変更内容:

- `config` リソースの `SkipLoadingProfile` を `true` に戻す
- `LoadConfigValue` でプロファイルファイルの読み込みのみスキップし、環境変数・グローバルフラグ・デフォルト値の読み込みは維持する
- `SkipLoadingProfile=true` 時は `saclient.Client.Populate()` の失敗を警告に留めて継続する
- プロファイル名の検証で `Client.Profile()` の代わりに `ProfileOp.GetCurrentName()` を使用する

これにより、手動で `~/.usacloud/current` を修正せずに `usacloud config use` などで復旧できるようになります。

### ドキュメントの変更は必要ですか？

不要

<!-- for GitHub Copilot: レビューは日本語で実施してください -->