### PR TITLE
[CI] use app token for release workflow

### DIFF
--- a/.github/workflows/tagpr_and_release.yml
+++ b/.github/workflows/tagpr_and_release.yml
@@ -53,7 +53,7 @@ jobs:
         version: '~> v2.10'
         args: release  --clean
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         NFPM_DEFAULT_PASSPHRASE: ${{ secrets.PASSPHRASE }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
Caskリリースの際にgoreleaserの中でgithub APIを使ってsacloud/homebrew-usacloudにコードコミットしている箇所があるようです https://github.com/goreleaser/goreleaser/blob/0cfdc86b5e839241aae46592c4b987f6d72fd67a/internal/pipe/cask/cask.go#L194

というわけなのでそちらに書き込めるトークンを利用するようにします