### PR TITLE
Fix compatibility with latest golangci-lint

### DIFF
--- a/pkg/commands/rest/request.go
+++ b/pkg/commands/rest/request.go
@@ -160,7 +160,9 @@ func requestFunc(ctx cli.Context, parameter interface{}) ([]interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	results, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -345,7 +345,7 @@ func TestConfig_loadFromEnvOverwrite(t *testing.T) {
 
 	clearTestEnv()
 	setEnv(map[string]string{
-		"SAKURACLOUD_ACCESS_TOKEN": "token from env",
+		"SAKURACLOUD_ACCESS_TOKEN": "token from env", // #nosec G101 -- non-secret test fixture
 	})
 	cfg.loadFromEnv()
 

--- a/pkg/util/empty.go
+++ b/pkg/util/empty.go
@@ -32,7 +32,7 @@ func IsEmpty(object interface{}) bool {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
 	// pointers are empty if nil or if the value they point to is empty
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if objValue.IsNil() {
 			return true
 		}

--- a/pkg/vdef/converter_filters.go
+++ b/pkg/vdef/converter_filters.go
@@ -179,7 +179,7 @@ func dereferenceFilter(v interface{}) (interface{}, error) {
 	}
 
 	vt := reflect.ValueOf(v)
-	if vt.Kind() != reflect.Ptr {
+	if vt.Kind() != reflect.Pointer {
 		return v, nil
 	}
 	return vt.Elem().Interface(), nil

--- a/tools/clitag/parser.go
+++ b/tools/clitag/parser.go
@@ -51,7 +51,7 @@ func (p *Parser) Parse(v interface{}) ([]StructField, error) {
 
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return p.Parse(rv.Elem().Interface()) // dereference pointer
 	case reflect.Struct:
 		return p.ParseFields(StructField{}, reflect.TypeOf(v))
@@ -115,7 +115,7 @@ func (p *Parser) ParseField(parent StructField, f reflect.StructField) ([]Struct
 
 	kind := f.Type.Kind()
 	switch kind {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if f.Type.Elem().Kind() == reflect.Struct {
 			return p.ParseFields(parent, f.Type.Elem())
 		}

--- a/tools/command.go
+++ b/tools/command.go
@@ -90,7 +90,7 @@ func (c *Command) cliFlagDefinitionStatement(parameterVariableName string, field
 	fieldVar := fmt.Sprintf("%s.%s", parameterVariableName, field.FieldName)
 	fieldPointerVar := fieldVar
 	fieldType := dereferencePtrType(field.Type)
-	if field.Type.Kind() == reflect.Ptr {
+	if field.Type.Kind() == reflect.Pointer {
 		switch fieldType.Kind() {
 		case reflect.Bool:
 			fieldVar = "false"
@@ -166,7 +166,7 @@ func (c *Command) CLIFlagInitializePointerStatement(parameterVariableName, flagS
 func (c *Command) cliFlagInitializePointerStatement(parameterVariableName string, field Field) string {
 	fieldVar := fmt.Sprintf("%s.%s", parameterVariableName, field.FieldName)
 	fieldType := dereferencePtrType(field.Type)
-	if field.Type.Kind() != reflect.Ptr {
+	if field.Type.Kind() != reflect.Pointer {
 		return ""
 	}
 
@@ -234,7 +234,7 @@ func (c *Command) CLIFlagCleanupEmptyStatement(parameterVariableName, flagSetVar
 
 func (c *Command) cliFlagCleanupEmptyStatement(parameterVariableName, flagSetVariableName string, field Field) string {
 	fieldVar := fmt.Sprintf("%s.%s", parameterVariableName, field.FieldName)
-	if field.Type.Kind() != reflect.Ptr {
+	if field.Type.Kind() != reflect.Pointer {
 		return ""
 	}
 
@@ -250,7 +250,7 @@ func isLibsacloudIDType(t reflect.Type) bool {
 }
 
 func dereferencePtrType(t reflect.Type) reflect.Type {
-	if t.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Pointer {
 		return t
 	}
 	return dereferencePtrType(t.Elem())


### PR DESCRIPTION
Latest golangci-lint reports an unchecked HTTP response body close and a false-positive test credential. This updates the cleanup to explicitly discard the close error and documents the non-secret fixture for gosec.

It also applies the current Go formatter's `reflect.Ptr` to `reflect.Pointer` rename in affected files.