### PR TITLE
[CI] migrate to homebrew_casks

### DIFF
--- a/.github/workflows/tagpr_and_release.yml
+++ b/.github/workflows/tagpr_and_release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run GoReleaser
       uses:  goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:
-        version: '~> v2'
+        version: '~> v2.10'
         args: release  --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,12 +57,15 @@ nfpms:
     formats:
       - deb
       - rpm
-brews:
+homebrew_casks:
   - repository:
       owner: sacloud
       name: homebrew-usacloud
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    url_template: "https://github.com/sacloud/usacloud/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url:
+      template: "https://github.com/sacloud/usacloud/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+      verified: "github.com/sacloud/usacloud/"
+    name: usacloud
     commit_author:
       name: Usacloud
       email: sacloud.users@gmail.com
@@ -70,8 +73,10 @@ brews:
     license: "Apache-2.0"
     # for debug
     # skip_upload: true
-    test: |
-      system "#{bin}/usacloud --version"
+    hooks:
+      post:
+        install: |-
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/usacloud"] if OS.mac?
 release:
   extra_files:
     - glob: ./scripts/install.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,9 @@ builds:
         goarch: arm
     binary: '{{ .ProjectName }}'
 archives:
-  - format: zip
+  - formats:
+      - 'zip'
+      # - 'tar.gz' ...
     name_template: '{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_SHA256SUMS'


### PR DESCRIPTION
goreleaserで使っている `brew` がdeprecated

https://goreleaser.com/resources/deprecations/#brews

になっているため、推奨移行先であるhomebrew_casksに移行します。

だいたい従来と同じですが、今回からcom.apple.quarantineを消す対応が追加されています。本当はちゃんと署名したほうが良いのかもしれないが証明書が有料なので…