### PR TITLE
release.yml に categories 指定を追加

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,14 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: 🚀 Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: 📦 Dependency Updates
+      labels:
+        - dependencies
+


### PR DESCRIPTION
dependabot の更新を別セクションにします

<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

https://github.com/sacloud/packer-plugin-sakuracloud/pull/311 と同様の変更です。
dependabot の履歴を分離します

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

### ドキュメントの変更は必要ですか？
