### PR TITLE
docs: add repository agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Go `1.25.8`（`go.mod` で指定）を使用します。
 
 ## リポジトリの規約
 
+- すべてのコミットで DCO への同意が必須である。`git commit --signoff` を使用し、コミットメッセージに `Signed-off-by` トレーラーを追加する。
 - 新しい Go ファイルでは、Apache ライセンスヘッダーとリポジトリの著作権年のパターンを維持する。`make gen` は `set-license`、`gofmt`、`gosimports` を実行する。
 - `golangci-lint` は意図的に生成ファイルを除外し、`--fix` を付けて実行される。コミット前に、適用されたフォーマット変更を確認する。
 - ユニットテストには標準の `testing` パッケージと `testify/require` を使用する。End-to-End テストは `e2e` ビルドタグ付きで `e2e/` 配下に分離されている。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,53 +1,53 @@
-# Usacloud Agent Instructions
+# Usacloud エージェント向け指示
 
-## Project overview
+## プロジェクト概要
 
-`usacloud` is the official CLI for Sakura Cloud. `main.go` delegates to `pkg.Run()`, which registers Cobra commands and executes the root command.
+`usacloud` はさくらのクラウド公式 CLI です。`main.go` は `pkg.Run()` に処理を委譲し、そこで Cobra コマンドを登録してルートコマンドを実行します。
 
-- `pkg/commands/root` defines persistent configuration flags and the root Cobra command.
-- `pkg/resources.go` registers top-level resources.
-- IaaS resources are collected in `pkg/commands/iaas/resources.go`.
-- They are attached beneath `usacloud iaas` and exposed as hidden root-level commands for backward compatibility.
-- Each resource package under `pkg/commands/<platform>/<resource>` defines a `core.Resource` and registers `core.Command` values from `init()`. Parameter structs combine shared `cflag` types with resource-specific fields.
-- `pkg/core` drives the common command lifecycle.
-- It loads configuration and profiles, initializes clients and output, and validates parameters.
-- It also expands selectors across zones, confirms destructive operations, invokes commands, and prints results.
-- Commands without a custom `core.Command.Func` use generated adapters in `pkg/services/<platform>/*_services_gen.go` to call the matching service library. The generated `zz_*_gen.go` files in command packages create Cobra flags from parameter struct tags.
-- `tools/gen-commands` reads registered resources and commands to generate those adapters and flag files. Do not manually edit files ending in `_gen.go` or marked `Code generated`; change the resource/command definition or generator template, then regenerate.
+- `pkg/commands/root` は永続的な設定フラグと Cobra のルートコマンドを定義する。
+- `pkg/resources.go` はトップレベルのリソースを登録する。
+- IaaS リソースは `pkg/commands/iaas/resources.go` にまとめられている。
+- これらは `usacloud iaas` の配下に追加され、後方互換性のため、非表示のルートレベルコマンドとしても公開される。
+- `pkg/commands/<platform>/<resource>` 配下の各リソースパッケージは `core.Resource` を定義し、`init()` から `core.Command` の値を登録する。パラメータ構造体は、共有の `cflag` 型とリソース固有のフィールドを組み合わせる。
+- `pkg/core` は共通のコマンドライフサイクルを制御する。
+- 設定とプロファイルの読み込み、クライアントと出力の初期化、パラメータの検証をする。
+- また、ゾーンをまたぐセレクターの展開、破壊的操作の確認、コマンドの呼び出し、結果の出力も行う。
+- 独自の `core.Command.Func` を持たないコマンドは、`pkg/services/<platform>/*_services_gen.go` に生成されたアダプターを使用し、対応するサービスライブラリを呼び出す。コマンドパッケージ内の生成された `zz_*_gen.go` ファイルは、パラメータ構造体のタグから Cobra フラグを作成する。
+- `tools/gen-commands` は登録済みのリソースとコマンドを読み取り、これらのアダプターとフラグファイルを生成する。ファイル名が `_gen.go` で終わるファイルや `Code generated` と記載されたファイルは手動で編集せず、リソースやコマンドの定義、またはジェネレーターテンプレートを変更してから再生成する。
 
-## Commands
+## コマンド
 
-Use Go `1.25.8` (from `go.mod`).
+Go `1.25.8`（`go.mod` で指定）を使用します。
 
-| Purpose | Command |
+| 目的 | コマンド |
 | --- | --- |
-| Install development tools | `make tools` |
-| Build the CLI | `make build` |
-| Regenerate command/service adapters, licenses, and formatting | `make gen` |
-| Run all unit tests | `make test` |
-| Run one package's tests | `go test ./pkg/config -run '^TestFillDefaults_ZonesEmpty$' -v` |
-| Run one test case in a command package | `go test ./pkg/commands/iaas/disk -run '^TestCreate_ConvertToServiceRequest$' -v` |
-| Run end-to-end tests | `make e2e-test` |
-| Run one end-to-end test | `make e2e-test TESTARGS='-run ^TestE2E_minimum$'` |
-| Go lint and formatting | `make lint-go` |
-| Text lint | `make lint-text` |
-| GitHub Actions workflow lint | `make lint-action` |
+| 開発ツールのインストール | `make tools` |
+| CLI のビルド | `make build` |
+| コマンド／サービスアダプター、ライセンス、フォーマットの再生成 | `make gen` |
+| すべてのユニットテストの実行 | `make test` |
+| 1 パッケージのテストの実行 | `go test ./pkg/config -run '^TestFillDefaults_ZonesEmpty$' -v` |
+| コマンドパッケージ内の 1 テストケースの実行 | `go test ./pkg/commands/iaas/disk -run '^TestCreate_ConvertToServiceRequest$' -v` |
+| End-to-End テストの実行 | `make e2e-test` |
+| 1 件の End-to-End テストの実行 | `make e2e-test TESTARGS='-run ^TestE2E_minimum$'` |
+| Go の lint とフォーマット | `make lint-go` |
+| テキストの lint | `make lint-text` |
+| GitHub Actions ワークフローの lint | `make lint-action` |
 
-`make test` runs `go test ./...` with the race detector. End-to-end tests have the `e2e` build tag, install the local CLI first, and can take up to 240 minutes.
+`make test` は race detector を有効にして `go test ./...` を実行します。End-to-End テストには `e2e` ビルドタグがあり、最初にローカルの CLI をインストールします。完了まで最大 240 分かかる場合があります。
 
-## Command implementation conventions
+## コマンド実装の規約
 
-- Define CLI flags and service request mapping declaratively on parameter structs. Embedded shared parameters normally use both `cli:",squash"` and `mapconv:",squash"`; fields that must not reach service requests use `mapconv:"-"`.
-- Use `validate` tags for standard validation. Add named value mappings in `pkg/vdef/definitions.go` when a flag needs `options=...`, filtering, or key/value conversion. Put validation that depends on several fields in the command's custom validator.
-- Set `SelectorTypeRequireSingle` or `SelectorTypeRequireMulti` for commands that accept resource ID, partial name, or tag arguments.
-- The core handles lookup and per-zone execution. Account for `--zone=all` and use `ctx.WithResource` rather than duplicating selector logic.
-- Keep a command's `Category` and `Order` consistent with the shared categories. `Resource.AddCommand` fails for an unknown category and sorts help output by these values.
-- Add new IaaS resources to `pkg/commands/iaas/resources.go`; add non-IaaS top-level resources to `pkg/resources.go`. Set `ServiceType` to the corresponding service-library type so generation can create adapters.
-- Prefer the generated default service call where the service method matches the command. Provide `ServiceFuncAltName` for naming mismatches; use a custom `Func` only for behavior the service adapter cannot express.
-- Commands that change resources should embed `cflag.ConfirmParameter`; noninteractive callers then require `--assumeyes`/`-y`. List commands conventionally set `NoProgress: true` and define explicit `ColumnDefs`.
+- CLI フラグとサービスリクエストへのマッピングは、パラメータ構造体で宣言的に定義する。埋め込まれた共有パラメータには通常 `cli:",squash"` と `mapconv:",squash"` の両方を使用し、サービスリクエストへ渡してはならないフィールドには `mapconv:"-"` を使用する。
+- 標準的な検証には `validate` タグを使用する。フラグに `options=...`、フィルタリング、キー／値変換が必要な場合は、`pkg/vdef/definitions.go` に名前付きの値マッピングを追加する。複数のフィールドに依存する検証は、コマンド固有のバリデーターに記述する。
+- リソース ID、名前の一部、またはタグを引数として受け取るコマンドには、`SelectorTypeRequireSingle` または `SelectorTypeRequireMulti` を設定する。
+- リソースの検索とゾーンごとの実行は core が処理する。セレクターのロジックを重複して実装せず、`--zone=all` を考慮して `ctx.WithResource` を使用する。
+- コマンドの `Category` と `Order` は共有カテゴリーと整合させる。`Resource.AddCommand` は未知のカテゴリーを拒否し、これらの値を使ってヘルプ出力を並べ替える。
+- 新しい IaaS リソースは `pkg/commands/iaas/resources.go` に、IaaS 以外の新しいトップレベルリソースは `pkg/resources.go` に追加する。ジェネレーターがアダプターを作成できるよう、`ServiceType` には対応するサービスライブラリの型を設定する。
+- サービスメソッドがコマンドと一致する場合は、生成されるデフォルトのサービス呼び出しを優先する。名前が一致しない場合は `ServiceFuncAltName` を指定し、サービスアダプターで表現できない動作に限って独自の `Func` を使用する。
+- リソースを変更するコマンドには `cflag.ConfirmParameter` を埋め込む。これにより、非対話的な呼び出しでは `--assumeyes`／`-y` が必須になる。list コマンドでは慣例として `NoProgress: true` を設定し、`ColumnDefs` を明示的に定義する。
 
-## Repository conventions
+## リポジトリの規約
 
-- Preserve the Apache license header and the repository copyright year pattern in new Go files. `make gen` runs `set-license`, `gofmt`, and `gosimports`.
-- `golangci-lint` deliberately excludes generated files and runs with `--fix`; review the resulting formatting changes before committing.
-- Unit tests use the standard `testing` package with `testify/require`. End-to-end tests are isolated under `e2e/` behind the `e2e` build tag.
+- 新しい Go ファイルでは、Apache ライセンスヘッダーとリポジトリの著作権年のパターンを維持する。`make gen` は `set-license`、`gofmt`、`gosimports` を実行する。
+- `golangci-lint` は意図的に生成ファイルを除外し、`--fix` を付けて実行される。コミット前に、適用されたフォーマット変更を確認する。
+- ユニットテストには標準の `testing` パッケージと `testify/require` を使用する。End-to-End テストは `e2e` ビルドタグ付きで `e2e/` 配下に分離されている。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Usacloud Agent Instructions
+
+## Project overview
+
+`usacloud` is the official CLI for Sakura Cloud. `main.go` delegates to `pkg.Run()`, which registers Cobra commands and executes the root command.
+
+- `pkg/commands/root` defines persistent configuration flags and the root Cobra command.
+- `pkg/resources.go` registers top-level resources.
+- IaaS resources are collected in `pkg/commands/iaas/resources.go`.
+- They are attached beneath `usacloud iaas` and exposed as hidden root-level commands for backward compatibility.
+- Each resource package under `pkg/commands/<platform>/<resource>` defines a `core.Resource` and registers `core.Command` values from `init()`. Parameter structs combine shared `cflag` types with resource-specific fields.
+- `pkg/core` drives the common command lifecycle.
+- It loads configuration and profiles, initializes clients and output, and validates parameters.
+- It also expands selectors across zones, confirms destructive operations, invokes commands, and prints results.
+- Commands without a custom `core.Command.Func` use generated adapters in `pkg/services/<platform>/*_services_gen.go` to call the matching service library. The generated `zz_*_gen.go` files in command packages create Cobra flags from parameter struct tags.
+- `tools/gen-commands` reads registered resources and commands to generate those adapters and flag files. Do not manually edit files ending in `_gen.go` or marked `Code generated`; change the resource/command definition or generator template, then regenerate.
+
+## Commands
+
+Use Go `1.25.8` (from `go.mod`).
+
+| Purpose | Command |
+| --- | --- |
+| Install development tools | `make tools` |
+| Build the CLI | `make build` |
+| Regenerate command/service adapters, licenses, and formatting | `make gen` |
+| Run all unit tests | `make test` |
+| Run one package's tests | `go test ./pkg/config -run '^TestFillDefaults_ZonesEmpty$' -v` |
+| Run one test case in a command package | `go test ./pkg/commands/iaas/disk -run '^TestCreate_ConvertToServiceRequest$' -v` |
+| Run end-to-end tests | `make e2e-test` |
+| Run one end-to-end test | `make e2e-test TESTARGS='-run ^TestE2E_minimum$'` |
+| Go lint and formatting | `make lint-go` |
+| Text lint | `make lint-text` |
+| GitHub Actions workflow lint | `make lint-action` |
+
+`make test` runs `go test ./...` with the race detector. End-to-end tests have the `e2e` build tag, install the local CLI first, and can take up to 240 minutes.
+
+## Command implementation conventions
+
+- Define CLI flags and service request mapping declaratively on parameter structs. Embedded shared parameters normally use both `cli:",squash"` and `mapconv:",squash"`; fields that must not reach service requests use `mapconv:"-"`.
+- Use `validate` tags for standard validation. Add named value mappings in `pkg/vdef/definitions.go` when a flag needs `options=...`, filtering, or key/value conversion. Put validation that depends on several fields in the command's custom validator.
+- Set `SelectorTypeRequireSingle` or `SelectorTypeRequireMulti` for commands that accept resource ID, partial name, or tag arguments.
+- The core handles lookup and per-zone execution. Account for `--zone=all` and use `ctx.WithResource` rather than duplicating selector logic.
+- Keep a command's `Category` and `Order` consistent with the shared categories. `Resource.AddCommand` fails for an unknown category and sorts help output by these values.
+- Add new IaaS resources to `pkg/commands/iaas/resources.go`; add non-IaaS top-level resources to `pkg/resources.go`. Set `ServiceType` to the corresponding service-library type so generation can create adapters.
+- Prefer the generated default service call where the service method matches the command. Provide `ServiceFuncAltName` for naming mismatches; use a custom `Func` only for behavior the service adapter cannot express.
+- Commands that change resources should embed `cflag.ConfirmParameter`; noninteractive callers then require `--assumeyes`/`-y`. List commands conventionally set `NoProgress: true` and define explicit `ColumnDefs`.
+
+## Repository conventions
+
+- Preserve the Apache license header and the repository copyright year pattern in new Go files. `make gen` runs `set-license`, `gofmt`, and `gosimports`.
+- `golangci-lint` deliberately excludes generated files and runs with `--fix`; review the resulting formatting changes before committing.
+- Unit tests use the standard `testing` package with `testify/require`. End-to-end tests are isolated under `e2e/` behind the `e2e` build tag.


### PR DESCRIPTION
Add a repository-level `AGENTS.md` so AI coding sessions have the project-specific context needed to work safely and efficiently.

It documents the Go build, test, lint, and focused test commands; the Cobra resource and command registration flow; generated adapter boundaries; and parameter, validation, selector, and formatting conventions.