### PR TITLE
test: make config command tests portable on Windows

### DIFF
--- a/pkg/commands/config/config_test.go
+++ b/pkg/commands/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,7 +42,7 @@ type testIO struct {
 
 func newTestIO(t *testing.T) *testIO {
 	t.Helper()
-	f, err := os.Open("/dev/null")
+	f, err := os.Open(os.DevNull)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = f.Close() })
 	return &testIO{in: f}
@@ -356,7 +357,7 @@ func TestCurrentProfile(t *testing.T) {
 	require.NoError(t, err)
 
 	out := ctx.io.(*testIO).out.String()
-	require.Equal(t, "foo\n", out)
+	require.Equal(t, "foo", strings.TrimSpace(out))
 }
 
 func TestEditProfile(t *testing.T) {
@@ -440,7 +441,7 @@ func TestConfigCommandsWithBrokenCurrent(t *testing.T) {
 		require.NoError(t, err)
 
 		out := ctx.io.(*testIO).out.String()
-		require.Equal(t, "broken\n", out)
+		require.Equal(t, "broken", strings.TrimSpace(out))
 	})
 
 	t.Run("list shows existing profiles", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

Windows 環境での CI 失敗を修正するため、`pkg/commands/config/config_test.go` を OS 非依存に変更した。

- `/dev/null` の代わりに `os.DevNull` を使用
- `fmt.Fprintln` による改行コードの違い（Windows は CRLF）に対応するため、テストのアサーションで `strings.TrimSpace` を使用

### ドキュメントの変更は必要ですか？

不要

### テスト結果

```
> go version
go version go1.26.3 windows/amd64

>  go test -v ./...
?       github.com/sacloud/usacloud     [no test files]
?       github.com/sacloud/usacloud/e2e [no test files]
?       github.com/sacloud/usacloud/pkg [no test files]
?       github.com/sacloud/usacloud/pkg/category        [no test files]
?       github.com/sacloud/usacloud/pkg/ccol    [no test files]
?       github.com/sacloud/usacloud/pkg/cflag   [no test files]
=== RUN   Test_getOutputWriter
=== RUN   Test_getOutputWriter/nil_options
=== RUN   Test_getOutputWriter/no_output_options
=== RUN   Test_getOutputWriter/empty_options
=== RUN   Test_getOutputWriter/with_--quiet_option
=== RUN   Test_getOutputWriter/with_format_option
=== RUN   Test_getOutputWriter/with_query_option
=== RUN   Test_getOutputWriter/with_json_output-type
=== RUN   Test_getOutputWriter/with_yaml_output-type
=== RUN   Test_getOutputWriter/with_table_output-type
=== RUN   Test_getOutputWriter/with_DefaultOutputType_and_empty_output-type
=== RUN   Test_getOutputWriter/with_both_of_DefaultOutputType_and_output-type
--- PASS: Test_getOutputWriter (0.00s)
    --- PASS: Test_getOutputWriter/nil_options (0.00s)
    --- PASS: Test_getOutputWriter/no_output_options (0.00s)
    --- PASS: Test_getOutputWriter/empty_options (0.00s)
    --- PASS: Test_getOutputWriter/with_--quiet_option (0.00s)
    --- PASS: Test_getOutputWriter/with_format_option (0.00s)
    --- PASS: Test_getOutputWriter/with_query_option (0.00s)
    --- PASS: Test_getOutputWriter/with_json_output-type (0.00s)
    --- PASS: Test_getOutputWriter/with_yaml_output-type (0.00s)
    --- PASS: Test_getOutputWriter/with_table_output-type (0.00s)
    --- PASS: Test_getOutputWriter/with_DefaultOutputType_and_empty_output-type (0.00s)
    --- PASS: Test_getOutputWriter/with_both_of_DefaultOutputType_and_output-type (0.00s)
=== RUN   TestNewCLIContext_SkipLoadingProfile_WithBrokenCurrent
[WARN] API client population failed; ignored for config/current because profile loading is skipped: API Error - failed to open broken\config.json: openat broken\config.json: The system cannot find the path specified.
--- PASS: TestNewCLIContext_SkipLoadingProfile_WithBrokenCurrent (0.02s)
PASS
ok      github.com/sacloud/usacloud/pkg/cli     (cached)
?       github.com/sacloud/usacloud/pkg/commands/completion     [no test files]
=== RUN   TestCreateProfile
=== RUN   TestCreateProfile/new_profile
=== RUN   TestCreateProfile/with_--use
=== RUN   TestCreateProfile/already_exists
--- PASS: TestCreateProfile (0.06s)
    --- PASS: TestCreateProfile/new_profile (0.02s)
    --- PASS: TestCreateProfile/with_--use (0.02s)
    --- PASS: TestCreateProfile/already_exists (0.02s)
=== RUN   TestDeleteProfile
=== RUN   TestDeleteProfile/delete_non-current
=== RUN   TestDeleteProfile/delete_current_resets_to_default
=== RUN   TestDeleteProfile/delete_non-existent
--- PASS: TestDeleteProfile (0.09s)
    --- PASS: TestDeleteProfile/delete_non-current (0.05s)
    --- PASS: TestDeleteProfile/delete_current_resets_to_default (0.02s)
    --- PASS: TestDeleteProfile/delete_non-existent (0.01s)
=== RUN   TestUseProfile
--- PASS: TestUseProfile (0.02s)
=== RUN   TestListProfiles
--- PASS: TestListProfiles (0.01s)
=== RUN   TestShowProfile
--- PASS: TestShowProfile (0.01s)
=== RUN   TestPathProfile
--- PASS: TestPathProfile (0.01s)
=== RUN   TestCurrentProfile
--- PASS: TestCurrentProfile (0.01s)
=== RUN   TestEditProfile
=== RUN   TestEditProfile/edit_existing_profile
=== RUN   TestEditProfile/create_new_profile
=== RUN   TestEditProfile/with_--use
--- PASS: TestEditProfile (0.06s)
    --- PASS: TestEditProfile/edit_existing_profile (0.03s)
    --- PASS: TestEditProfile/create_new_profile (0.02s)
    --- PASS: TestEditProfile/with_--use (0.01s)
=== RUN   TestConfigCommandsWithBrokenCurrent
=== RUN   TestConfigCommandsWithBrokenCurrent/current_shows_raw_current_value
=== RUN   TestConfigCommandsWithBrokenCurrent/list_shows_existing_profiles
=== RUN   TestConfigCommandsWithBrokenCurrent/use_fixes_current_profile
--- PASS: TestConfigCommandsWithBrokenCurrent (0.06s)
    --- PASS: TestConfigCommandsWithBrokenCurrent/current_shows_raw_current_value (0.01s)
    --- PASS: TestConfigCommandsWithBrokenCurrent/list_shows_existing_profiles (0.02s)
    --- PASS: TestConfigCommandsWithBrokenCurrent/use_fixes_current_profile (0.03s)
PASS
ok      github.com/sacloud/usacloud/pkg/commands/config (cached)
?       github.com/sacloud/usacloud/pkg/commands/iaas   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/archive   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/authstatus        [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/autobackup        [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/autoscale [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/bill      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/bridge    [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/category  [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/cdrom     [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/certificateauthority      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/common    [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/containerregistry [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/coupon    [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/database  [no test files]
=== RUN   TestDiskDefaultColumnDefs
--- PASS: TestDiskDefaultColumnDefs (0.00s)
=== RUN   TestCreate_ConvertToServiceRequest
=== RUN   TestCreate_ConvertToServiceRequest/full
--- PASS: TestCreate_ConvertToServiceRequest (0.00s)
    --- PASS: TestCreate_ConvertToServiceRequest/full (0.00s)
=== RUN   TestCreateParameter_Validate
--- PASS: TestCreateParameter_Validate (0.00s)
=== RUN   TestList_ConvertToServiceRequest
--- PASS: TestList_ConvertToServiceRequest (0.00s)
=== RUN   TestUpdate_ConvertToServiceRequest
=== RUN   TestUpdate_ConvertToServiceRequest/full
=== RUN   TestUpdate_ConvertToServiceRequest/nil
=== RUN   TestUpdate_ConvertToServiceRequest/empty
--- PASS: TestUpdate_ConvertToServiceRequest (0.00s)
    --- PASS: TestUpdate_ConvertToServiceRequest/full (0.00s)
    --- PASS: TestUpdate_ConvertToServiceRequest/nil (0.00s)
    --- PASS: TestUpdate_ConvertToServiceRequest/empty (0.00s)
=== RUN   TestUpdateParameter_Validate
--- PASS: TestUpdateParameter_Validate (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/commands/iaas/disk      (cached)
?       github.com/sacloud/usacloud/pkg/commands/iaas/diskplan  [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/dns       [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/enhanceddb        [no test files]
=== RUN   TestSendMessageParameter_Validate
--- PASS: TestSendMessageParameter_Validate (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/commands/iaas/esme      (cached)
?       github.com/sacloud/usacloud/pkg/commands/iaas/gslb      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/icon      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/iface     [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/internet  [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/internetplan      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/ipaddress [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/ipv6addr  [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/ipv6net   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/license   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/licenseinfo       [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/loadbalancer      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/localrouter       [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/mobilegateway     [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/nfs       [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/note      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/packetfilter      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/privatehost       [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/privatehostplan   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/proxylb   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/region    [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/self      [no test files]
=== RUN   Test_validateBootParameter
=== RUN   Test_validateBootParameter/minimum
=== RUN   Test_validateBootParameter/with_valid_cloud-config
=== RUN   Test_validateBootParameter/with_invalid_cloud-config
--- PASS: Test_validateBootParameter (0.00s)
    --- PASS: Test_validateBootParameter/minimum (0.00s)
    --- PASS: Test_validateBootParameter/with_valid_cloud-config (0.00s)
    --- PASS: Test_validateBootParameter/with_invalid_cloud-config (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/commands/iaas/server    (cached)
?       github.com/sacloud/usacloud/pkg/commands/iaas/serverplan        [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/serviceclass      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/sim       [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/simplemonitor     [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/sshkey    [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/subnet    [no test files]
?       github.com/sacloud/usacloud/pkg/commands/iaas/swytch    [no test files]
=== RUN   Test_routerSettingUpdate_Customize
=== RUN   Test_routerSettingUpdate_Customize/empty
=== RUN   Test_routerSettingUpdate_Customize/with_wireguard_json
=== RUN   Test_routerSettingUpdate_Customize/with_static_nat_json
--- PASS: Test_routerSettingUpdate_Customize (0.00s)
    --- PASS: Test_routerSettingUpdate_Customize/empty (0.00s)
    --- PASS: Test_routerSettingUpdate_Customize/with_wireguard_json (0.00s)
    --- PASS: Test_routerSettingUpdate_Customize/with_static_nat_json (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/commands/iaas/vpcrouter (cached)
?       github.com/sacloud/usacloud/pkg/commands/iaas/zone      [no test files]
?       github.com/sacloud/usacloud/pkg/commands/rest   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/root   [no test files]
?       github.com/sacloud/usacloud/pkg/commands/update-self    [no test files]
?       github.com/sacloud/usacloud/pkg/commands/version        [no test files]
?       github.com/sacloud/usacloud/pkg/commands/webaccel       [no test files]
?       github.com/sacloud/usacloud/pkg/commands/webaccel/webaccelerator        [no test files]
=== RUN   TestFillDefaults_ZonesEmpty
--- PASS: TestFillDefaults_ZonesEmpty (0.00s)
=== RUN   TestFillDefaults_ZonesWithAll
--- PASS: TestFillDefaults_ZonesWithAll (0.00s)
=== RUN   TestFillDefaults_ZonesWithoutAll
--- PASS: TestFillDefaults_ZonesWithoutAll (0.00s)
=== RUN   TestFillDefaults_EnvVar
--- PASS: TestFillDefaults_EnvVar (0.00s)
=== RUN   TestConfig_loadFromEnv
=== RUN   TestConfig_loadFromEnv/SAKURA_*_only
=== RUN   TestConfig_loadFromEnv/SAKURACLOUD_*_only
=== RUN   TestConfig_loadFromEnv/both_SAKURA_*_and_SAKURACLOUD_*_(SAKURA_*_preferred)
=== RUN   TestConfig_loadFromEnv/no_env_(defaults)
--- PASS: TestConfig_loadFromEnv (0.00s)
    --- PASS: TestConfig_loadFromEnv/SAKURA_*_only (0.00s)
    --- PASS: TestConfig_loadFromEnv/SAKURACLOUD_*_only (0.00s)
    --- PASS: TestConfig_loadFromEnv/both_SAKURA_*_and_SAKURACLOUD_*_(SAKURA_*_preferred) (0.00s)
    --- PASS: TestConfig_loadFromEnv/no_env_(defaults) (0.00s)
=== RUN   TestConfig_loadFromEnvOverwrite
--- PASS: TestConfig_loadFromEnvOverwrite (0.00s)
=== RUN   TestLoadConfigValue
=== RUN   TestLoadConfigValue/no_profiles
=== RUN   TestLoadConfigValue/default_profile_exists
=== RUN   TestLoadConfigValue/--profile_flag
=== RUN   TestLoadConfigValue/SAKURA_PROFILE_env
=== RUN   TestLoadConfigValue/current_points_to_existing_profile
=== RUN   TestLoadConfigValue/current_points_to_deleted_profile
=== RUN   TestLoadConfigValue/flag_wins_over_env
--- PASS: TestLoadConfigValue (0.08s)
    --- PASS: TestLoadConfigValue/no_profiles (0.00s)
    --- PASS: TestLoadConfigValue/default_profile_exists (0.02s)
    --- PASS: TestLoadConfigValue/--profile_flag (0.01s)
    --- PASS: TestLoadConfigValue/SAKURA_PROFILE_env (0.01s)
    --- PASS: TestLoadConfigValue/current_points_to_existing_profile (0.01s)
    --- PASS: TestLoadConfigValue/current_points_to_deleted_profile (0.00s)
    --- PASS: TestLoadConfigValue/flag_wins_over_env (0.03s)
=== RUN   TestLoadConfigValue_SkipLoadingProfile
=== RUN   TestLoadConfigValue_SkipLoadingProfile/skips_profile_file_but_still_loads_env_and_flags
=== RUN   TestLoadConfigValue_SkipLoadingProfile/broken_current_file_does_not_cause_error
--- PASS: TestLoadConfigValue_SkipLoadingProfile (0.01s)
    --- PASS: TestLoadConfigValue_SkipLoadingProfile/skips_profile_file_but_still_loads_env_and_flags (0.01s)
    --- PASS: TestLoadConfigValue_SkipLoadingProfile/broken_current_file_does_not_cause_error (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/config  (cached)
?       github.com/sacloud/usacloud/pkg/connect [no test files]
?       github.com/sacloud/usacloud/pkg/conv    [no test files]
?       github.com/sacloud/usacloud/pkg/core    [no test files]
?       github.com/sacloud/usacloud/pkg/examples        [no test files]
=== RUN   TestHoge
    functions_test.go:24: dns1
--- PASS: TestHoge (0.00s)
=== RUN   TestNames
--- PASS: TestNames (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/naming  (cached)
=== RUN   TestFreeOutput_Print
--- PASS: TestFreeOutput_Print (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/output  (cached)
?       github.com/sacloud/usacloud/pkg/printer [no test files]
=== RUN   TestByGoJQ
=== RUN   TestByGoJQ/with_map
=== RUN   TestByGoJQ/with_slice
=== RUN   TestByGoJQ/with_struct
=== RUN   TestByGoJQ/with_primitive
=== RUN   TestByGoJQ/with_invalid_query
--- PASS: TestByGoJQ (0.00s)
    --- PASS: TestByGoJQ/with_map (0.00s)
    --- PASS: TestByGoJQ/with_slice (0.00s)
    --- PASS: TestByGoJQ/with_struct (0.00s)
    --- PASS: TestByGoJQ/with_primitive (0.00s)
    --- PASS: TestByGoJQ/with_invalid_query (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/query   (cached)
?       github.com/sacloud/usacloud/pkg/self    [no test files]
?       github.com/sacloud/usacloud/pkg/services        [no test files]
?       github.com/sacloud/usacloud/pkg/services/iaas   [no test files]
?       github.com/sacloud/usacloud/pkg/services/registry       [no test files]
?       github.com/sacloud/usacloud/pkg/services/webaccel       [no test files]
?       github.com/sacloud/usacloud/pkg/term    [no test files]
?       github.com/sacloud/usacloud/pkg/test    [no test files]
=== RUN   TestBytesFromPathOrContent
--- PASS: TestBytesFromPathOrContent (0.01s)
=== RUN   TestMarshalJSONFromPathOrContent
--- PASS: TestMarshalJSONFromPathOrContent (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/util    (cached)
=== RUN   TestPublicKeyFormat
=== RUN   TestPublicKeyFormat/target_is_nil
=== RUN   TestPublicKeyFormat/value_is_nil
=== RUN   TestPublicKeyFormat/value_is_empty
=== RUN   TestPublicKeyFormat/value_is_invalid_path
=== RUN   TestPublicKeyFormat/value_is_invalid_key_content
=== RUN   TestPublicKeyFormat/value_has_valid_key
=== RUN   TestPublicKeyFormat/value_is_valid_path
=== RUN   TestPublicKeyFormat/value_is_valid_conrent
--- PASS: TestPublicKeyFormat (0.01s)
    --- PASS: TestPublicKeyFormat/target_is_nil (0.00s)
    --- PASS: TestPublicKeyFormat/value_is_nil (0.00s)
    --- PASS: TestPublicKeyFormat/value_is_empty (0.00s)
    --- PASS: TestPublicKeyFormat/value_is_invalid_path (0.00s)
    --- PASS: TestPublicKeyFormat/value_is_invalid_key_content (0.00s)
    --- PASS: TestPublicKeyFormat/value_has_valid_key (0.00s)
    --- PASS: TestPublicKeyFormat/value_is_valid_path (0.00s)
    --- PASS: TestPublicKeyFormat/value_is_valid_conrent (0.00s)
=== RUN   TestValidator_Exec
--- PASS: TestValidator_Exec (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/validate        (cached)
=== RUN   TestConverterFilters_fromDefinitions
--- PASS: TestConverterFilters_fromDefinitions (0.00s)
=== RUN   TestDefinition_initialize
--- PASS: TestDefinition_initialize (0.00s)
=== RUN   TestConverterFuncGenerator
=== RUN   TestConverterFuncGenerator/convertFuncToValue
=== RUN   TestConverterFuncGenerator/convertFuncToKey
--- PASS: TestConverterFuncGenerator (0.00s)
    --- PASS: TestConverterFuncGenerator/convertFuncToValue (0.00s)
    --- PASS: TestConverterFuncGenerator/convertFuncToKey (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/vdef    (cached)
=== RUN   TestGitHubRelease_GreaterThanCurrent
--- PASS: TestGitHubRelease_GreaterThanCurrent (0.00s)
=== RUN   TestGitHubRelease_UnmarshalJSON
--- PASS: TestGitHubRelease_UnmarshalJSON (0.00s)
PASS
ok      github.com/sacloud/usacloud/pkg/version (cached)
?       github.com/sacloud/usacloud/tools       [no test files]
=== RUN   TestParser_parseTag
--- PASS: TestParser_parseTag (0.00s)
=== RUN   TestParser_Parse
--- PASS: TestParser_Parse (0.00s)
PASS
ok      github.com/sacloud/usacloud/tools/clitag        (cached)
?       github.com/sacloud/usacloud/tools/gen-commands  [no test files]
?       github.com/sacloud/usacloud/tools/utils [no test files]

```


<!-- for GitHub Copilot: レビューは日本語で実施してください -->