### PR TITLE
Improve REST command help

### DIFF
--- a/pkg/commands/rest/request.go
+++ b/pkg/commands/rest/request.go
@@ -34,6 +34,8 @@ import (
 
 var requestCommand = &core.Command{
 	Name:       "request",
+	Usage:      "Send an authenticated request directly to the SAKURA Cloud API",
+	ArgsUsage:  "URL",
 	Category:   "basic",
 	Order:      20,
 	NoProgress: true,
@@ -48,9 +50,9 @@ var requestCommand = &core.Command{
 }
 
 type requestParameter struct {
-	Zone        string `validate:"omitempty,zone"` // 通常のzoneと扱いが異なるためcflag.ZoneParameterを利用しない
-	Method      string `cli:",short=X,options=rest_method" validate:"required,rest_method"`
-	Data        string `cli:",short=d" validate:"omitempty,file|json"`
+	Zone        string `cli:",desc=Zone for a relative URL (defaults to the active profile zone)" validate:"omitempty,zone"` // 通常のzoneと扱いが異なるためcflag.ZoneParameterを利用しない
+	Method      string `cli:",short=X,options=rest_method,desc=HTTP method" validate:"required,rest_method"`
+	Data        string `cli:",short=d,desc=JSON request body or path to a JSON file" validate:"omitempty,file|json"`
 	Query       string `cli:",category=output,desc=Query for JSON output" validate:"omitempty" json:"-"`
 	QueryDriver string `cli:",category=output,desc=Name of the driver that handles queries to JSON output options: [jmespath/jq]" json:"-" validate:"omitempty,oneof=jmespath jq"`
 

--- a/pkg/commands/rest/request.go
+++ b/pkg/commands/rest/request.go
@@ -126,7 +126,7 @@ func validateRequest(ctx cli.Context, parameter interface{}) error {
 func missingURLError(argumentCount int) error {
 	return validate.NewValidationError(
 		validate.NewFlagError("URL", fmt.Sprintf(
-			"required (received %d arguments). Specify an API path such as /server or an absolute URL such as https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server. Run 'usacloud rest --help' for more examples",
+			"exactly one is required (received %d arguments). Specify an API path such as /server or an absolute URL such as https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server. Run 'usacloud rest --help' for more examples",
 			argumentCount,
 		)),
 	)

--- a/pkg/commands/rest/request.go
+++ b/pkg/commands/rest/request.go
@@ -109,9 +109,7 @@ func validateRequest(ctx cli.Context, parameter interface{}) error {
 	}
 
 	if len(ctx.Args()) != 1 {
-		return validate.NewValidationError(
-			validate.NewFlagError("arguments", fmt.Sprintf("accepts only 1 arg, received %d", len(ctx.Args()))),
-		)
+		return missingURLError(len(ctx.Args()))
 	}
 
 	url := ctx.Args()[0]
@@ -123,6 +121,15 @@ func validateRequest(ctx cli.Context, parameter interface{}) error {
 		}
 	}
 	return nil
+}
+
+func missingURLError(argumentCount int) error {
+	return validate.NewValidationError(
+		validate.NewFlagError("URL", fmt.Sprintf(
+			"required (received %d arguments). Specify an API path such as /server or an absolute URL such as https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server. Run 'usacloud rest --help' for more examples",
+			argumentCount,
+		)),
+	)
 }
 
 func requestFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) {

--- a/pkg/commands/rest/resource.go
+++ b/pkg/commands/rest/resource.go
@@ -20,8 +20,9 @@ import (
 )
 
 var Resource = &core.Resource{
-	Name: "rest",
-	Usage: `Send an authenticated request directly to the SAKURA Cloud API.
+	Name:  "rest",
+	Usage: "Send an authenticated request directly to the SAKURA Cloud API",
+	LongUsage: `Send an authenticated request directly to the SAKURA Cloud API.
 
 Specify either a full HTTPS URL or an API path such as /server. For a path,
 usacloud builds the API URL from --zone (or the zone in the active profile).

--- a/pkg/commands/rest/resource.go
+++ b/pkg/commands/rest/resource.go
@@ -20,8 +20,25 @@ import (
 )
 
 var Resource = &core.Resource{
-	Name:               "rest",
-	Usage:              "Invoke SAKURA cloud API directly",
+	Name: "rest",
+	Usage: `Send an authenticated request directly to the SAKURA Cloud API.
+
+Specify either a full HTTPS URL or an API path such as /server. For a path,
+usacloud builds the API URL from --zone (or the zone in the active profile).
+
+Examples:
+  # List servers in the configured zone
+  usacloud rest /server
+
+  # Request an absolute URL (the --zone option is not used)
+  usacloud rest https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server
+
+  # Send JSON in a request body
+  usacloud rest -X POST -d '{"Server":{"Name":"example"}}' /server
+
+  # Query a response with JMESPath
+  usacloud rest --query 'Servers[].Name' /server`,
+	ArgsUsage:          "URL",
 	Category:           category.ResourceCategoryOther,
 	IsGlobalResource:   true,
 	DefaultCommandName: "request",

--- a/pkg/commands/rest/resource_test.go
+++ b/pkg/commands/rest/resource_test.go
@@ -25,7 +25,13 @@ func TestHelpIncludesRESTRequestUsage(t *testing.T) {
 	if got, want := cmd.Use, "rest URL"; got != want {
 		t.Errorf("resource usage = %q, want %q", got, want)
 	}
-	if got, want := cmd.Long, Resource.Usage; got != want {
+	if got, want := cmd.Short, Resource.Usage; got != want {
+		t.Errorf("resource summary = %q, want %q", got, want)
+	}
+	if strings.Contains(cmd.Short, "\n") {
+		t.Errorf("resource summary must fit on one line: %q", cmd.Short)
+	}
+	if got, want := cmd.Long, Resource.LongUsage; got != want {
 		t.Errorf("resource help = %q, want %q", got, want)
 	}
 	if want := "usacloud rest https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server"; !strings.Contains(cmd.Long, want) {

--- a/pkg/commands/rest/resource_test.go
+++ b/pkg/commands/rest/resource_test.go
@@ -60,7 +60,7 @@ func TestMissingURLMessageIncludesUsage(t *testing.T) {
 	err := missingURLError(0)
 
 	for _, want := range []string{
-		"URL: required (received 0 arguments)",
+		"URL: exactly one is required (received 0 arguments)",
 		"/server",
 		"https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server",
 		"usacloud rest --help",
@@ -68,5 +68,9 @@ func TestMissingURLMessageIncludesUsage(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("missing URL error does not include %q: %s", want, err)
 		}
+	}
+
+	if got := missingURLError(2).Error(); !strings.Contains(got, "URL: exactly one is required (received 2 arguments)") {
+		t.Errorf("multiple URL error does not describe the required count: %s", got)
 	}
 }

--- a/pkg/commands/rest/resource_test.go
+++ b/pkg/commands/rest/resource_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017-2025 The sacloud/usacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHelpIncludesRESTRequestUsage(t *testing.T) {
+	cmd := Resource.CLICommand()
+
+	if got, want := cmd.Use, "rest URL"; got != want {
+		t.Errorf("resource usage = %q, want %q", got, want)
+	}
+	if got, want := cmd.Long, Resource.Usage; got != want {
+		t.Errorf("resource help = %q, want %q", got, want)
+	}
+	if want := "usacloud rest https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server"; !strings.Contains(cmd.Long, want) {
+		t.Errorf("resource help does not include absolute URL example %q", want)
+	}
+
+	request, _, err := cmd.Find([]string{"request"})
+	if err != nil {
+		t.Fatalf("finding request command: %v", err)
+	}
+	if got, want := request.Use, "request URL"; got != want {
+		t.Errorf("request usage = %q, want %q", got, want)
+	}
+	for name, want := range map[string]string{
+		"data":   "JSON request body or path to a JSON file",
+		"method": "HTTP method options: [get/post/patch/put/delete/GET/POST/PATCH/PUT/DELETE]",
+		"zone":   "Zone for a relative URL (defaults to the active profile zone)",
+	} {
+		if got := request.Flags().Lookup(name).Usage; got != want {
+			t.Errorf("--%s description = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/pkg/commands/rest/resource_test.go
+++ b/pkg/commands/rest/resource_test.go
@@ -49,3 +49,18 @@ func TestHelpIncludesRESTRequestUsage(t *testing.T) {
 		}
 	}
 }
+
+func TestMissingURLMessageIncludesUsage(t *testing.T) {
+	err := missingURLError(0)
+
+	for _, want := range []string{
+		"URL: required (received 0 arguments)",
+		"/server",
+		"https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server",
+		"usacloud rest --help",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("missing URL error does not include %q: %s", want, err)
+		}
+	}
+}

--- a/pkg/commands/rest/zz_request_gen.go
+++ b/pkg/commands/rest/zz_request_gen.go
@@ -29,9 +29,9 @@ func (p *requestParameter) CleanupEmptyValue(fs *pflag.FlagSet) {
 
 func (p *requestParameter) buildFlags(fs *pflag.FlagSet) {
 
-	fs.StringVarP(&p.Zone, "zone", "", p.Zone, "")
-	fs.StringVarP(&p.Method, "method", "X", p.Method, "(*required) options: [get/post/patch/put/delete/GET/POST/PATCH/PUT/DELETE]")
-	fs.StringVarP(&p.Data, "data", "d", p.Data, "")
+	fs.StringVarP(&p.Zone, "zone", "", p.Zone, "Zone for a relative URL (defaults to the active profile zone)")
+	fs.StringVarP(&p.Method, "method", "X", p.Method, "HTTP method options: [get/post/patch/put/delete/GET/POST/PATCH/PUT/DELETE]")
+	fs.StringVarP(&p.Data, "data", "d", p.Data, "JSON request body or path to a JSON file")
 	fs.StringVarP(&p.Query, "query", "", p.Query, "Query for JSON output")
 	fs.StringVarP(&p.QueryDriver, "query-driver", "", p.QueryDriver, "Name of the driver that handles queries to JSON output options: [jmespath/jq]")
 	fs.StringVarP(&p.AuthPreference, "auth-preference", "", p.AuthPreference, "Authorization preference: [basic/bearer]")

--- a/pkg/core/resource.go
+++ b/pkg/core/resource.go
@@ -29,6 +29,7 @@ type Resource struct {
 	Name               string
 	Aliases            []string
 	Usage              string
+	LongUsage          string
 	ArgsUsage          string
 	DefaultCommandName string
 	Category           category.Category
@@ -49,7 +50,7 @@ func (r *Resource) CLICommand() *cobra.Command {
 		Use:     r.Name + r.argsUsage(),
 		Aliases: r.Aliases,
 		Short:   r.Usage,
-		Long:    r.Usage,
+		Long:    r.longUsage(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if r.DefaultCommandName == "" {
 				cmd.HelpFunc()(cmd, args)
@@ -77,6 +78,13 @@ func (r *Resource) CLICommand() *cobra.Command {
 	buildCommandsUsage(cmd, r.CategorizedCommands())
 	cmd.InheritedFlags().SortFlags = false
 	return cmd
+}
+
+func (r *Resource) longUsage() string {
+	if r.LongUsage != "" {
+		return r.LongUsage
+	}
+	return r.Usage
 }
 
 func (r *Resource) argsUsage() string {

--- a/pkg/core/resource.go
+++ b/pkg/core/resource.go
@@ -29,6 +29,7 @@ type Resource struct {
 	Name               string
 	Aliases            []string
 	Usage              string
+	ArgsUsage          string
 	DefaultCommandName string
 	Category           category.Category
 	Warning            string
@@ -45,7 +46,7 @@ type Resource struct {
 
 func (r *Resource) CLICommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     r.Name,
+		Use:     r.Name + r.argsUsage(),
 		Aliases: r.Aliases,
 		Short:   r.Usage,
 		Long:    r.Usage,
@@ -76,6 +77,16 @@ func (r *Resource) CLICommand() *cobra.Command {
 	buildCommandsUsage(cmd, r.CategorizedCommands())
 	cmd.InheritedFlags().SortFlags = false
 	return cmd
+}
+
+func (r *Resource) argsUsage() string {
+	if r.ArgsUsage == "" {
+		return ""
+	}
+	if r.ArgsUsage[0] == ' ' {
+		return r.ArgsUsage
+	}
+	return " " + r.ArgsUsage
 }
 
 func (r *Resource) runDefaultCmd(cmd *cobra.Command, currentArgs []string) error {


### PR DESCRIPTION
`usacloud rest` did not describe its required URL argument or show enough context to distinguish relative API paths from absolute URLs. This makes the command difficult to discover without the external guide.

Add concise built-in usage guidance and examples for relative paths, absolute URLs, JSON request bodies, and JMESPath queries. The command now labels its URL argument and clarifies the behavior of `--zone`, `--data`, and `--method`.

A focused test keeps the REST help contract and key flag descriptions from regressing.

----

Command output samples:

```
% ./usacloud rest 

validation error:
        URL: required (received 0 arguments). Specify an API path such as /server or an absolute URL such as https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server. Run 'usacloud rest --help' for more examples

% ./usacloud rest --help
Send an authenticated request directly to the SAKURA Cloud API.

Specify either a full HTTPS URL or an API path such as /server. For a path,
usacloud builds the API URL from --zone (or the zone in the active profile).

Examples:
  # List servers in the configured zone
  usacloud rest /server

  # Request an absolute URL (the --zone option is not used)
  usacloud rest https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server

  # Send JSON in a request body
  usacloud rest -X POST -d '{"Server":{"Name":"example"}}' /server

  # Query a response with JMESPath
  usacloud rest --query 'Servers[].Name' /server

Usage:
  usacloud rest URL [flags]
  usacloud rest [command]

Available Commands:
  request     Send an authenticated request directly to the SAKURA Cloud API

Flags:
      --auth-preference string   Authorization preference: [basic/bearer]
  -d, --data string              JSON request body or path to a JSON file
  -h, --help                     help for rest
  -X, --method string            HTTP method options: [get/post/patch/put/delete/GET/POST/PATCH/PUT/DELETE] (default "get")
      --query string             Query for JSON output
      --query-driver string      Name of the driver that handles queries to JSON output options: [jmespath/jq]
      --zone string              Zone for a relative URL (defaults to the active profile zone)

Global Flags:
      --profile string                        the name of saved credentials
      --token string                          the API token used when calling SAKURA Cloud API
      --secret string                         the API secret used when calling SAKURA Cloud API
      --zones strings                         permitted zone names
      --no-color                              disable ANSI color output
      --trace                                 enable trace logs for API calling
      --fake                                  enable fake API driver
      --fake-store string                     path to file store used by the fake API driver
      --process-timeout-sec int               number of seconds before the command execution is timed out
      --argument-match-mode string            how to compare the argument and resource name when identifying the resource to be manipulated  options: [partial/exact]
  -v, --version                               show version info
      --private-key-path option[string]       path to an RSA 2048 bit private key PEM format
      --service-principal-id option[string]   the ID of the service principal
      --service-principal-key-id kid          the kid of the service principal

Use "usacloud rest [command] --help" for more information about a command.

% ./usacloud rest /server
{
    "Count": 0,
    "From": 0,
    "Servers": [],
    "Total": 0,
    "is_ok": true
}

% ./usacloud rest https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server
{
    "Count": 0,
    "From": 0,
    "Servers": [],
    "Total": 0,
    "is_ok": true
}
```

### original

```
% usacloud rest

validation error:
        arguments: accepts only 1 arg, received 0


% usacloud rest --help
Invoke SAKURA cloud API directly

Usage:
  usacloud rest [flags]
  usacloud rest [command]

Available Commands:
  request     

Flags:
      --auth-preference string   Authorization preference: [basic/bearer]
  -d, --data string              
  -h, --help                     help for rest
  -X, --method string            (*required) options: [get/post/patch/put/delete/GET/POST/PATCH/PUT/DELETE] (default "get")
      --query string             Query for JSON output
      --query-driver string      Name of the driver that handles queries to JSON output options: [jmespath/jq]
      --zone string

Global Flags:
      --profile string                        the name of saved credentials
      --token string                          the API token used when calling SAKURA Cloud API
      --secret string                         the API secret used when calling SAKURA Cloud API
      --zones strings                         permitted zone names
      --no-color                              disable ANSI color output
      --trace                                 enable trace logs for API calling
      --fake                                  enable fake API driver
      --fake-store string                     path to file store used by the fake API driver
      --process-timeout-sec int               number of seconds before the command execution is timed out
      --argument-match-mode string            how to compare the argument and resource name when identifying the resource to be manipulated  options: [partial/exact]
  -v, --version                               show version info
      --private-key-path option[string]       path to an RSA 2048 bit private key PEM format
      --service-principal-id option[string]   the ID of the service principal
      --service-principal-key-id kid          the kid of the service principal

Use "usacloud rest [command] --help" for more information about a command.


% usacloud rest /server
{
    "Count": 0,
    "From": 0,
    "Servers": [],
    "Total": 0,
    "is_ok": true
}

% usacloud rest https://secure.sakura.ad.jp/cloud/zone/is1a/api/cloud/1.1/server
{
    "Count": 0,
    "From": 0,
    "Servers": [],
    "Total": 0,
    "is_ok": true
}
```

